### PR TITLE
Add domain-aware SELECT * query optimization

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kilnx-org/kilnx/internal/build"
 	"github.com/kilnx-org/kilnx/internal/database"
 	"github.com/kilnx-org/kilnx/internal/lexer"
+	"github.com/kilnx-org/kilnx/internal/optimizer"
 	"github.com/kilnx-org/kilnx/internal/parser"
 	"github.com/kilnx-org/kilnx/internal/runtime"
 )
@@ -111,6 +112,8 @@ func cmdRun(filename string) error {
 		}
 	}
 
+	optimizer.Optimize(app)
+
 	// Resolve config
 	port := 8080
 	dbPath := dbPathFor(filename)
@@ -204,6 +207,8 @@ func cmdTest(filename string) error {
 			return fmt.Errorf("static analysis found errors")
 		}
 	}
+
+	optimizer.Optimize(app)
 
 	if len(app.Tests) == 0 {
 		fmt.Println("No tests found.")

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -75,6 +75,7 @@ import (
 	"github.com/kilnx-org/kilnx/internal/analyzer"
 	"github.com/kilnx-org/kilnx/internal/database"
 	"github.com/kilnx-org/kilnx/internal/lexer"
+	"github.com/kilnx-org/kilnx/internal/optimizer"
 	"github.com/kilnx-org/kilnx/internal/parser"
 	"github.com/kilnx-org/kilnx/internal/runtime"
 )
@@ -104,6 +105,8 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
+	optimizer.Optimize(app)
 
 	port := 8080
 	dbPath := "app.db"

--- a/internal/optimizer/optimizer.go
+++ b/internal/optimizer/optimizer.go
@@ -1,0 +1,256 @@
+package optimizer
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// interpolateRe matches {queryName.field} patterns used in text/html interpolation.
+var interpolateRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)\}`)
+
+// selectStarRe matches SELECT * or SELECT DISTINCT * at the start of a SQL query (case-insensitive).
+var selectStarRe = regexp.MustCompile(`(?i)^(SELECT\s+(?:DISTINCT\s+)?)\*(\s+FROM\s+)`)
+
+// Optimize performs domain-aware query optimization on a parsed Kilnx app.
+// It rewrites SELECT * queries to only select columns that are actually
+// consumed by components (table, list, card) and interpolations.
+func Optimize(app *parser.App) {
+	for i := range app.Pages {
+		optimizePage(&app.Pages[i])
+	}
+	for i := range app.Fragments {
+		optimizePage(&app.Fragments[i])
+	}
+	for i := range app.APIs {
+		optimizePage(&app.APIs[i])
+	}
+}
+
+func optimizePage(page *parser.Page) {
+	// Build a map of query name -> set of fields used by consumers
+	usedFields := collectUsedFields(page.Body)
+
+	// Count unnamed queries to avoid unsafe _last optimization
+	unnamedCount := countUnnamedQueries(page.Body)
+
+	// Rewrite SELECT * queries where we know all consumed fields
+	for i, node := range page.Body {
+		if node.Type != parser.NodeQuery {
+			continue
+		}
+		queryName := node.Name
+		if queryName == "" {
+			if unnamedCount > 1 {
+				continue // multiple unnamed queries share _last, skip to avoid wrong columns
+			}
+			queryName = "_last"
+		}
+
+		fields, known := usedFields[queryName]
+		if !known || fields == nil || len(fields.fields) == 0 {
+			continue
+		}
+
+		rewritten := rewriteSelectStar(node.SQL, fields)
+		if rewritten != node.SQL {
+			page.Body[i].SQL = rewritten
+		}
+	}
+}
+
+// collectUsedFields walks all nodes in a page body and collects which fields
+// each query name needs. Returns nil for a query if field usage can't be
+// fully determined (e.g. table with no explicit columns).
+func collectUsedFields(nodes []parser.Node) map[string]*fieldSet {
+	result := make(map[string]*fieldSet)
+
+	for _, node := range nodes {
+		switch node.Type {
+		case parser.NodeTable:
+			queryName := node.Name
+			if queryName == "" {
+				queryName = "_last"
+			}
+			if len(node.Columns) == 0 {
+				// Auto-detect mode: we can't know which columns are needed
+				// Mark as unknowable so we skip optimization
+				result[queryName] = nil
+				continue
+			}
+			if result[queryName] == nil && !hasKey(result, queryName) {
+				result[queryName] = newFieldSet()
+			}
+			fs := result[queryName]
+			if fs == nil {
+				continue // already marked unknowable
+			}
+			for _, col := range node.Columns {
+				fs.add(col.Field)
+			}
+			// Row actions may interpolate :field from query rows
+			for _, action := range node.RowActions {
+				for _, f := range extractPathParams(action.Path) {
+					fs.add(f)
+				}
+			}
+
+		case parser.NodeList:
+			queryName := node.Name
+			if queryName == "" {
+				queryName = "_last"
+			}
+			if result[queryName] == nil && !hasKey(result, queryName) {
+				result[queryName] = newFieldSet()
+			}
+			fs := result[queryName]
+			if fs == nil {
+				continue
+			}
+			for _, prop := range []string{"title", "subtitle", "image"} {
+				if v, ok := node.Props[prop]; ok && v != "" {
+					fs.add(v)
+				}
+			}
+			if v, ok := node.Props["action_path"]; ok && v != "" {
+				for _, f := range extractPathParams(v) {
+					fs.add(f)
+				}
+			}
+
+		case parser.NodeSearch:
+			queryName := node.Name
+			if queryName == "" {
+				queryName = "_last"
+			}
+			if result[queryName] == nil && !hasKey(result, queryName) {
+				result[queryName] = newFieldSet()
+			}
+			fs := result[queryName]
+			if fs == nil {
+				continue
+			}
+			for _, f := range node.SearchFields {
+				fs.add(f)
+			}
+
+		case parser.NodeText:
+			addInterpolatedFields(result, node.Value)
+
+		case parser.NodeHTML:
+			addInterpolatedFields(result, node.HTMLContent)
+
+		case parser.NodeOn:
+			childFields := collectUsedFields(node.Children)
+			for k, v := range childFields {
+				if v == nil {
+					result[k] = nil
+				} else if !hasKey(result, k) {
+					result[k] = v
+				} else if existing := result[k]; existing != nil {
+					for _, f := range v.fields {
+						existing.add(f)
+					}
+				}
+				// else: result[k] is nil (unknowable), keep it nil
+			}
+		}
+	}
+
+	return result
+}
+
+// addInterpolatedFields extracts {queryName.field} references from text
+// and adds the fields to the appropriate query's field set.
+func addInterpolatedFields(result map[string]*fieldSet, text string) {
+	matches := interpolateRe.FindAllStringSubmatch(text, -1)
+	for _, m := range matches {
+		queryName := m[1]
+		field := m[2]
+		if field == "count" {
+			continue // built-in, not a real column
+		}
+		if result[queryName] == nil && !hasKey(result, queryName) {
+			result[queryName] = newFieldSet()
+		}
+		fs := result[queryName]
+		if fs == nil {
+			continue
+		}
+		fs.add(field)
+	}
+}
+
+// extractPathParams pulls :param names from a URL path like /users/:id/edit.
+func extractPathParams(path string) []string {
+	var params []string
+	for _, segment := range strings.Split(path, "/") {
+		if strings.HasPrefix(segment, ":") {
+			params = append(params, segment[1:])
+		}
+	}
+	return params
+}
+
+// rewriteSelectStar replaces SELECT * FROM with SELECT col1, col2, ... FROM
+// only if the SQL starts with SELECT [DISTINCT] * FROM.
+func rewriteSelectStar(sql string, fields *fieldSet) string {
+	trimmed := strings.TrimSpace(sql)
+	loc := selectStarRe.FindStringSubmatchIndex(trimmed)
+	if loc == nil {
+		return sql
+	}
+
+	// Preserve leading whitespace from original
+	leadingWS := sql[:len(sql)-len(strings.TrimLeft(sql, " \t\n\r"))]
+
+	prefix := trimmed[loc[2]:loc[3]]    // "SELECT " or "SELECT DISTINCT "
+	fromPart := trimmed[loc[4]:loc[5]]   // " FROM "
+	rest := trimmed[loc[1]:]             // everything after "* FROM "
+
+	cols := fields.sorted()
+	return leadingWS + prefix + strings.Join(cols, ", ") + fromPart + rest
+}
+
+// fieldSet is an ordered set of field names.
+type fieldSet struct {
+	fields []string
+	seen   map[string]bool
+}
+
+func newFieldSet() *fieldSet {
+	return &fieldSet{seen: make(map[string]bool)}
+}
+
+func (fs *fieldSet) add(field string) {
+	// Handle dot notation: author.name -> just use the full field as-is
+	if fs.seen[field] {
+		return
+	}
+	fs.seen[field] = true
+	fs.fields = append(fs.fields, field)
+}
+
+func (fs *fieldSet) sorted() []string {
+	// Return in insertion order for deterministic output
+	return fs.fields
+}
+
+func hasKey(m map[string]*fieldSet, key string) bool {
+	_, ok := m[key]
+	return ok
+}
+
+func countUnnamedQueries(nodes []parser.Node) int {
+	count := 0
+	for _, node := range nodes {
+		if node.Type == parser.NodeQuery && node.Name == "" {
+			count++
+		}
+		if node.Type == parser.NodeOn {
+			count += countUnnamedQueries(node.Children)
+		}
+	}
+	return count
+}

--- a/internal/optimizer/optimizer_test.go
+++ b/internal/optimizer/optimizer_test.go
@@ -1,0 +1,593 @@
+package optimizer
+
+import (
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+func TestRewriteSelectStar_TableWithColumns(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type: parser.NodeTable,
+					Name: "users",
+					Columns: []parser.TableColumn{
+						{Field: "name"},
+						{Field: "email"},
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name, email FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteSelectStar_ListWithProps(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type: parser.NodeList,
+					Name: "users",
+					Props: map[string]string{
+						"title":    "name",
+						"subtitle": "email",
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name, email FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNoRewrite_TableWithoutColumns(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type:    parser.NodeTable,
+					Name:    "users",
+					Columns: nil, // auto-detect mode
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT * FROM user"
+	if got != want {
+		t.Errorf("should not rewrite, got %q", got)
+	}
+}
+
+func TestNoRewrite_ExplicitColumns(t *testing.T) {
+	original := "SELECT name, email FROM user"
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  original,
+				},
+				{
+					Type: parser.NodeTable,
+					Name: "users",
+					Columns: []parser.TableColumn{
+						{Field: "name"},
+						{Field: "email"},
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	if got != original {
+		t.Errorf("should not rewrite explicit columns, got %q", got)
+	}
+}
+
+func TestRewrite_WithDistinct(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT DISTINCT * FROM user",
+				},
+				{
+					Type: parser.NodeTable,
+					Name: "users",
+					Columns: []parser.TableColumn{
+						{Field: "name"},
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT DISTINCT name FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewrite_MultiLineSQL(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user WHERE active = 1 ORDER BY name",
+				},
+				{
+					Type: parser.NodeList,
+					Name: "users",
+					Props: map[string]string{
+						"title": "name",
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name FROM user WHERE active = 1 ORDER BY name"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewrite_QueryUsedByMultipleComponents(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type: parser.NodeList,
+					Name: "users",
+					Props: map[string]string{
+						"title": "name",
+					},
+				},
+				{
+					Type: parser.NodeTable,
+					Name: "users",
+					Columns: []parser.TableColumn{
+						{Field: "email"},
+						{Field: "created"},
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name, email, created FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewrite_InterpolatedFields(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "stats",
+					SQL:  "SELECT * FROM stats",
+				},
+				{
+					Type:  parser.NodeText,
+					Value: "Total users: {stats.total}",
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT total FROM stats"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewrite_HTMLInterpolation(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/profile",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "user",
+					SQL:  "SELECT * FROM user WHERE id = 1",
+				},
+				{
+					Type:        parser.NodeHTML,
+					HTMLContent: "<h1>{user.name}</h1><p>{user.bio}</p>",
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name, bio FROM user WHERE id = 1"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewrite_RowActionsIncludeParams(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type: parser.NodeTable,
+					Name: "users",
+					Columns: []parser.TableColumn{
+						{Field: "name"},
+					},
+					RowActions: []parser.RowAction{
+						{Label: "edit", Path: "/users/:id/edit"},
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name, id FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewrite_Fragment(t *testing.T) {
+	app := &parser.App{
+		Fragments: []parser.Page{{
+			Path: "/user-list",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type: parser.NodeList,
+					Name: "users",
+					Props: map[string]string{
+						"title": "name",
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Fragments[0].Body[0].SQL
+	want := "SELECT name FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNoRewrite_NoConsumers(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT * FROM user"
+	if got != want {
+		t.Errorf("should not rewrite without consumers, got %q", got)
+	}
+}
+
+func TestNoRewrite_CountInterpolation(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/dashboard",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type:  parser.NodeText,
+					Value: "Total: {users.count}",
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	// .count is a built-in, not a real column, so no fields are collected
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT * FROM user"
+	if got != want {
+		t.Errorf("should not rewrite with only .count, got %q", got)
+	}
+}
+
+func TestRewrite_CaseInsensitive(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "select * from user",
+				},
+				{
+					Type: parser.NodeList,
+					Name: "users",
+					Props: map[string]string{
+						"title": "name",
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "select name from user"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewrite_DedupFields(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type: parser.NodeList,
+					Name: "users",
+					Props: map[string]string{
+						"title":    "name",
+						"subtitle": "name",
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNoRewrite_MultipleUnnamedQueries(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/dashboard",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type: parser.NodeQuery,
+					SQL:  "SELECT * FROM post",
+				},
+				{
+					Type: parser.NodeTable,
+					Columns: []parser.TableColumn{
+						{Field: "name"},
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got1 := app.Pages[0].Body[0].SQL
+	got2 := app.Pages[0].Body[1].SQL
+	if got1 != "SELECT * FROM user" {
+		t.Errorf("should not rewrite first unnamed query, got %q", got1)
+	}
+	if got2 != "SELECT * FROM post" {
+		t.Errorf("should not rewrite second unnamed query, got %q", got2)
+	}
+}
+
+func TestNoRewrite_ActionLabelNotColumn(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type: parser.NodeList,
+					Name: "users",
+					Props: map[string]string{
+						"title":        "name",
+						"action_label": "Edit",
+						"action_path":  "/users/:id/edit",
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name, id FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q (action_label should NOT be a column)", got, want)
+	}
+}
+
+func TestRewrite_NodeOnChildren(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "user",
+					SQL:  "SELECT * FROM user WHERE id = 1",
+				},
+				{
+					Type: parser.NodeOn,
+					Children: []parser.Node{
+						{
+							Type:  parser.NodeText,
+							Value: "Welcome {user.name}",
+						},
+						{
+							Type:        parser.NodeHTML,
+							HTMLContent: "<span>{user.email}</span>",
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name, email FROM user WHERE id = 1"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewrite_SearchFieldsIncluded(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "users",
+					SQL:  "SELECT * FROM user",
+				},
+				{
+					Type: parser.NodeTable,
+					Name: "users",
+					Columns: []parser.TableColumn{
+						{Field: "name"},
+					},
+				},
+				{
+					Type:         parser.NodeSearch,
+					Name:         "users",
+					SearchFields: []string{"email", "name"},
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT name, email FROM user"
+	if got != want {
+		t.Errorf("got %q, want %q (search fields must be included)", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/optimizer/` package that rewrites `SELECT *` to only fetch columns actually consumed by components (table, list, search, text/html interpolations)
- Inserted into the compilation pipeline after static analysis, before runtime, in `cmdRun`, `cmdTest`, and `build`
- Safe guards: skips optimization when columns can't be statically determined (auto-detect tables, multiple unnamed queries, no consumers)

## Test plan

- [x] 19 unit tests covering all rewrite/no-rewrite scenarios
- [x] `go build ./...` passes
- [x] `go test ./...` passes (existing analyzer tests unaffected)
- [ ] Manual test with blog.kilnx example app