### PR TITLE
Add compile-time SQL static analysis

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kilnx-org/kilnx/internal/analyzer"
 	"github.com/kilnx-org/kilnx/internal/build"
 	"github.com/kilnx-org/kilnx/internal/database"
 	"github.com/kilnx-org/kilnx/internal/lexer"
@@ -61,6 +62,15 @@ func main() {
 			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
+	case "check":
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: kilnx check <file.kilnx>")
+			os.Exit(1)
+		}
+		if err := cmdCheck(os.Args[2]); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
 	case "version":
 		fmt.Println("kilnx v1.0.0")
 	default:
@@ -70,10 +80,35 @@ func main() {
 	}
 }
 
+func cmdCheck(filename string) error {
+	app, err := loadApp(filename)
+	if err != nil {
+		return err
+	}
+
+	diags := analyzer.Analyze(app)
+	if len(diags) == 0 {
+		fmt.Println("No issues found.")
+		return nil
+	}
+
+	hasErrors := printDiagnostics(diags)
+	if hasErrors {
+		return fmt.Errorf("static analysis found errors")
+	}
+	return nil
+}
+
 func cmdRun(filename string) error {
 	app, err := loadApp(filename)
 	if err != nil {
 		return err
+	}
+
+	if diags := analyzer.Analyze(app); len(diags) > 0 {
+		if printDiagnostics(diags) {
+			return fmt.Errorf("static analysis found errors, not starting server")
+		}
 	}
 
 	// Resolve config
@@ -164,6 +199,12 @@ func cmdTest(filename string) error {
 		return err
 	}
 
+	if diags := analyzer.Analyze(app); len(diags) > 0 {
+		if printDiagnostics(diags) {
+			return fmt.Errorf("static analysis found errors")
+		}
+	}
+
 	if len(app.Tests) == 0 {
 		fmt.Println("No tests found.")
 		return nil
@@ -234,11 +275,29 @@ func dbPathFor(kilnxFile string) string {
 	return filepath.Join(dir, name+".db")
 }
 
+func printDiagnostics(diags []analyzer.Diagnostic) bool {
+	hasErrors := false
+	for _, d := range diags {
+		prefix := "warning"
+		if d.Level == "error" {
+			prefix = "error"
+			hasErrors = true
+		}
+		if d.Line > 0 {
+			fmt.Fprintf(os.Stderr, "kilnx %s: [%s] %s (line %d)\n", prefix, d.Context, d.Message, d.Line)
+		} else {
+			fmt.Fprintf(os.Stderr, "kilnx %s: [%s] %s\n", prefix, d.Context, d.Message)
+		}
+	}
+	return hasErrors
+}
+
 func printUsage() {
 	fmt.Println("Usage: kilnx <command> [arguments]")
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  run <file.kilnx>        Start the server (auto-migrates)")
+	fmt.Println("  check <file.kilnx>      Run static analysis")
 	fmt.Println("  build <file.kilnx> [-o] Compile to standalone binary")
 	fmt.Println("  migrate <file.kilnx>    Apply database migrations")
 	fmt.Println("  test <file.kilnx>       Run declarative tests")

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -1,0 +1,699 @@
+package analyzer
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// Diagnostic represents a compile-time finding from static analysis.
+type Diagnostic struct {
+	Level   string // "error" or "warning"
+	Message string
+	Line    int    // source line (0 if unknown)
+	Context string // location, e.g. "page /users"
+}
+
+// TableInfo holds the known columns for a model-derived table.
+type TableInfo struct {
+	Name    string
+	Columns map[string]bool
+}
+
+// Schema is the compile-time view of the database derived from model declarations.
+type Schema struct {
+	Tables map[string]*TableInfo
+}
+
+func BuildSchema(models []parser.Model) *Schema {
+	s := &Schema{Tables: make(map[string]*TableInfo)}
+	for _, m := range models {
+		info := &TableInfo{Name: m.Name, Columns: make(map[string]bool)}
+		info.Columns["id"] = true
+		for _, f := range m.Fields {
+			if f.Type == parser.FieldReference {
+				info.Columns[f.Name+"_id"] = true
+			} else {
+				info.Columns[f.Name] = true
+			}
+		}
+		s.Tables[m.Name] = info
+	}
+	return s
+}
+
+// Analyze performs static analysis on a parsed Kilnx app, checking SQL
+// references against declared models.
+func Analyze(app *parser.App) []Diagnostic {
+	var diags []Diagnostic
+	schema := BuildSchema(app.Models)
+
+	diags = append(diags, checkAuthRef(app, schema)...)
+	diags = append(diags, checkModelRefs(app, schema)...)
+	diags = append(diags, checkAllSQL(app, schema)...)
+
+	return diags
+}
+
+func checkAuthRef(app *parser.App, schema *Schema) []Diagnostic {
+	if app.Auth == nil {
+		return nil
+	}
+	if _, ok := schema.Tables[app.Auth.Table]; !ok {
+		return []Diagnostic{{
+			Level:   "error",
+			Message: fmt.Sprintf("auth references table '%s' which is not defined as a model", app.Auth.Table),
+			Context: "auth",
+		}}
+	}
+	return nil
+}
+
+func checkModelRefs(app *parser.App, schema *Schema) []Diagnostic {
+	var diags []Diagnostic
+	for _, m := range app.Models {
+		for _, f := range m.Fields {
+			if f.Type == parser.FieldReference {
+				if _, ok := schema.Tables[f.Reference]; !ok {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("field '%s' references model '%s' which is not defined", f.Name, f.Reference),
+						Context: fmt.Sprintf("model %s", m.Name),
+					})
+				}
+			}
+		}
+	}
+	return diags
+}
+
+func checkAllSQL(app *parser.App, schema *Schema) []Diagnostic {
+	var diags []Diagnostic
+
+	for _, p := range app.Pages {
+		ctx := fmt.Sprintf("page %s", p.Path)
+		diags = append(diags, analyzeNodes(p.Body, schema, ctx)...)
+	}
+	for _, a := range app.Actions {
+		ctx := fmt.Sprintf("action %s", a.Path)
+		diags = append(diags, analyzeNodes(a.Body, schema, ctx)...)
+	}
+	for _, f := range app.Fragments {
+		ctx := fmt.Sprintf("fragment %s", f.Path)
+		diags = append(diags, analyzeNodes(f.Body, schema, ctx)...)
+	}
+	for _, a := range app.APIs {
+		ctx := fmt.Sprintf("api %s", a.Path)
+		diags = append(diags, analyzeNodes(a.Body, schema, ctx)...)
+	}
+	for _, s := range app.Streams {
+		if s.SQL != "" {
+			ctx := fmt.Sprintf("stream %s", s.Path)
+			diags = append(diags, analyzeSQL(s.SQL, schema, ctx)...)
+		}
+	}
+	for _, s := range app.Schedules {
+		ctx := fmt.Sprintf("schedule %s", s.Name)
+		diags = append(diags, analyzeNodes(s.Body, schema, ctx)...)
+	}
+	for _, j := range app.Jobs {
+		ctx := fmt.Sprintf("job %s", j.Name)
+		diags = append(diags, analyzeNodes(j.Body, schema, ctx)...)
+	}
+	for _, wh := range app.Webhooks {
+		for _, ev := range wh.Events {
+			ctx := fmt.Sprintf("webhook %s on %s", wh.Path, ev.Name)
+			diags = append(diags, analyzeNodes(ev.Body, schema, ctx)...)
+		}
+	}
+	for _, sock := range app.Sockets {
+		base := fmt.Sprintf("socket %s", sock.Path)
+		diags = append(diags, analyzeNodes(sock.OnConnect, schema, base+" on connect")...)
+		diags = append(diags, analyzeNodes(sock.OnMessage, schema, base+" on message")...)
+		diags = append(diags, analyzeNodes(sock.OnDisconnect, schema, base+" on disconnect")...)
+	}
+
+	return diags
+}
+
+func analyzeNodes(nodes []parser.Node, schema *Schema, context string) []Diagnostic {
+	var diags []Diagnostic
+	for _, node := range nodes {
+		switch node.Type {
+		case parser.NodeQuery:
+			if node.SQL != "" {
+				diags = append(diags, analyzeSQL(node.SQL, schema, context)...)
+			}
+		case parser.NodeForm:
+			if node.ModelName != "" {
+				if _, ok := schema.Tables[node.ModelName]; !ok {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("form references model '%s' which is not defined", node.ModelName),
+						Context: context,
+					})
+				}
+			}
+			if node.QuerySQL != "" {
+				diags = append(diags, analyzeSQL(node.QuerySQL, schema, context)...)
+			}
+		case parser.NodeRespond:
+			if node.QuerySQL != "" {
+				diags = append(diags, analyzeSQL(node.QuerySQL, schema, context)...)
+			}
+		case parser.NodeValidate:
+			if node.ModelName != "" {
+				if _, ok := schema.Tables[node.ModelName]; !ok {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("validate references model '%s' which is not defined", node.ModelName),
+						Context: context,
+					})
+				}
+			}
+		case parser.NodeSearch:
+			diags = append(diags, checkSearchFields(node, schema, context)...)
+		case parser.NodeOn:
+			diags = append(diags, analyzeNodes(node.Children, schema, context)...)
+		}
+	}
+	return diags
+}
+
+func checkSearchFields(node parser.Node, schema *Schema, context string) []Diagnostic {
+	var diags []Diagnostic
+	for _, field := range node.SearchFields {
+		found := false
+		for _, table := range schema.Tables {
+			if table.Columns[field] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			diags = append(diags, Diagnostic{
+				Level:   "warning",
+				Message: fmt.Sprintf("search field '%s' not found in any model", field),
+				Context: context,
+			})
+		}
+	}
+	return diags
+}
+
+// --- SQL analysis ---
+
+func analyzeSQL(sql string, schema *Schema, context string) []Diagnostic {
+	var diags []Diagnostic
+	tokens := tokenizeSQL(sql)
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	tableRefs := extractTableRefs(tokens)
+	aliasToTable := make(map[string]string)
+	for _, ref := range tableRefs {
+		if _, ok := schema.Tables[ref.name]; !ok {
+			diags = append(diags, Diagnostic{
+				Level:   "error",
+				Message: fmt.Sprintf("table '%s' is not defined as a model", ref.name),
+				Context: context,
+			})
+		}
+		aliasToTable[ref.name] = ref.name
+		if ref.alias != "" {
+			aliasToTable[ref.alias] = ref.name
+		}
+	}
+
+	stmtType := ""
+	if len(tokens) > 0 && tokens[0].typ == stKeyword {
+		stmtType = tokens[0].lower
+	}
+
+	switch stmtType {
+	case "insert":
+		table, cols := extractInsertColumns(tokens)
+		if info, ok := schema.Tables[table]; ok {
+			for _, col := range cols {
+				if !info.Columns[col] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("column '%s' does not exist in model '%s'", col, table),
+						Context: context,
+					})
+				}
+			}
+		}
+	case "update":
+		table, cols := extractUpdateColumns(tokens)
+		if info, ok := schema.Tables[table]; ok {
+			for _, col := range cols {
+				if !info.Columns[col] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("column '%s' does not exist in model '%s'", col, table),
+						Context: context,
+					})
+				}
+			}
+		}
+	case "select":
+		diags = append(diags, checkSelectColumns(tokens, tableRefs, aliasToTable, schema, context)...)
+	}
+
+	return diags
+}
+
+func checkSelectColumns(tokens []sqlToken, tableRefs []tableRef, aliasToTable map[string]string, schema *Schema, context string) []Diagnostic {
+	var diags []Diagnostic
+	cols := extractSelectColumns(tokens)
+	if cols == nil {
+		return nil
+	}
+
+	for _, col := range cols {
+		if col.table != "" {
+			realTable, ok := aliasToTable[col.table]
+			if !ok {
+				continue
+			}
+			if info, ok := schema.Tables[realTable]; ok {
+				if !info.Columns[col.column] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("column '%s' does not exist in model '%s'", col.column, realTable),
+						Context: context,
+					})
+				}
+			}
+		} else if len(tableRefs) == 1 {
+			table := tableRefs[0].name
+			if info, ok := schema.Tables[table]; ok {
+				if !info.Columns[col.column] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("column '%s' does not exist in model '%s'", col.column, table),
+						Context: context,
+					})
+				}
+			}
+		}
+	}
+	return diags
+}
+
+// --- SQL tokenizer ---
+
+const (
+	stKeyword = iota
+	stIdent
+	stString
+	stNumber
+	stParam
+	stPunct
+	stStar
+	stOperator
+)
+
+type sqlToken struct {
+	typ   int
+	value string
+	lower string
+}
+
+var sqlKeywords = map[string]bool{
+	"select": true, "from": true, "where": true, "and": true, "or": true,
+	"insert": true, "into": true, "values": true, "update": true, "set": true,
+	"delete": true, "join": true, "left": true, "right": true, "inner": true,
+	"outer": true, "cross": true, "on": true, "as": true, "order": true,
+	"by": true, "group": true, "having": true, "limit": true, "offset": true,
+	"desc": true, "asc": true, "not": true, "null": true, "is": true,
+	"in": true, "like": true, "between": true, "exists": true, "union": true,
+	"distinct": true, "all": true, "case": true, "when": true, "then": true,
+	"else": true, "end": true, "true": true, "false": true,
+	"count": true, "sum": true, "avg": true, "min": true, "max": true,
+	"now": true, "datetime": true, "date": true, "time": true,
+	"cast": true, "coalesce": true, "ifnull": true, "typeof": true,
+	"interval": true, "replace": true, "substr": true, "length": true,
+	"lower": true, "upper": true, "trim": true, "abs": true, "round": true,
+}
+
+func tokenizeSQL(sql string) []sqlToken {
+	var tokens []sqlToken
+	runes := []rune(sql)
+	i := 0
+
+	for i < len(runes) {
+		ch := runes[i]
+
+		if unicode.IsSpace(ch) {
+			i++
+			continue
+		}
+
+		if ch == '\'' {
+			j := i + 1
+			for j < len(runes) {
+				if runes[j] == '\'' {
+					if j+1 < len(runes) && runes[j+1] == '\'' {
+						j += 2
+						continue
+					}
+					break
+				}
+				j++
+			}
+			if j < len(runes) {
+				j++
+			}
+			tokens = append(tokens, sqlToken{typ: stString, value: string(runes[i:j])})
+			i = j
+			continue
+		}
+
+		if ch == ':' {
+			j := i + 1
+			for j < len(runes) && (unicode.IsLetter(runes[j]) || unicode.IsDigit(runes[j]) || runes[j] == '_' || runes[j] == '.') {
+				j++
+			}
+			if j > i+1 {
+				tokens = append(tokens, sqlToken{typ: stParam, value: string(runes[i:j])})
+				i = j
+				continue
+			}
+			tokens = append(tokens, sqlToken{typ: stPunct, value: ":"})
+			i++
+			continue
+		}
+
+		if unicode.IsDigit(ch) {
+			j := i
+			for j < len(runes) && (unicode.IsDigit(runes[j]) || runes[j] == '.') {
+				j++
+			}
+			tokens = append(tokens, sqlToken{typ: stNumber, value: string(runes[i:j])})
+			i = j
+			continue
+		}
+
+		if ch == '*' {
+			tokens = append(tokens, sqlToken{typ: stStar, value: "*"})
+			i++
+			continue
+		}
+
+		if ch == '|' && i+1 < len(runes) && runes[i+1] == '|' {
+			tokens = append(tokens, sqlToken{typ: stOperator, value: "||"})
+			i += 2
+			continue
+		}
+		if ch == '<' || ch == '>' || ch == '=' || ch == '!' {
+			j := i + 1
+			if j < len(runes) && runes[j] == '=' {
+				j++
+			}
+			tokens = append(tokens, sqlToken{typ: stOperator, value: string(runes[i:j])})
+			i = j
+			continue
+		}
+
+		if ch == '(' || ch == ')' || ch == ',' || ch == '.' || ch == ';' || ch == '+' || ch == '-' || ch == '%' {
+			tokens = append(tokens, sqlToken{typ: stPunct, value: string(ch)})
+			i++
+			continue
+		}
+
+		if ch == '"' {
+			j := i + 1
+			for j < len(runes) && runes[j] != '"' {
+				j++
+			}
+			if j < len(runes) {
+				j++
+			}
+			word := string(runes[i+1 : j-1])
+			tokens = append(tokens, sqlToken{typ: stIdent, value: word, lower: strings.ToLower(word)})
+			i = j
+			continue
+		}
+
+		if unicode.IsLetter(ch) || ch == '_' {
+			j := i
+			for j < len(runes) && (unicode.IsLetter(runes[j]) || unicode.IsDigit(runes[j]) || runes[j] == '_') {
+				j++
+			}
+			word := string(runes[i:j])
+			lower := strings.ToLower(word)
+			if sqlKeywords[lower] {
+				tokens = append(tokens, sqlToken{typ: stKeyword, value: word, lower: lower})
+			} else {
+				tokens = append(tokens, sqlToken{typ: stIdent, value: word, lower: lower})
+			}
+			i = j
+			continue
+		}
+
+		i++
+	}
+
+	return tokens
+}
+
+// --- SQL reference extraction ---
+
+type tableRef struct {
+	name  string
+	alias string
+}
+
+type columnRef struct {
+	table  string
+	column string
+}
+
+func extractTableRefs(tokens []sqlToken) []tableRef {
+	var refs []tableRef
+
+	for i := 0; i < len(tokens); i++ {
+		t := tokens[i]
+		if t.typ != stKeyword {
+			continue
+		}
+		if t.lower != "from" && t.lower != "join" && t.lower != "into" && t.lower != "update" {
+			continue
+		}
+		if i+1 >= len(tokens) || tokens[i+1].typ != stIdent {
+			continue
+		}
+
+		ref := tableRef{name: tokens[i+1].lower}
+
+		if i+2 < len(tokens) {
+			next := tokens[i+2]
+			if next.typ == stKeyword && next.lower == "as" && i+3 < len(tokens) && tokens[i+3].typ == stIdent {
+				ref.alias = tokens[i+3].lower
+			} else if next.typ == stIdent {
+				nl := next.lower
+				if !isClauseKeyword(nl) {
+					ref.alias = nl
+				}
+			}
+		}
+
+		refs = append(refs, ref)
+	}
+
+	return refs
+}
+
+func isClauseKeyword(s string) bool {
+	switch s {
+	case "where", "on", "set", "order", "group", "having", "limit",
+		"values", "inner", "left", "right", "outer", "cross", "join",
+		"and", "or", "not", "union":
+		return true
+	}
+	return false
+}
+
+func extractInsertColumns(tokens []sqlToken) (string, []string) {
+	var table string
+	var cols []string
+
+	for i := 0; i < len(tokens)-1; i++ {
+		if tokens[i].typ == stKeyword && tokens[i].lower == "into" && tokens[i+1].typ == stIdent {
+			table = tokens[i+1].lower
+			for j := i + 2; j < len(tokens); j++ {
+				if tokens[j].typ == stPunct && tokens[j].value == "(" {
+					for k := j + 1; k < len(tokens); k++ {
+						if tokens[k].typ == stPunct && tokens[k].value == ")" {
+							break
+						}
+						if tokens[k].typ == stIdent {
+							cols = append(cols, tokens[k].lower)
+						}
+					}
+					break
+				}
+				if tokens[j].typ == stKeyword && tokens[j].lower == "values" {
+					break
+				}
+			}
+			break
+		}
+	}
+
+	return table, cols
+}
+
+func extractUpdateColumns(tokens []sqlToken) (string, []string) {
+	var table string
+	var cols []string
+
+	for i := 0; i < len(tokens)-1; i++ {
+		if tokens[i].typ == stKeyword && tokens[i].lower == "update" && tokens[i+1].typ == stIdent {
+			table = tokens[i+1].lower
+		}
+		if tokens[i].typ == stKeyword && tokens[i].lower == "set" {
+			for j := i + 1; j < len(tokens); j++ {
+				if tokens[j].typ == stKeyword && (tokens[j].lower == "where" || tokens[j].lower == "order" || tokens[j].lower == "limit") {
+					break
+				}
+				if tokens[j].typ == stIdent && j+1 < len(tokens) && tokens[j+1].typ == stOperator && tokens[j+1].value == "=" {
+					cols = append(cols, tokens[j].lower)
+				}
+			}
+			break
+		}
+	}
+
+	return table, cols
+}
+
+// extractSelectColumns returns column references from a SELECT clause.
+// Returns nil if SELECT * is used (meaning "all columns, no individual check").
+func extractSelectColumns(tokens []sqlToken) []columnRef {
+	var cols []columnRef
+	inSelect := false
+	parenDepth := 0
+
+	for i := 0; i < len(tokens); i++ {
+		if tokens[i].typ == stKeyword && tokens[i].lower == "select" {
+			inSelect = true
+			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "distinct" {
+				i++
+			}
+			continue
+		}
+		if !inSelect {
+			continue
+		}
+
+		if tokens[i].typ == stKeyword && tokens[i].lower == "from" && parenDepth == 0 {
+			break
+		}
+
+		if tokens[i].typ == stPunct && tokens[i].value == "(" {
+			parenDepth++
+			continue
+		}
+		if tokens[i].typ == stPunct && tokens[i].value == ")" {
+			if parenDepth > 0 {
+				parenDepth--
+			}
+			continue
+		}
+
+		if parenDepth > 0 {
+			continue
+		}
+
+		if tokens[i].typ == stStar {
+			return nil
+		}
+
+		// Skip aggregate/scalar function calls: func(...)
+		if tokens[i].typ == stKeyword && i+1 < len(tokens) && tokens[i+1].typ == stPunct && tokens[i+1].value == "(" {
+			depth := 1
+			i += 2
+			for i < len(tokens) && depth > 0 {
+				if tokens[i].typ == stPunct && tokens[i].value == "(" {
+					depth++
+				}
+				if tokens[i].typ == stPunct && tokens[i].value == ")" {
+					depth--
+				}
+				i++
+			}
+			if i < len(tokens) && tokens[i].typ == stKeyword && tokens[i].lower == "as" {
+				i++
+				if i < len(tokens) {
+					i++
+				}
+			}
+			i--
+			continue
+		}
+
+		if tokens[i].typ == stKeyword && tokens[i].lower == "case" {
+			depth := 1
+			i++
+			for i < len(tokens) && depth > 0 {
+				if tokens[i].typ == stKeyword && tokens[i].lower == "case" {
+					depth++
+				}
+				if tokens[i].typ == stKeyword && tokens[i].lower == "end" {
+					depth--
+				}
+				i++
+			}
+			if i < len(tokens) && tokens[i].typ == stKeyword && tokens[i].lower == "as" {
+				i++
+				if i < len(tokens) {
+					i++
+				}
+			}
+			i--
+			continue
+		}
+
+		if tokens[i].typ == stIdent {
+			if i+2 < len(tokens) && tokens[i+1].typ == stPunct && tokens[i+1].value == "." && tokens[i+2].typ == stIdent {
+				cols = append(cols, columnRef{table: tokens[i].lower, column: tokens[i+2].lower})
+				i += 2
+			} else {
+				cols = append(cols, columnRef{column: tokens[i].lower})
+			}
+
+			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "as" {
+				i += 2
+			}
+			continue
+		}
+
+		if tokens[i].typ == stPunct && tokens[i].value == "," {
+			continue
+		}
+
+		// String literal: skip, including any "as alias"
+		if tokens[i].typ == stString {
+			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "as" {
+				i += 2
+			}
+			continue
+		}
+
+		// Number literal: skip, including any "as alias"
+		if tokens[i].typ == stNumber {
+			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "as" {
+				i += 2
+			}
+			continue
+		}
+	}
+
+	return cols
+}

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -1,0 +1,689 @@
+package analyzer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+func TestBuildSchema(t *testing.T) {
+	models := []parser.Model{
+		{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+				{Name: "password", Type: parser.FieldPassword},
+				{Name: "role", Type: parser.FieldOption},
+				{Name: "active", Type: parser.FieldBool},
+				{Name: "created", Type: parser.FieldTimestamp},
+			},
+		},
+		{
+			Name: "post",
+			Fields: []parser.Field{
+				{Name: "title", Type: parser.FieldText},
+				{Name: "body", Type: parser.FieldRichtext},
+				{Name: "author", Type: parser.FieldReference, Reference: "user"},
+				{Name: "created", Type: parser.FieldTimestamp},
+			},
+		},
+	}
+
+	schema := BuildSchema(models)
+
+	if len(schema.Tables) != 2 {
+		t.Fatalf("expected 2 tables, got %d", len(schema.Tables))
+	}
+
+	user := schema.Tables["user"]
+	if user == nil {
+		t.Fatal("user table not found")
+	}
+	for _, col := range []string{"id", "name", "email", "password", "role", "active", "created"} {
+		if !user.Columns[col] {
+			t.Errorf("user.%s should exist", col)
+		}
+	}
+
+	post := schema.Tables["post"]
+	if post == nil {
+		t.Fatal("post table not found")
+	}
+	if !post.Columns["author_id"] {
+		t.Error("post.author_id should exist (reference field)")
+	}
+	if post.Columns["author"] {
+		t.Error("post.author should NOT exist (reference becomes author_id)")
+	}
+}
+
+func TestTokenizeSQL(t *testing.T) {
+	tests := []struct {
+		sql      string
+		wantLen  int
+		wantLast string
+	}{
+		{"SELECT * FROM user", 4, "user"},
+		{"SELECT name, email FROM user WHERE id = :id", 10, ""},
+		{"INSERT INTO user (name, email) VALUES (:name, :email)", 14, ""},
+		{"SELECT 'hello world' as greeting", 4, ""},
+		{"DELETE FROM user WHERE active = 0", 8, ""},
+	}
+
+	for _, tt := range tests {
+		tokens := tokenizeSQL(tt.sql)
+		if len(tokens) < 2 {
+			t.Errorf("tokenizeSQL(%q): got %d tokens, expected at least 2", tt.sql, len(tokens))
+		}
+	}
+}
+
+func TestExtractTableRefs(t *testing.T) {
+	tests := []struct {
+		sql    string
+		tables []string
+	}{
+		{"SELECT * FROM user", []string{"user"}},
+		{"SELECT * FROM user u", []string{"user"}},
+		{"SELECT * FROM user AS u", []string{"user"}},
+		{"DELETE FROM user WHERE id = 1", []string{"user"}},
+		{"INSERT INTO user (name) VALUES ('test')", []string{"user"}},
+		{"UPDATE user SET name = 'test' WHERE id = 1", []string{"user"}},
+		{"SELECT u.name, p.title FROM user u JOIN post p ON p.author_id = u.id", []string{"user", "post"}},
+		{"SELECT u.name FROM user u LEFT JOIN post p ON p.author_id = u.id", []string{"user", "post"}},
+		{"SELECT 'connected' as status", nil},
+	}
+
+	for _, tt := range tests {
+		tokens := tokenizeSQL(tt.sql)
+		refs := extractTableRefs(tokens)
+
+		var names []string
+		for _, r := range refs {
+			names = append(names, r.name)
+		}
+
+		if len(names) != len(tt.tables) {
+			t.Errorf("extractTableRefs(%q): got %v, want %v", tt.sql, names, tt.tables)
+			continue
+		}
+		for i, name := range names {
+			if name != tt.tables[i] {
+				t.Errorf("extractTableRefs(%q)[%d]: got %q, want %q", tt.sql, i, name, tt.tables[i])
+			}
+		}
+	}
+}
+
+func TestExtractTableRefsAliases(t *testing.T) {
+	tokens := tokenizeSQL("SELECT u.name FROM user u JOIN post p ON p.author_id = u.id")
+	refs := extractTableRefs(tokens)
+
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 table refs, got %d", len(refs))
+	}
+	if refs[0].name != "user" || refs[0].alias != "u" {
+		t.Errorf("ref[0]: got {%s, %s}, want {user, u}", refs[0].name, refs[0].alias)
+	}
+	if refs[1].name != "post" || refs[1].alias != "p" {
+		t.Errorf("ref[1]: got {%s, %s}, want {post, p}", refs[1].name, refs[1].alias)
+	}
+}
+
+func TestExtractInsertColumns(t *testing.T) {
+	tokens := tokenizeSQL("INSERT INTO user (name, email, role) VALUES (:name, :email, :role)")
+	table, cols := extractInsertColumns(tokens)
+
+	if table != "user" {
+		t.Errorf("table: got %q, want 'user'", table)
+	}
+	expected := []string{"name", "email", "role"}
+	if len(cols) != len(expected) {
+		t.Fatalf("cols: got %v, want %v", cols, expected)
+	}
+	for i, col := range cols {
+		if col != expected[i] {
+			t.Errorf("cols[%d]: got %q, want %q", i, col, expected[i])
+		}
+	}
+}
+
+func TestExtractUpdateColumns(t *testing.T) {
+	tokens := tokenizeSQL("UPDATE user SET name = :name, email = :email WHERE id = :id")
+	table, cols := extractUpdateColumns(tokens)
+
+	if table != "user" {
+		t.Errorf("table: got %q, want 'user'", table)
+	}
+	expected := []string{"name", "email"}
+	if len(cols) != len(expected) {
+		t.Fatalf("cols: got %v, want %v", cols, expected)
+	}
+	for i, col := range cols {
+		if col != expected[i] {
+			t.Errorf("cols[%d]: got %q, want %q", i, col, expected[i])
+		}
+	}
+}
+
+func TestExtractSelectColumns(t *testing.T) {
+	tests := []struct {
+		sql  string
+		want []columnRef
+		nil_ bool
+	}{
+		{
+			sql:  "SELECT * FROM user",
+			nil_: true,
+		},
+		{
+			sql:  "SELECT id, name, email FROM user",
+			want: []columnRef{{column: "id"}, {column: "name"}, {column: "email"}},
+		},
+		{
+			sql:  "SELECT count(*) as total FROM user",
+			want: []columnRef{},
+		},
+		{
+			sql:  "SELECT u.name, u.email FROM user u",
+			want: []columnRef{{table: "u", column: "name"}, {table: "u", column: "email"}},
+		},
+		{
+			sql:  "SELECT id, count(*) as total FROM user GROUP BY id",
+			want: []columnRef{{column: "id"}},
+		},
+		{
+			sql:  "SELECT 'connected' as status",
+			want: []columnRef{},
+		},
+	}
+
+	for _, tt := range tests {
+		tokens := tokenizeSQL(tt.sql)
+		cols := extractSelectColumns(tokens)
+
+		if tt.nil_ {
+			if cols != nil {
+				t.Errorf("extractSelectColumns(%q): expected nil, got %v", tt.sql, cols)
+			}
+			continue
+		}
+
+		if len(cols) != len(tt.want) {
+			t.Errorf("extractSelectColumns(%q): got %d cols, want %d", tt.sql, len(cols), len(tt.want))
+			continue
+		}
+		for i, col := range cols {
+			if col.table != tt.want[i].table || col.column != tt.want[i].column {
+				t.Errorf("extractSelectColumns(%q)[%d]: got {%s,%s}, want {%s,%s}",
+					tt.sql, i, col.table, col.column, tt.want[i].table, tt.want[i].column)
+			}
+		}
+	}
+}
+
+func TestAnalyze_ValidApp(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{
+				Name: "user",
+				Fields: []parser.Field{
+					{Name: "name", Type: parser.FieldText},
+					{Name: "email", Type: parser.FieldEmail},
+					{Name: "password", Type: parser.FieldPassword},
+					{Name: "role", Type: parser.FieldOption},
+					{Name: "active", Type: parser.FieldBool},
+					{Name: "created", Type: parser.FieldTimestamp},
+				},
+			},
+			{
+				Name: "post",
+				Fields: []parser.Field{
+					{Name: "title", Type: parser.FieldText},
+					{Name: "body", Type: parser.FieldRichtext},
+					{Name: "status", Type: parser.FieldOption},
+					{Name: "author", Type: parser.FieldReference, Reference: "user"},
+					{Name: "created", Type: parser.FieldTimestamp},
+				},
+			},
+		},
+		Auth: &parser.AuthConfig{Table: "user", Identity: "email", Password: "password"},
+		Pages: []parser.Page{
+			{
+				Path: "/users",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, Name: "users", SQL: "SELECT id, name, email, role FROM user ORDER BY id DESC"},
+					{Type: parser.NodeSearch, Name: "users", SearchFields: []string{"name", "email"}},
+				},
+			},
+		},
+		Actions: []parser.Page{
+			{
+				Path: "/users/new",
+				Body: []parser.Node{
+					{Type: parser.NodeValidate, ModelName: "user"},
+					{Type: parser.NodeQuery, SQL: "INSERT INTO user (name, email, password, role) VALUES (:name, :email, :password, :role)"},
+				},
+			},
+			{
+				Path: "/users/:id/edit",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: "UPDATE user SET name = :name, email = :email, role = :role WHERE id = :id"},
+				},
+			},
+		},
+		Streams: []parser.Stream{
+			{Path: "/stream/users", SQL: "SELECT count(*) as total FROM user"},
+		},
+	}
+
+	diags := Analyze(app)
+	if len(diags) > 0 {
+		for _, d := range diags {
+			t.Errorf("unexpected diagnostic: [%s] %s: %s", d.Level, d.Context, d.Message)
+		}
+	}
+}
+
+func TestAnalyze_UnknownTable(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
+		},
+		Pages: []parser.Page{
+			{
+				Path: "/test",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: "SELECT * FROM nonexistent"},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %v", len(diags), diags)
+	}
+	if diags[0].Level != "error" {
+		t.Errorf("expected error, got %s", diags[0].Level)
+	}
+	if !strings.Contains(diags[0].Message, "nonexistent") {
+		t.Errorf("expected message to mention 'nonexistent', got: %s", diags[0].Message)
+	}
+}
+
+func TestAnalyze_UnknownColumn_Insert(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+			}},
+		},
+		Actions: []parser.Page{
+			{
+				Path: "/users/new",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: "INSERT INTO user (name, username) VALUES (:name, :username)"},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "username") && strings.Contains(d.Message, "user") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about column 'username' in 'user', got: %v", diags)
+	}
+}
+
+func TestAnalyze_UnknownColumn_Update(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			}},
+		},
+		Actions: []parser.Page{
+			{
+				Path: "/users/:id",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: "UPDATE user SET username = :username WHERE id = :id"},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "username") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about column 'username', got: %v", diags)
+	}
+}
+
+func TestAnalyze_UnknownColumn_Select(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+			}},
+		},
+		Pages: []parser.Page{
+			{
+				Path: "/test",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: "SELECT id, name, username FROM user"},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "username") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about column 'username', got: %v", diags)
+	}
+}
+
+func TestAnalyze_InvalidAuthTable(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
+		},
+		Auth: &parser.AuthConfig{Table: "accounts"},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "accounts") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about auth table 'accounts', got: %v", diags)
+	}
+}
+
+func TestAnalyze_InvalidReference(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "post", Fields: []parser.Field{
+				{Name: "title", Type: parser.FieldText},
+				{Name: "author", Type: parser.FieldReference, Reference: "user"},
+			}},
+		},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "user") && strings.Contains(d.Message, "not defined") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about undefined model 'user', got: %v", diags)
+	}
+}
+
+func TestAnalyze_InvalidFormModel(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
+		},
+		Pages: []parser.Page{
+			{
+				Path: "/test",
+				Body: []parser.Node{
+					{Type: parser.NodeForm, ModelName: "account"},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "account") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about form model 'account', got: %v", diags)
+	}
+}
+
+func TestAnalyze_InvalidValidateModel(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
+		},
+		Actions: []parser.Page{
+			{
+				Path: "/test",
+				Body: []parser.Node{
+					{Type: parser.NodeValidate, ModelName: "profile"},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "profile") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about validate model 'profile', got: %v", diags)
+	}
+}
+
+func TestAnalyze_SearchFieldWarning(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+			}},
+		},
+		Pages: []parser.Page{
+			{
+				Path: "/test",
+				Body: []parser.Node{
+					{Type: parser.NodeSearch, Name: "users", SearchFields: []string{"name", "phone"}},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "warning" && strings.Contains(d.Message, "phone") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about search field 'phone', got: %v", diags)
+	}
+}
+
+func TestAnalyze_NoFalsePositives_AggregatesAndLiterals(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "active", Type: parser.FieldBool},
+				{Name: "created", Type: parser.FieldTimestamp},
+			}},
+		},
+		Pages: []parser.Page{
+			{
+				Path: "/stats",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: "SELECT count(*) as total FROM user"},
+				},
+			},
+		},
+		Schedules: []parser.Schedule{
+			{
+				Name: "cleanup",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: "DELETE FROM user WHERE active = 0 AND created < datetime('now', '-30 days')"},
+				},
+			},
+		},
+		Sockets: []parser.Socket{
+			{
+				Path:      "/ws/test",
+				OnConnect: []parser.Node{{Type: parser.NodeQuery, SQL: "SELECT 'connected' as status"}},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" {
+			t.Errorf("unexpected error: [%s] %s", d.Context, d.Message)
+		}
+	}
+}
+
+func TestAnalyze_QualifiedColumnRef(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			}},
+			{Name: "post", Fields: []parser.Field{
+				{Name: "title", Type: parser.FieldText},
+				{Name: "author", Type: parser.FieldReference, Reference: "user"},
+			}},
+		},
+		Pages: []parser.Page{
+			{
+				Path: "/test",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: "SELECT u.name, p.title FROM user u JOIN post p ON p.author_id = u.id"},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" {
+			t.Errorf("unexpected error: [%s] %s", d.Context, d.Message)
+		}
+	}
+}
+
+func TestAnalyze_QualifiedColumnRef_Invalid(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			}},
+		},
+		Pages: []parser.Page{
+			{
+				Path: "/test",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: "SELECT u.username FROM user u"},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "username") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about column 'username', got: %v", diags)
+	}
+}
+
+func TestAnalyze_RespondQuerySQL(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
+		},
+		Actions: []parser.Page{
+			{
+				Path: "/test",
+				Body: []parser.Node{
+					{Type: parser.NodeRespond, QuerySQL: "SELECT * FROM nonexistent WHERE id = :id"},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "nonexistent") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about table 'nonexistent', got: %v", diags)
+	}
+}
+
+func TestAnalyze_WebhookAndJobSQL(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "post", Fields: []parser.Field{
+				{Name: "title", Type: parser.FieldText},
+				{Name: "body", Type: parser.FieldRichtext},
+				{Name: "status", Type: parser.FieldOption},
+				{Name: "author", Type: parser.FieldReference, Reference: "post"},
+			}},
+		},
+		Webhooks: []parser.Webhook{
+			{
+				Path: "/hooks/test",
+				Events: []parser.WebhookEvent{
+					{
+						Name: "test.event",
+						Body: []parser.Node{
+							{Type: parser.NodeQuery, SQL: "INSERT INTO post (title, body, status, author_id) VALUES ('test', 'body', 'draft', 1)"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "not defined as a model") {
+			t.Errorf("unexpected table error: %s", d.Message)
+		}
+	}
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -72,6 +72,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kilnx-org/kilnx/internal/analyzer"
 	"github.com/kilnx-org/kilnx/internal/database"
 	"github.com/kilnx-org/kilnx/internal/lexer"
 	"github.com/kilnx-org/kilnx/internal/parser"
@@ -86,6 +87,22 @@ func main() {
 	if err != nil {
 		fmt.Printf("Parse error: %v\n", err)
 		os.Exit(1)
+	}
+
+	if diags := analyzer.Analyze(app); len(diags) > 0 {
+		hasErrors := false
+		for _, d := range diags {
+			prefix := "warning"
+			if d.Level == "error" {
+				prefix = "error"
+				hasErrors = true
+			}
+			fmt.Fprintf(os.Stderr, "kilnx %s: [%s] %s\n", prefix, d.Context, d.Message)
+		}
+		if hasErrors {
+			fmt.Fprintln(os.Stderr, "Static analysis found errors, aborting.")
+			os.Exit(1)
+		}
 	}
 
 	port := 8080


### PR DESCRIPTION
## Summary

- Introduces `internal/analyzer` package that verifies SQL queries against declared models at compile time, catching table/column errors before runtime
- Adds `kilnx check` CLI command for standalone static analysis
- Integrates analysis into `kilnx run`, `kilnx test`, and `kilnx build` pipelines

## What it checks

| Check | Level | Example |
|---|---|---|
| Table existence (FROM/JOIN/INSERT/UPDATE) | error | `table 'comments' is not defined as a model` |
| Column existence in SELECT | error | `column 'username' does not exist in model 'user'` |
| Column existence in INSERT | error | `column 'nickname' does not exist in model 'user'` |
| Column existence in UPDATE SET | error | `column 'username' does not exist in model 'user'` |
| Qualified column refs (alias.col) | error | via alias resolution |
| Auth table reference | error | `auth references table 'accounts' which is not defined` |
| Reference field validity | error | `field 'author' references model 'user' which is not defined` |
| Form/validate model references | error | `form references model 'account' which is not defined` |
| Search field existence | warning | `search field 'phone' not found in any model` |

## How it works

The analyzer builds a schema from model declarations, tokenizes SQL strings with a lightweight SQL tokenizer, extracts table/column references, and cross-references them against the schema. This is possible because Kilnx keeps models and queries in the same AST — a structural advantage over tools like sqlc or Prisma that operate across separate files.

