### PR TITLE
Complete type inference: template interpolations and table column validation

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -85,6 +85,8 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkModelRefs(app, schema)...)
 	diags = append(diags, checkAllSQL(app, schema)...)
 	diags = append(diags, checkSecurity(app, schema)...)
+	diags = append(diags, checkTemplateInterpolations(app, schema)...)
+	diags = append(diags, checkTableColumnRefs(app, schema)...)
 
 	return diags
 }

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -1428,3 +1428,322 @@ func TestExtractSubqueries(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckTemplateInterpolations_ValidField(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "users", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeHTML, HTMLContent: `<p>{users.name}</p><p>{users.email}</p>`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "template reference") {
+			t.Errorf("unexpected template error: %s", d.Message)
+		}
+	}
+}
+
+func TestCheckTemplateInterpolations_InvalidField(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "users", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeHTML, HTMLContent: `<p>{users.nonexistent}</p>`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "nonexistent") && strings.Contains(d.Message, "does not exist in model 'user'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error for nonexistent field, got: %v", diags)
+	}
+}
+
+func TestCheckTemplateInterpolations_UnknownQuery(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeHTML, HTMLContent: `<p>{missing.name}</p>`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "unknown query 'missing'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error for unknown query, got: %v", diags)
+	}
+}
+
+func TestCheckTemplateInterpolations_ReservedNames(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeHTML, HTMLContent: `<title>{page.title}</title>{kilnx.css}{t.greeting}`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "template reference") {
+			t.Errorf("reserved names should not trigger errors: %s", d.Message)
+		}
+	}
+}
+
+func TestCheckTemplateInterpolations_BuiltinCount(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "users", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeHTML, HTMLContent: `<span>{users.count} users</span>`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "count") && strings.Contains(d.Message, "template reference") {
+			t.Errorf(".count is a built-in field and should not trigger error: %s", d.Message)
+		}
+	}
+}
+
+func TestCheckTemplateInterpolations_Fragment(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "post",
+			Fields: []parser.Field{
+				{Name: "title", Type: parser.FieldText},
+				{Name: "body", Type: parser.FieldRichtext},
+			},
+		}},
+		Fragments: []parser.Page{{
+			Path: "/posts/row",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "post", SQL: "SELECT * FROM post WHERE id = :id"},
+				{Type: parser.NodeHTML, HTMLContent: `<div>{post.title}</div><div>{post.missing}</div>`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	foundMissing := false
+	foundTitle := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "template reference") {
+			if strings.Contains(d.Message, "missing") {
+				foundMissing = true
+			}
+			if strings.Contains(d.Message, "title") {
+				foundTitle = true
+			}
+		}
+	}
+	if !foundMissing {
+		t.Errorf("expected error for {post.missing}, got: %v", diags)
+	}
+	if foundTitle {
+		t.Errorf("should not error for valid {post.title}")
+	}
+}
+
+func TestCheckTableColumnRefs_Valid(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+				{Name: "phone", Type: parser.FieldPhone},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "users", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeTable, Name: "users", Columns: []parser.TableColumn{
+					{Field: "name"},
+					{Field: "email"},
+					{Field: "phone"},
+				}},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "table column") {
+			t.Errorf("unexpected table column error: %s", d.Message)
+		}
+	}
+}
+
+func TestCheckTableColumnRefs_InvalidColumn(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "users", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeTable, Name: "users", Columns: []parser.TableColumn{
+					{Field: "name"},
+					{Field: "email"},
+					{Field: "phone"},
+					{Field: "address"},
+				}},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	foundPhone := false
+	foundAddress := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "table column") {
+			if strings.Contains(d.Message, "'phone'") && strings.Contains(d.Message, "model 'user'") {
+				foundPhone = true
+			}
+			if strings.Contains(d.Message, "'address'") && strings.Contains(d.Message, "model 'user'") {
+				foundAddress = true
+			}
+		}
+	}
+	if !foundPhone {
+		t.Errorf("expected error for phone column, got: %v", diags)
+	}
+	if !foundAddress {
+		t.Errorf("expected error for address column, got: %v", diags)
+	}
+}
+
+func TestCheckTableColumnRefs_IdColumn(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "users", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeTable, Name: "users", Columns: []parser.TableColumn{
+					{Field: "id"},
+					{Field: "name"},
+				}},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "table column") {
+			t.Errorf("id is auto-generated and should be valid: %s", d.Message)
+		}
+	}
+}
+
+func TestCheckTableColumnRefs_ReferenceField(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{
+				Name: "user",
+				Fields: []parser.Field{
+					{Name: "name", Type: parser.FieldText},
+				},
+			},
+			{
+				Name: "post",
+				Fields: []parser.Field{
+					{Name: "title", Type: parser.FieldText},
+					{Name: "author", Type: parser.FieldReference, Reference: "user"},
+				},
+			},
+		},
+		Pages: []parser.Page{{
+			Path: "/posts",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "posts", SQL: "SELECT * FROM post"},
+				{Type: parser.NodeTable, Name: "posts", Columns: []parser.TableColumn{
+					{Field: "title"},
+					{Field: "author_id"},
+				}},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "table column") {
+			t.Errorf("author_id should be valid for reference field: %s", d.Message)
+		}
+	}
+}
+
+func TestQueryModelMap(t *testing.T) {
+	pages := []parser.Page{{
+		Path: "/users",
+		Body: []parser.Node{
+			{Type: parser.NodeQuery, Name: "users", SQL: "SELECT * FROM user"},
+			{Type: parser.NodeQuery, Name: "posts", SQL: "SELECT * FROM post WHERE author_id = :id"},
+		},
+	}}
+
+	m := queryModelMap(pages, nil, nil)
+	if m["users"] != "user" {
+		t.Errorf("expected users -> user, got %s", m["users"])
+	}
+	if m["posts"] != "post" {
+		t.Errorf("expected posts -> post, got %s", m["posts"])
+	}
+}

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -2,11 +2,15 @@ package analyzer
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/kilnx-org/kilnx/internal/parser"
 )
