### PR TITLE
Add implicit type inference system to analyzer

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -16,10 +16,10 @@ type Diagnostic struct {
 	Context string // location, e.g. "page /users"
 }
 
-// TableInfo holds the known columns for a model-derived table.
+// TableInfo holds the known columns and their types for a model-derived table.
 type TableInfo struct {
 	Name    string
-	Columns map[string]bool
+	Columns map[string]*ColumnInfo
 }
 
 // ModelFieldInfo holds the form-level field names for a model.
@@ -36,31 +36,32 @@ type Schema struct {
 	ModelFields map[string]*ModelFieldInfo
 }
 
+// BuildSchema creates a compile-time view of the database from model declarations.
 func BuildSchema(models []parser.Model) *Schema {
 	s := &Schema{
 		Tables:      make(map[string]*TableInfo),
 		ModelFields: make(map[string]*ModelFieldInfo),
 	}
 	for _, m := range models {
-		info := &TableInfo{Name: m.Name, Columns: make(map[string]bool)}
+		info := &TableInfo{Name: m.Name, Columns: make(map[string]*ColumnInfo)}
 		mf := &ModelFieldInfo{
 			FormFields:    make(map[string]bool),
 			FieldToColumn: make(map[string]string),
 			ColumnToField: make(map[string]string),
 		}
-		info.Columns["id"] = true
+		info.Columns["id"] = &ColumnInfo{FieldType: parser.FieldInt}
 		mf.FormFields["id"] = true
 		mf.FieldToColumn["id"] = "id"
 		mf.ColumnToField["id"] = "id"
 		for _, f := range m.Fields {
 			if f.Type == parser.FieldReference {
 				colName := f.Name + "_id"
-				info.Columns[colName] = true
+				info.Columns[colName] = &ColumnInfo{FieldType: parser.FieldInt}
 				mf.FormFields[f.Name] = true
 				mf.FieldToColumn[f.Name] = colName
 				mf.ColumnToField[colName] = f.Name
 			} else {
-				info.Columns[f.Name] = true
+				info.Columns[f.Name] = &ColumnInfo{FieldType: f.Type}
 				mf.FormFields[f.Name] = true
 				mf.FieldToColumn[f.Name] = f.Name
 				mf.ColumnToField[f.Name] = f.Name
@@ -73,11 +74,13 @@ func BuildSchema(models []parser.Model) *Schema {
 }
 
 // Analyze performs static analysis on a parsed Kilnx app, checking SQL
-// references against declared models.
+// references against declared models and type compatibility.
 func Analyze(app *parser.App) []Diagnostic {
 	var diags []Diagnostic
 	schema := BuildSchema(app.Models)
 
+	diags = append(diags, checkModelDefaults(app.Models)...)
+	diags = append(diags, checkModelMinMax(app.Models)...)
 	diags = append(diags, checkAuthRef(app, schema)...)
 	diags = append(diags, checkModelRefs(app, schema)...)
 	diags = append(diags, checkAllSQL(app, schema)...)
@@ -127,7 +130,6 @@ func checkAllSQL(app *parser.App, schema *Schema) []Diagnostic {
 	for _, a := range app.Actions {
 		ctx := fmt.Sprintf("action %s", a.Path)
 		diags = append(diags, analyzeNodes(a.Body, schema, ctx)...)
-		// Validate named params in action SQL against form fields
 		modelName := findActionModel(a, app)
 		diags = append(diags, checkActionParams(a, modelName, schema, ctx)...)
 	}
@@ -169,9 +171,6 @@ func checkAllSQL(app *parser.App, schema *Schema) []Diagnostic {
 	return diags
 }
 
-// checkActionParams validates named params in all SQL nodes of an action,
-// including query SQL, form QuerySQL, and respond QuerySQL. Recurses into
-// NodeOn children to cover on success/error branches.
 func checkActionParams(action parser.Page, modelName string, schema *Schema, context string) []Diagnostic {
 	return checkActionParamsNodes(action.Body, action.Path, modelName, schema, context)
 }
@@ -245,7 +244,7 @@ func checkSearchFields(node parser.Node, schema *Schema, context string) []Diagn
 	for _, field := range node.SearchFields {
 		found := false
 		for _, table := range schema.Tables {
-			if table.Columns[field] {
+			if _, colExists := table.Columns[field]; colExists {
 				found = true
 				break
 			}
@@ -296,7 +295,7 @@ func analyzeSQL(sql string, schema *Schema, context string) []Diagnostic {
 		table, cols := extractInsertColumns(tokens)
 		if info, ok := schema.Tables[table]; ok {
 			for _, col := range cols {
-				if !info.Columns[col] {
+				if _, colExists := info.Columns[col]; !colExists {
 					diags = append(diags, Diagnostic{
 						Level:   "error",
 						Message: fmt.Sprintf("column '%s' does not exist in model '%s'", col, table),
@@ -309,7 +308,7 @@ func analyzeSQL(sql string, schema *Schema, context string) []Diagnostic {
 		table, cols := extractUpdateColumns(tokens)
 		if info, ok := schema.Tables[table]; ok {
 			for _, col := range cols {
-				if !info.Columns[col] {
+				if _, colExists := info.Columns[col]; !colExists {
 					diags = append(diags, Diagnostic{
 						Level:   "error",
 						Message: fmt.Sprintf("column '%s' does not exist in model '%s'", col, table),
@@ -320,6 +319,17 @@ func analyzeSQL(sql string, schema *Schema, context string) []Diagnostic {
 		}
 	case "select":
 		diags = append(diags, checkSelectColumns(tokens, tableRefs, aliasToTable, schema, context)...)
+	}
+
+	// Type-level checks
+	diags = append(diags, checkWhereTypes(tokens, tableRefs, aliasToTable, schema, context)...)
+	switch stmtType {
+	case "insert":
+		tbl, _ := extractInsertColumns(tokens)
+		diags = append(diags, checkInsertValueTypes(tokens, tbl, schema, context)...)
+	case "update":
+		tbl, _ := extractUpdateColumns(tokens)
+		diags = append(diags, checkUpdateSetTypes(tokens, tbl, schema, context)...)
 	}
 
 	return diags
@@ -339,7 +349,7 @@ func checkSelectColumns(tokens []sqlToken, tableRefs []tableRef, aliasToTable ma
 				continue
 			}
 			if info, ok := schema.Tables[realTable]; ok {
-				if !info.Columns[col.column] {
+				if _, colExists := info.Columns[col.column]; !colExists {
 					diags = append(diags, Diagnostic{
 						Level:   "error",
 						Message: fmt.Sprintf("column '%s' does not exist in model '%s'", col.column, realTable),
@@ -350,7 +360,7 @@ func checkSelectColumns(tokens []sqlToken, tableRefs []tableRef, aliasToTable ma
 		} else if len(tableRefs) == 1 {
 			table := tableRefs[0].name
 			if info, ok := schema.Tables[table]; ok {
-				if !info.Columns[col.column] {
+				if _, colExists := info.Columns[col.column]; !colExists {
 					diags = append(diags, Diagnostic{
 						Level:   "error",
 						Message: fmt.Sprintf("column '%s' does not exist in model '%s'", col.column, table),
@@ -365,7 +375,6 @@ func checkSelectColumns(tokens []sqlToken, tableRefs []tableRef, aliasToTable ma
 
 // --- Named param validation ---
 
-// extractNamedParams returns all :param references from SQL tokens.
 func extractNamedParams(tokens []sqlToken) []string {
 	var params []string
 	seen := make(map[string]bool)
@@ -381,7 +390,6 @@ func extractNamedParams(tokens []sqlToken) []string {
 	return params
 }
 
-// extractURLParams extracts named segments from a URL path like /deals/:id/edit.
 func extractURLParams(path string) map[string]bool {
 	params := make(map[string]bool)
 	for _, seg := range strings.Split(path, "/") {
@@ -392,12 +400,7 @@ func extractURLParams(path string) map[string]bool {
 	return params
 }
 
-// findActionModel determines which model an action operates on by checking:
-// 1. validate/form nodes in the action body
-// 2. matching page with same path that has a form
-// 3. the target table in INSERT/UPDATE SQL statements
 func findActionModel(action parser.Page, app *parser.App) string {
-	// Check if the action body has a validate node referencing a model
 	for _, n := range action.Body {
 		if n.Type == parser.NodeValidate && n.ModelName != "" {
 			return n.ModelName
@@ -406,7 +409,6 @@ func findActionModel(action parser.Page, app *parser.App) string {
 			return n.ModelName
 		}
 	}
-	// Look for a matching page with the same path that has a form
 	for _, p := range app.Pages {
 		if p.Path == action.Path {
 			for _, n := range p.Body {
@@ -416,7 +418,6 @@ func findActionModel(action parser.Page, app *parser.App) string {
 			}
 		}
 	}
-	// Infer from SQL: extract table name from INSERT INTO or UPDATE statements
 	for _, n := range action.Body {
 		if n.Type == parser.NodeQuery && n.SQL != "" {
 			tokens := tokenizeSQL(n.SQL)
@@ -439,8 +440,6 @@ func findActionModel(action parser.Page, app *parser.App) string {
 	return ""
 }
 
-// checkNamedParams validates that SQL named parameters match available form fields
-// and URL params. Reports errors with "did you mean?" suggestions.
 func checkNamedParams(sql string, tokens []sqlToken, path string, modelName string, schema *Schema, context string) []Diagnostic {
 	var diags []Diagnostic
 	params := extractNamedParams(tokens)
@@ -448,15 +447,11 @@ func checkNamedParams(sql string, tokens []sqlToken, path string, modelName stri
 		return nil
 	}
 
-	// Build set of available param names
 	available := make(map[string]bool)
-
-	// URL path params (e.g., :id from /deals/:id)
 	for p := range extractURLParams(path) {
 		available[p] = true
 	}
 
-	// Model form fields
 	var mf *ModelFieldInfo
 	if modelName != "" {
 		if m, ok := schema.ModelFields[modelName]; ok {
@@ -467,13 +462,10 @@ func checkNamedParams(sql string, tokens []sqlToken, path string, modelName stri
 		}
 	}
 
-	// Check each param
 	for _, param := range params {
 		if available[param] {
 			continue
 		}
-
-		// Maybe it's a DB column name and the form sends the field name?
 		if mf != nil {
 			if fieldName, ok := mf.ColumnToField[param]; ok {
 				diags = append(diags, Diagnostic{
@@ -488,8 +480,6 @@ func checkNamedParams(sql string, tokens []sqlToken, path string, modelName stri
 				continue
 			}
 		}
-
-		// Try to find a close match
 		suggestion := findClosestMatch(param, available)
 		if suggestion != "" {
 			diags = append(diags, Diagnostic{
@@ -501,7 +491,6 @@ func checkNamedParams(sql string, tokens []sqlToken, path string, modelName stri
 				Context: context,
 			})
 		} else {
-			// List available params
 			var avail []string
 			for a := range available {
 				avail = append(avail, ":"+a)
@@ -520,10 +509,9 @@ func checkNamedParams(sql string, tokens []sqlToken, path string, modelName stri
 	return diags
 }
 
-// findClosestMatch returns the closest match from candidates using edit distance.
 func findClosestMatch(target string, candidates map[string]bool) string {
 	best := ""
-	bestDist := (len(target) + 2) / 3 // threshold: must be within ~1/3 of the length
+	bestDist := (len(target) + 2) / 3
 	if bestDist < 1 {
 		bestDist = 1
 	}
@@ -537,7 +525,6 @@ func findClosestMatch(target string, candidates map[string]bool) string {
 	return best
 }
 
-// editDistance computes the Levenshtein distance between two strings.
 func editDistance(a, b string) int {
 	la, lb := len(a), len(b)
 	if la == 0 {
@@ -546,7 +533,6 @@ func editDistance(a, b string) int {
 	if lb == 0 {
 		return la
 	}
-
 	prev := make([]int, lb+1)
 	curr := make([]int, lb+1)
 	for j := 0; j <= lb; j++ {
@@ -843,8 +829,6 @@ func extractUpdateColumns(tokens []sqlToken) (string, []string) {
 	return table, cols
 }
 
-// extractSelectColumns returns column references from a SELECT clause.
-// Returns nil if SELECT * is used (meaning "all columns, no individual check").
 func extractSelectColumns(tokens []sqlToken) []columnRef {
 	var cols []columnRef
 	inSelect := false
@@ -885,7 +869,6 @@ func extractSelectColumns(tokens []sqlToken) []columnRef {
 			return nil
 		}
 
-		// Skip aggregate/scalar function calls: func(...)
 		if tokens[i].typ == stKeyword && i+1 < len(tokens) && tokens[i+1].typ == stPunct && tokens[i+1].value == "(" {
 			depth := 1
 			i += 2
@@ -898,7 +881,7 @@ func extractSelectColumns(tokens []sqlToken) []columnRef {
 				}
 				i++
 			}
-			if i < len(tokens) && tokens[i].typ == stKeyword && tokens[i].lower == "as" {
+			if i < len(tokens) && tokens[i].typ == stKeyword && tokens[i].lower == "as" && i+1 < len(tokens) {
 				i++
 				if i < len(tokens) {
 					i++
@@ -920,7 +903,7 @@ func extractSelectColumns(tokens []sqlToken) []columnRef {
 				}
 				i++
 			}
-			if i < len(tokens) && tokens[i].typ == stKeyword && tokens[i].lower == "as" {
+			if i < len(tokens) && tokens[i].typ == stKeyword && tokens[i].lower == "as" && i+1 < len(tokens) {
 				i++
 				if i < len(tokens) {
 					i++
@@ -938,8 +921,7 @@ func extractSelectColumns(tokens []sqlToken) []columnRef {
 				cols = append(cols, columnRef{column: tokens[i].lower})
 			}
 
-			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "as" &&
-				i+2 < len(tokens) {
+			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "as" && i+2 < len(tokens) {
 				i += 2
 			}
 			continue
@@ -949,19 +931,15 @@ func extractSelectColumns(tokens []sqlToken) []columnRef {
 			continue
 		}
 
-		// String literal: skip, including any "as alias"
 		if tokens[i].typ == stString {
-			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "as" &&
-				i+2 < len(tokens) {
+			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "as" && i+2 < len(tokens) {
 				i += 2
 			}
 			continue
 		}
 
-		// Number literal: skip, including any "as alias"
 		if tokens[i].typ == stNumber {
-			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "as" &&
-				i+2 < len(tokens) {
+			if i+1 < len(tokens) && tokens[i+1].typ == stKeyword && tokens[i+1].lower == "as" && i+2 < len(tokens) {
 				i += 2
 			}
 			continue

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -42,7 +42,7 @@ func TestBuildSchema(t *testing.T) {
 		t.Fatal("user table not found")
 	}
 	for _, col := range []string{"id", "name", "email", "password", "role", "active", "created"} {
-		if !user.Columns[col] {
+		if _, exists := user.Columns[col]; !exists {
 			t.Errorf("user.%s should exist", col)
 		}
 	}
@@ -51,10 +51,10 @@ func TestBuildSchema(t *testing.T) {
 	if post == nil {
 		t.Fatal("post table not found")
 	}
-	if !post.Columns["author_id"] {
+	if _, exists := post.Columns["author_id"]; !exists {
 		t.Error("post.author_id should exist (reference field)")
 	}
-	if post.Columns["author"] {
+	if _, exists := post.Columns["author"]; exists {
 		t.Error("post.author should NOT exist (reference becomes author_id)")
 	}
 }
@@ -866,5 +866,276 @@ func TestAnalyze_WebhookAndJobSQL(t *testing.T) {
 		if d.Level == "error" && strings.Contains(d.Message, "not defined as a model") {
 			t.Errorf("unexpected table error: %s", d.Message)
 		}
+	}
+}
+
+// --- Type system tests ---
+
+func TestCheckModelDefaults_IntFieldWithStringDefault(t *testing.T) {
+	models := []parser.Model{{
+		Name: "item",
+		Fields: []parser.Field{
+			{Name: "count", Type: parser.FieldInt, Default: "abc"},
+		},
+	}}
+	diags := checkModelDefaults(models)
+	if len(diags) != 1 || !strings.Contains(diags[0].Message, "not a valid integer") {
+		t.Errorf("expected int default error, got: %v", diags)
+	}
+}
+
+func TestCheckModelDefaults_IntFieldWithValidDefault(t *testing.T) {
+	models := []parser.Model{{
+		Name: "item",
+		Fields: []parser.Field{
+			{Name: "count", Type: parser.FieldInt, Default: "42"},
+		},
+	}}
+	diags := checkModelDefaults(models)
+	if len(diags) != 0 {
+		t.Errorf("expected no errors, got: %v", diags)
+	}
+}
+
+func TestCheckModelDefaults_BoolFieldWithInvalidDefault(t *testing.T) {
+	models := []parser.Model{{
+		Name: "item",
+		Fields: []parser.Field{
+			{Name: "active", Type: parser.FieldBool, Default: "maybe"},
+		},
+	}}
+	diags := checkModelDefaults(models)
+	if len(diags) != 1 || !strings.Contains(diags[0].Message, "use 'true' or 'false'") {
+		t.Errorf("expected bool default error, got: %v", diags)
+	}
+}
+
+func TestCheckModelDefaults_OptionFieldWithInvalidDefault(t *testing.T) {
+	models := []parser.Model{{
+		Name: "user",
+		Fields: []parser.Field{
+			{Name: "role", Type: parser.FieldOption, Default: "superadmin", Options: []string{"admin", "editor", "viewer"}},
+		},
+	}}
+	diags := checkModelDefaults(models)
+	if len(diags) != 1 || !strings.Contains(diags[0].Message, "valid options are") {
+		t.Errorf("expected option default error, got: %v", diags)
+	}
+}
+
+func TestCheckModelDefaults_FloatFieldWithValidDefault(t *testing.T) {
+	models := []parser.Model{{
+		Name: "item",
+		Fields: []parser.Field{
+			{Name: "price", Type: parser.FieldFloat, Default: "3.14"},
+		},
+	}}
+	diags := checkModelDefaults(models)
+	if len(diags) != 0 {
+		t.Errorf("expected no errors, got: %v", diags)
+	}
+}
+
+func TestAnalyze_WhereTypeMismatch_IntVsString(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "age", Type: parser.FieldInt},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, SQL: "SELECT id FROM user WHERE age = 'hello'"},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "not compatible") && strings.Contains(d.Message, "age") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected type mismatch error for age vs string, got: %v", diags)
+	}
+}
+
+func TestAnalyze_WhereNoFalsePositive_IntVsNumber(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "age", Type: parser.FieldInt},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, SQL: "SELECT id FROM user WHERE age = 25"},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if strings.Contains(d.Message, "not compatible") {
+			t.Errorf("unexpected type error: %s", d.Message)
+		}
+	}
+}
+
+func TestAnalyze_WhereNoFalsePositive_BoolVsInt(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "active", Type: parser.FieldBool},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, SQL: "SELECT id FROM user WHERE active = 1"},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if strings.Contains(d.Message, "not compatible") {
+			t.Errorf("unexpected type error: %s", d.Message)
+		}
+	}
+}
+
+func TestAnalyze_WhereNoFalsePositive_Param(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "age", Type: parser.FieldInt},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, SQL: "SELECT id FROM user WHERE age = :age"},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if strings.Contains(d.Message, "not compatible") {
+			t.Errorf("unexpected type error: %s", d.Message)
+		}
+	}
+}
+
+func TestAnalyze_WhereWarning_BoolVsStringTrue(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "active", Type: parser.FieldBool},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, SQL: "SELECT id FROM user WHERE active = 'true'"},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "warning" && strings.Contains(d.Message, "use 1 (true) or 0 (false)") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about bool vs string 'true', got: %v", diags)
+	}
+}
+
+func TestAnalyze_InsertTypeMismatch(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "age", Type: parser.FieldInt},
+			},
+		}},
+		Actions: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, SQL: "INSERT INTO user (name, age) VALUES ('Alice', 'twenty')"},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "inserting") && strings.Contains(d.Message, "age") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected insert type mismatch for age, got: %v", diags)
+	}
+}
+
+func TestAnalyze_InsertNoFalsePositive_Param(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "age", Type: parser.FieldInt},
+			},
+		}},
+		Actions: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, SQL: "INSERT INTO user (name, age) VALUES (:name, :age)"},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if strings.Contains(d.Message, "inserting") || strings.Contains(d.Message, "not compatible") {
+			t.Errorf("unexpected type error: %s", d.Message)
+		}
+	}
+}
+
+func TestAnalyze_UpdateTypeMismatch(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "age", Type: parser.FieldInt},
+			},
+		}},
+		Actions: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, SQL: "UPDATE user SET age = 'hello' WHERE id = 1"},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "setting column") && strings.Contains(d.Message, "age") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected update type mismatch for age, got: %v", diags)
 	}
 }

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -1,0 +1,452 @@
+package analyzer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// ColumnInfo holds the inferred type for a single database column.
+type ColumnInfo struct {
+	FieldType parser.FieldType
+}
+
+// TypeCategory groups field types for compatibility checking.
+type TypeCategory int
+
+const (
+	CategoryText    TypeCategory = iota // text, email, richtext, password, image, phone, option
+	CategoryNumeric                     // int, float
+	CategoryBool                        // bool
+	CategoryTime                        // timestamp
+)
+
+func categoryOf(ft parser.FieldType) TypeCategory {
+	switch ft {
+	case parser.FieldInt, parser.FieldFloat:
+		return CategoryNumeric
+	case parser.FieldBool:
+		return CategoryBool
+	case parser.FieldTimestamp:
+		return CategoryTime
+	default:
+		return CategoryText
+	}
+}
+
+func categoryName(c TypeCategory) string {
+	switch c {
+	case CategoryNumeric:
+		return "numeric"
+	case CategoryBool:
+		return "bool"
+	case CategoryTime:
+		return "timestamp"
+	default:
+		return "text"
+	}
+}
+
+// typesCompatible checks if two type categories can be compared.
+// Bool is compatible with numeric because SQLite stores bools as INTEGER.
+func typesCompatible(a, b TypeCategory) bool {
+	if a == b {
+		return true
+	}
+	if (a == CategoryBool && b == CategoryNumeric) || (a == CategoryNumeric && b == CategoryBool) {
+		return true
+	}
+	return false
+}
+
+// --- Model-level type checks ---
+
+func checkModelDefaults(models []parser.Model) []Diagnostic {
+	var diags []Diagnostic
+	for _, m := range models {
+		ctx := fmt.Sprintf("model %s", m.Name)
+		for _, f := range m.Fields {
+			if f.Default == "" {
+				continue
+			}
+			switch f.Type {
+			case parser.FieldInt:
+				if _, err := strconv.Atoi(f.Default); err != nil {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("field '%s' is type int but has default value '%s' which is not a valid integer", f.Name, f.Default),
+						Context: ctx,
+					})
+				}
+			case parser.FieldFloat:
+				if _, err := strconv.ParseFloat(f.Default, 64); err != nil {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("field '%s' is type float but has default value '%s' which is not a valid number", f.Name, f.Default),
+						Context: ctx,
+					})
+				}
+			case parser.FieldBool:
+				if f.Default != "true" && f.Default != "false" {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("field '%s' is type bool but has default value '%s' - use 'true' or 'false'", f.Name, f.Default),
+						Context: ctx,
+					})
+				}
+			case parser.FieldOption:
+				if len(f.Options) > 0 {
+					found := false
+					for _, opt := range f.Options {
+						if opt == f.Default {
+							found = true
+							break
+						}
+					}
+					if !found {
+						diags = append(diags, Diagnostic{
+							Level:   "error",
+							Message: fmt.Sprintf("field '%s' has default '%s' but valid options are: %s", f.Name, f.Default, strings.Join(f.Options, ", ")),
+							Context: ctx,
+						})
+					}
+				}
+			}
+		}
+	}
+	return diags
+}
+
+func checkModelMinMax(models []parser.Model) []Diagnostic {
+	var diags []Diagnostic
+	for _, m := range models {
+		ctx := fmt.Sprintf("model %s", m.Name)
+		for _, f := range m.Fields {
+			if f.Min != "" {
+				if err := validateMinMax(f.Min, f.Type); err != nil {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("field '%s' has invalid min value '%s': %s", f.Name, f.Min, err),
+						Context: ctx,
+					})
+				}
+			}
+			if f.Max != "" {
+				if err := validateMinMax(f.Max, f.Type); err != nil {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("field '%s' has invalid max value '%s': %s", f.Name, f.Max, err),
+						Context: ctx,
+					})
+				}
+			}
+		}
+	}
+	return diags
+}
+
+func validateMinMax(val string, ft parser.FieldType) error {
+	switch ft {
+	case parser.FieldInt:
+		if _, err := strconv.Atoi(val); err != nil {
+			return fmt.Errorf("expected integer for int field")
+		}
+	case parser.FieldFloat:
+		if _, err := strconv.ParseFloat(val, 64); err != nil {
+			return fmt.Errorf("expected number for float field")
+		}
+	case parser.FieldText, parser.FieldEmail, parser.FieldPassword, parser.FieldPhone:
+		if n, err := strconv.Atoi(val); err != nil || n < 0 {
+			return fmt.Errorf("expected non-negative integer (string length)")
+		}
+	}
+	return nil
+}
+
+// --- SQL type checking ---
+
+// ExprType represents the inferred type of a SQL expression.
+type ExprType struct {
+	Category TypeCategory
+	Source   string // description for error messages
+}
+
+// sqlComparison represents a binary comparison in a WHERE clause.
+type sqlComparison struct {
+	left       sqlToken
+	right      sqlToken
+	leftTable  string
+	rightTable string
+	op         string
+}
+
+// extractWhereComparisons extracts simple col op value comparisons from WHERE clauses.
+func extractWhereComparisons(tokens []sqlToken) []sqlComparison {
+	var comps []sqlComparison
+	inWhere := false
+	parenDepth := 0
+
+	for i := 0; i < len(tokens); i++ {
+		if tokens[i].typ == stKeyword && tokens[i].lower == "where" {
+			inWhere = true
+			continue
+		}
+		if !inWhere {
+			continue
+		}
+		if tokens[i].typ == stKeyword && parenDepth == 0 {
+			switch tokens[i].lower {
+			case "order", "group", "limit", "having", "union":
+				return comps
+			}
+		}
+		if tokens[i].typ == stPunct && tokens[i].value == "(" {
+			parenDepth++
+			continue
+		}
+		if tokens[i].typ == stPunct && tokens[i].value == ")" {
+			if parenDepth > 0 {
+				parenDepth--
+			}
+			continue
+		}
+		if parenDepth > 0 {
+			continue
+		}
+
+		if i+2 < len(tokens) && tokens[i+1].typ == stOperator {
+			op := tokens[i+1].value
+			if op == "=" || op == "!=" || op == "<" || op == ">" || op == "<=" || op == ">=" {
+				left := tokens[i]
+				right := tokens[i+2]
+				c := sqlComparison{left: left, right: right, op: op}
+
+				if i >= 2 && tokens[i-1].typ == stPunct && tokens[i-1].value == "." && tokens[i-2].typ == stIdent {
+					c.leftTable = tokens[i-2].lower
+				}
+				if i+4 < len(tokens) && tokens[i+3].typ == stPunct && tokens[i+3].value == "." && tokens[i+4].typ == stIdent {
+					c.rightTable = tokens[i+2].lower
+					c.right = tokens[i+4]
+				}
+
+				comps = append(comps, c)
+			}
+		}
+	}
+	return comps
+}
+
+// inferTokenType determines the type category of a SQL token based on schema.
+func inferTokenType(tok sqlToken, tableName string, aliasToTable map[string]string, schema *Schema) *ExprType {
+	switch tok.typ {
+	case stString:
+		return &ExprType{Category: CategoryText, Source: fmt.Sprintf("string literal %s", tok.value)}
+	case stNumber:
+		return &ExprType{Category: CategoryNumeric, Source: fmt.Sprintf("number %s", tok.value)}
+	case stIdent:
+		realTable := tableName
+		if aliasToTable != nil {
+			if mapped, ok := aliasToTable[tableName]; ok {
+				realTable = mapped
+			}
+		}
+		if realTable == "" {
+			for _, info := range schema.Tables {
+				if col, ok := info.Columns[tok.lower]; ok {
+					return &ExprType{
+						Category: categoryOf(col.FieldType),
+						Source:   fmt.Sprintf("column '%s' (%s)", tok.lower, string(col.FieldType)),
+					}
+				}
+			}
+			return nil
+		}
+		if info, ok := schema.Tables[realTable]; ok {
+			if col, ok := info.Columns[tok.lower]; ok {
+				return &ExprType{
+					Category: categoryOf(col.FieldType),
+					Source:   fmt.Sprintf("column '%s' (%s)", tok.lower, string(col.FieldType)),
+				}
+			}
+		}
+		return nil
+	case stKeyword:
+		if tok.lower == "true" || tok.lower == "false" {
+			return &ExprType{Category: CategoryBool, Source: fmt.Sprintf("boolean %s", tok.lower)}
+		}
+		if tok.lower == "null" {
+			return nil
+		}
+		return nil
+	case stParam:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// checkWhereTypes validates type compatibility in WHERE clause comparisons.
+func checkWhereTypes(tokens []sqlToken, tableRefs []tableRef, aliasToTable map[string]string, schema *Schema, context string) []Diagnostic {
+	var diags []Diagnostic
+	comps := extractWhereComparisons(tokens)
+
+	defaultTable := ""
+	if len(tableRefs) == 1 {
+		defaultTable = tableRefs[0].name
+	}
+
+	for _, c := range comps {
+		leftTable := c.leftTable
+		if leftTable == "" {
+			leftTable = defaultTable
+		}
+		rightTable := c.rightTable
+		if rightTable == "" {
+			rightTable = defaultTable
+		}
+
+		leftType := inferTokenType(c.left, leftTable, aliasToTable, schema)
+		rightType := inferTokenType(c.right, rightTable, aliasToTable, schema)
+
+		if leftType == nil || rightType == nil {
+			continue
+		}
+
+		if !typesCompatible(leftType.Category, rightType.Category) {
+			if leftType.Category == CategoryBool && rightType.Category == CategoryText {
+				val := strings.Trim(c.right.value, "'")
+				if val == "true" || val == "false" {
+					diags = append(diags, Diagnostic{
+						Level:   "warning",
+						Message: fmt.Sprintf("comparing %s with %s - use 1 (true) or 0 (false) instead of string", leftType.Source, rightType.Source),
+						Context: context,
+					})
+					continue
+				}
+			}
+			diags = append(diags, Diagnostic{
+				Level:   "error",
+				Message: fmt.Sprintf("comparing %s with %s - these types are not compatible", leftType.Source, rightType.Source),
+				Context: context,
+			})
+		}
+	}
+	return diags
+}
+
+// checkInsertValueTypes validates that INSERT literal values match column types.
+func checkInsertValueTypes(tokens []sqlToken, table string, schema *Schema, context string) []Diagnostic {
+	info, ok := schema.Tables[table]
+	if !ok {
+		return nil
+	}
+
+	var cols []string
+	var vals []sqlToken
+	inCols := false
+	inVals := false
+	parenDepth := 0
+
+	for i := 0; i < len(tokens); i++ {
+		if tokens[i].typ == stKeyword && tokens[i].lower == "values" {
+			inCols = false
+			continue
+		}
+		if tokens[i].typ == stPunct && tokens[i].value == "(" {
+			parenDepth++
+			if parenDepth == 1 {
+				if !inVals && len(cols) == 0 {
+					inCols = true
+				} else {
+					inVals = true
+				}
+			}
+			continue
+		}
+		if tokens[i].typ == stPunct && tokens[i].value == ")" {
+			parenDepth--
+			if parenDepth == 0 {
+				inCols = false
+				inVals = false
+			}
+			continue
+		}
+		if tokens[i].typ == stPunct && tokens[i].value == "," {
+			continue
+		}
+		if inCols && tokens[i].typ == stIdent {
+			cols = append(cols, tokens[i].lower)
+		}
+		if inVals && parenDepth == 1 {
+			vals = append(vals, tokens[i])
+		}
+	}
+
+	var diags []Diagnostic
+	for i := 0; i < len(cols) && i < len(vals); i++ {
+		colInfo, ok := info.Columns[cols[i]]
+		if !ok {
+			continue
+		}
+		valType := inferTokenType(vals[i], "", nil, schema)
+		if valType == nil {
+			continue
+		}
+		colCat := categoryOf(colInfo.FieldType)
+		if !typesCompatible(colCat, valType.Category) {
+			diags = append(diags, Diagnostic{
+				Level:   "error",
+				Message: fmt.Sprintf("inserting %s into column '%s' which is type %s", valType.Source, cols[i], string(colInfo.FieldType)),
+				Context: context,
+			})
+		}
+	}
+	return diags
+}
+
+// checkUpdateSetTypes validates that UPDATE SET literal values match column types.
+func checkUpdateSetTypes(tokens []sqlToken, table string, schema *Schema, context string) []Diagnostic {
+	info, ok := schema.Tables[table]
+	if !ok {
+		return nil
+	}
+
+	var diags []Diagnostic
+	inSet := false
+	for i := 0; i < len(tokens); i++ {
+		if tokens[i].typ == stKeyword && tokens[i].lower == "set" {
+			inSet = true
+			continue
+		}
+		if !inSet {
+			continue
+		}
+		if tokens[i].typ == stKeyword && (tokens[i].lower == "where" || tokens[i].lower == "order" || tokens[i].lower == "limit") {
+			break
+		}
+		if tokens[i].typ == stIdent && i+2 < len(tokens) && tokens[i+1].typ == stOperator && tokens[i+1].value == "=" {
+			col := tokens[i].lower
+			val := tokens[i+2]
+
+			colInfo, ok := info.Columns[col]
+			if !ok {
+				continue
+			}
+			valType := inferTokenType(val, "", nil, schema)
+			if valType == nil {
+				continue
+			}
+			colCat := categoryOf(colInfo.FieldType)
+			if !typesCompatible(colCat, valType.Category) {
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("setting column '%s' (%s) to %s - these types are not compatible", col, string(colInfo.FieldType), valType.Source),
+					Context: context,
+				})
+			}
+		}
+	}
+	return diags
+}


### PR DESCRIPTION
## Summary

- Extends the static analyzer with compile-time type checking inferred from model declarations
- `TableInfo.Columns` now stores `*ColumnInfo` with `FieldType` per column instead of just existence (`bool`)
- New `types.go` with type system: `ColumnInfo`, `TypeCategory` (text/numeric/bool/time), compatibility rules
- Validates model defaults (int default must be integer, bool must be true/false, option must be in declared list)
- Validates WHERE clause comparisons (catches `WHERE age = 'hello'` on int field)
- Validates INSERT/UPDATE literal values against column types
- Bool-numeric compatibility for SQLite (stores bools as INTEGER)
- Special warning for `bool = 'true'` suggesting `= 1` instead

## Test plan

- [x] All 41 tests pass (`go test ./internal/analyzer/ -v`)
- [x] Binary builds (`go build -o kilnx ./cmd/kilnx/`)
- [x] `kilnx check examples/blog.kilnx` passes with no issues
- [x] `kilnx check examples/crm.kilnx` passes with no issues
- [x] Type errors caught on intentionally bad `.kilnx` file (int default "abc", WHERE age = 'hello')