+
+// templateInterpolationRe matches {queryName.field} patterns in HTML content.
+var templateInterpolationRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)\}`)
 
 // ColumnInfo holds the inferred type for a single database column.
 type ColumnInfo struct {
@@ -448,5 +452,221 @@ func checkUpdateSetTypes(tokens []sqlToken, table string, schema *Schema, contex
 			}
 		}
 	}
+	return diags
+}
+
+// --- Template interpolation and component column checks ---
+
+// queryModelMap builds a mapping from query name to the primary table (model)
+// referenced in that query's SQL, by scanning all nodes in the given slices.
+func queryModelMap(pages []parser.Page, fragments []parser.Page, apis []parser.Page) map[string]string {
+	m := make(map[string]string)
+	collect := func(nodes []parser.Node) {
+		for _, n := range nodes {
+			if n.Type == parser.NodeQuery && n.Name != "" && n.SQL != "" {
+				tokens := tokenizeSQL(n.SQL)
+				refs := extractTableRefs(tokens)
+				if len(refs) > 0 {
+					m[n.Name] = refs[0].name
+				}
+			}
+		}
+	}
+	for _, p := range pages {
+		collect(p.Body)
+	}
+	for _, f := range fragments {
+		collect(f.Body)
+	}
+	for _, a := range apis {
+		collect(a.Body)
+	}
+	return m
+}
+
+// builtinFields are virtual fields available on any query result that should
+// not trigger a validation error (e.g. {users.count}).
+var builtinFields = map[string]bool{
+	"count": true,
+}
+
+// reservedInterpolations are top-level names that the runtime resolves
+// without requiring a matching query (e.g. {page.title}, {page.content}).
+var reservedInterpolations = map[string]bool{
+	"page":  true,
+	"kilnx": true,
+	"t":     true,
+}
+
+// checkTemplateInterpolations validates {queryName.field} references inside
+// HTML content of pages, fragments, and layouts against the schema.
+func checkTemplateInterpolations(app *parser.App, schema *Schema) []Diagnostic {
+	qMap := queryModelMap(app.Pages, app.Fragments, app.APIs)
+
+	var diags []Diagnostic
+
+	scanNodes := func(nodes []parser.Node, context string) {
+		// First pass: collect query names defined in this scope.
+		localQueries := make(map[string]string)
+		for _, n := range nodes {
+			if n.Type == parser.NodeQuery && n.Name != "" && n.SQL != "" {
+				tokens := tokenizeSQL(n.SQL)
+				refs := extractTableRefs(tokens)
+				if len(refs) > 0 {
+					localQueries[n.Name] = refs[0].name
+				}
+			}
+		}
+
+		for _, n := range nodes {
+			html := ""
+			switch n.Type {
+			case parser.NodeHTML:
+				html = n.HTMLContent
+			}
+			if html == "" {
+				continue
+			}
+			matches := templateInterpolationRe.FindAllStringSubmatch(html, -1)
+			for _, m := range matches {
+				queryName := m[1]
+				fieldName := m[2]
+
+				if reservedInterpolations[queryName] {
+					continue
+				}
+				if builtinFields[fieldName] {
+					continue
+				}
+
+				// Resolve the model for this query name.
+				modelName := ""
+				if mn, ok := localQueries[queryName]; ok {
+					modelName = mn
+				} else if mn, ok := qMap[queryName]; ok {
+					modelName = mn
+				}
+
+				if modelName == "" {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("template reference '{%s.%s}' uses unknown query '%s'", queryName, fieldName, queryName),
+						Context: context,
+					})
+					continue
+				}
+
+				info, ok := schema.Tables[modelName]
+				if !ok {
+					continue // model itself not found; already reported elsewhere
+				}
+				if _, colExists := info.Columns[fieldName]; !colExists {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("template reference '{%s.%s}': field '%s' does not exist in model '%s'", queryName, fieldName, fieldName, modelName),
+						Context: context,
+					})
+				}
+			}
+		}
+	}
+
+	for _, p := range app.Pages {
+		scanNodes(p.Body, fmt.Sprintf("page %s", p.Path))
+	}
+	for _, f := range app.Fragments {
+		scanNodes(f.Body, fmt.Sprintf("fragment %s", f.Path))
+	}
+
+	// Layouts use {page.title}, {page.content}, {nav}, {kilnx.css}, {kilnx.js}
+	// which are all reserved. We still scan for user query refs if any.
+	for _, l := range app.Layouts {
+		if l.HTMLContent == "" {
+			continue
+		}
+		matches := templateInterpolationRe.FindAllStringSubmatch(l.HTMLContent, -1)
+		for _, m := range matches {
+			queryName := m[1]
+			fieldName := m[2]
+
+			if reservedInterpolations[queryName] {
+				continue
+			}
+			if builtinFields[fieldName] {
+				continue
+			}
+
+			if _, ok := qMap[queryName]; !ok {
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("template reference '{%s.%s}' uses unknown query '%s'", queryName, fieldName, queryName),
+					Context: fmt.Sprintf("layout %s", l.Name),
+				})
+			}
+		}
+	}
+
+	return diags
+}
+
+// checkTableColumnRefs validates that columns declared in table components
+// exist in the model referenced by the table's query.
+func checkTableColumnRefs(app *parser.App, schema *Schema) []Diagnostic {
+	qMap := queryModelMap(app.Pages, app.Fragments, app.APIs)
+
+	var diags []Diagnostic
+
+	scanNodes := func(nodes []parser.Node, context string) {
+		// Collect local query-to-model mappings.
+		localQueries := make(map[string]string)
+		for _, n := range nodes {
+			if n.Type == parser.NodeQuery && n.Name != "" && n.SQL != "" {
+				tokens := tokenizeSQL(n.SQL)
+				refs := extractTableRefs(tokens)
+				if len(refs) > 0 {
+					localQueries[n.Name] = refs[0].name
+				}
+			}
+		}
+
+		for _, n := range nodes {
+			if n.Type != parser.NodeTable || n.Name == "" || len(n.Columns) == 0 {
+				continue
+			}
+
+			modelName := ""
+			if mn, ok := localQueries[n.Name]; ok {
+				modelName = mn
+			} else if mn, ok := qMap[n.Name]; ok {
+				modelName = mn
+			}
+			if modelName == "" {
+				continue // query not found; not our concern here
+			}
+
+			info, ok := schema.Tables[modelName]
+			if !ok {
+				continue
+			}
+
+			for _, col := range n.Columns {
+				if _, colExists := info.Columns[col.Field]; !colExists {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("table column '%s' does not exist in model '%s' (query '%s')", col.Field, modelName, n.Name),
+						Context: context,
+					})
+				}
+			}
+		}
+	}
+
+	for _, p := range app.Pages {
+		scanNodes(p.Body, fmt.Sprintf("page %s", p.Path))
+	}
+	for _, f := range app.Fragments {
+		scanNodes(f.Body, fmt.Sprintf("fragment %s", f.Path))
+	}
+
 	return diags
 }


### PR DESCRIPTION
## Summary

- Validate `{queryName.field}` template interpolations against schema
- Validate table component columns against query model
- Query-to-model mapping via `queryModelMap()`
- Skips reserved names (`page`, `kilnx`, `t`) and built-in fields (`count`)
- 12 new tests

Completes item #2 (type inference) to 100%.

## Test plan

- [x] 71/71 analyzer tests passing
- [x] Template interpolation with valid/invalid/unknown fields
- [x] Reserved names and built-in fields not flagged
- [x] Table column validation including id and reference fields