### PR TITLE
Complete query optimizer: dedup, JOIN pruning, stream hints

### DIFF
--- a/internal/optimizer/optimizer.go
+++ b/internal/optimizer/optimizer.go
@@ -13,19 +13,28 @@ var interpolateRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a
 // selectStarRe matches SELECT * or SELECT DISTINCT * at the start of a SQL query (case-insensitive).
 var selectStarRe = regexp.MustCompile(`(?i)^(SELECT\s+(?:DISTINCT\s+)?)\*(\s+FROM\s+)`)
 
+// joinRe matches JOIN clauses with optional type prefix and optional alias.
+// Groups: 1=join type (LEFT/RIGHT/etc, optional), 2=table name, 3=alias (optional)
+var joinRe = regexp.MustCompile(`(?i)\s+((?:LEFT|RIGHT|INNER|OUTER|CROSS|FULL)\s+)*JOIN\s+(\w+)(?:\s+(\w+))?\s+ON\s+`)
+
+// aggregateRe matches aggregate function calls in SQL.
+var aggregateRe = regexp.MustCompile(`(?i)\b(COUNT|SUM|AVG|MIN|MAX)\s*\(`)
+
 // Optimize performs domain-aware query optimization on a parsed Kilnx app.
-// It rewrites SELECT * queries to only select columns that are actually
-// consumed by components (table, list, card) and interpolations.
 func Optimize(app *parser.App) {
 	for i := range app.Pages {
 		optimizePage(&app.Pages[i])
+		deduplicateQueries(&app.Pages[i])
 	}
 	for i := range app.Fragments {
 		optimizePage(&app.Fragments[i])
+		deduplicateQueries(&app.Fragments[i])
 	}
 	for i := range app.APIs {
 		optimizePage(&app.APIs[i])
+		deduplicateQueries(&app.APIs[i])
 	}
+	markStreamCandidates(app)
 }
 
 func optimizePage(page *parser.Page) {
@@ -56,6 +65,12 @@ func optimizePage(page *parser.Page) {
 		rewritten := rewriteSelectStar(node.SQL, fields)
 		if rewritten != node.SQL {
 			page.Body[i].SQL = rewritten
+		}
+
+		// Prune JOINs where no columns from the joined table are used
+		pruned := pruneUnusedJoins(page.Body[i].SQL, fields)
+		if pruned != page.Body[i].SQL {
+			page.Body[i].SQL = pruned
 		}
 	}
 }
@@ -253,4 +268,165 @@ func countUnnamedQueries(nodes []parser.Node) int {
 		}
 	}
 	return count
+}
+
+// --- Query deduplication ---
+
+type queryEntry struct {
+	name  string
+	sql   string
+	index int // index in page.Body (-1 if nested)
+}
+
+// deduplicateQueries finds named queries with identical SQL on the same page
+// and removes duplicates, rewriting consumer references to point to the original.
+func deduplicateQueries(page *parser.Page) {
+	seen := make(map[string]string) // sql -> first query name
+
+	var entries []queryEntry
+	collectNamedQueries(page.Body, &entries, 0)
+
+	for _, e := range entries {
+		if e.sql == "" || e.name == "" {
+			continue
+		}
+		if original, exists := seen[e.sql]; exists {
+			// Duplicate found: rename consumers and clear the duplicate
+			renameConsumerRefs(page.Body, e.name, original)
+			if e.index >= 0 && e.index < len(page.Body) {
+				page.Body[e.index].SQL = ""
+			}
+		} else {
+			seen[e.sql] = e.name
+		}
+	}
+}
+
+func collectNamedQueries(nodes []parser.Node, entries *[]queryEntry, baseIndex int) {
+	for i, node := range nodes {
+		if node.Type == parser.NodeQuery && node.Name != "" && node.SQL != "" {
+			*entries = append(*entries, queryEntry{name: node.Name, sql: node.SQL, index: baseIndex + i})
+		}
+		if node.Type == parser.NodeOn {
+			collectNamedQueries(node.Children, entries, -1)
+		}
+	}
+}
+
+func renameConsumerRefs(nodes []parser.Node, oldName, newName string) {
+	for i := range nodes {
+		node := &nodes[i]
+		if node.Name == oldName {
+			switch node.Type {
+			case parser.NodeTable, parser.NodeList, parser.NodeSearch:
+				node.Name = newName
+			}
+		}
+		if node.Type == parser.NodeOn {
+			renameConsumerRefs(node.Children, oldName, newName)
+		}
+	}
+}
+
+// --- JOIN pruning ---
+
+// pruneUnusedJoins removes JOIN clauses when no columns from the joined table
+// are consumed by any component. Skips if any consumed field uses plain names
+// (no dot notation) since we can't determine which table owns the column.
+func pruneUnusedJoins(sql string, fields *fieldSet) string {
+	if fields == nil || len(fields.fields) == 0 {
+		return sql
+	}
+
+	// Check if all consumed fields use qualified (alias.column) notation
+	// If any field is unqualified, we can't safely prune
+	qualifiedPrefixes := make(map[string]bool)
+	for _, f := range fields.fields {
+		parts := strings.SplitN(f, ".", 2)
+		if len(parts) != 2 {
+			return sql // unqualified field, skip pruning
+		}
+		qualifiedPrefixes[strings.ToLower(parts[0])] = true
+	}
+
+	matches := joinRe.FindAllStringSubmatchIndex(sql, -1)
+	if len(matches) == 0 {
+		return sql
+	}
+
+	// Process matches in reverse order to preserve indices
+	result := sql
+	for i := len(matches) - 1; i >= 0; i-- {
+		m := matches[i]
+		// Group 2: table name
+		tableName := strings.ToLower(sql[m[4]:m[5]])
+		// Group 3: alias (may be empty)
+		alias := tableName
+		if m[6] >= 0 && m[7] >= 0 {
+			candidate := strings.ToLower(sql[m[6]:m[7]])
+			// Make sure the alias is not a SQL keyword
+			if candidate != "on" {
+				alias = candidate
+			}
+		}
+
+		// Check if the alias is used by any consumed field
+		if qualifiedPrefixes[alias] {
+			continue // columns from this JOIN are used, keep it
+		}
+
+		// Find the ON clause extent (match everything up to next JOIN or WHERE/ORDER/GROUP/LIMIT)
+		onEnd := findJoinClauseEnd(result, m[1]-3) // -3 to back up before "ON "
+		if onEnd > m[0] {
+			result = result[:m[0]] + result[onEnd:]
+		}
+	}
+
+	return result
+}
+
+func findJoinClauseEnd(sql string, start int) int {
+	upper := strings.ToUpper(sql)
+	// Find the extent of the ON condition
+	depth := 0
+	i := start
+	for i < len(sql) {
+		if sql[i] == '(' {
+			depth++
+		} else if sql[i] == ')' {
+			if depth > 0 {
+				depth--
+			}
+		}
+		if depth == 0 {
+			// Check for clause boundaries
+			remaining := upper[i:]
+			for _, kw := range []string{" JOIN ", " LEFT ", " RIGHT ", " INNER ", " OUTER ", " CROSS ", " FULL ", " WHERE ", " ORDER ", " GROUP ", " HAVING ", " LIMIT ", " UNION "} {
+				if strings.HasPrefix(remaining, kw) {
+					return i
+				}
+			}
+		}
+		i++
+	}
+	return len(sql)
+}
+
+// --- Stream materialization hints ---
+
+// markStreamCandidates marks stream queries with aggregate functions as
+// materialization candidates by prepending a hint comment.
+func markStreamCandidates(app *parser.App) {
+	for i := range app.Streams {
+		s := &app.Streams[i]
+		if s.SQL == "" || s.IntervalSecs <= 0 {
+			continue
+		}
+		if strings.HasPrefix(s.SQL, "/* kilnx:materialize-candidate */") {
+			continue // already marked
+		}
+		if aggregateRe.MatchString(s.SQL) {
+			s.SQL = "/* kilnx:materialize-candidate */ " + s.SQL
+		}
+	}
 }

--- a/internal/optimizer/optimizer_test.go
+++ b/internal/optimizer/optimizer_test.go
@@ -1,6 +1,7 @@
 package optimizer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/kilnx-org/kilnx/internal/parser"
@@ -554,6 +555,171 @@ func TestRewrite_NodeOnChildren(t *testing.T) {
 	want := "SELECT name, email FROM user WHERE id = 1"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// --- Deduplication tests ---
+
+func TestDeduplicate_IdenticalQueries(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "q1", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeQuery, Name: "q2", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeTable, Name: "q2", Columns: []parser.TableColumn{{Field: "name"}}},
+			},
+		}},
+	}
+	deduplicateQueries(&app.Pages[0])
+	if app.Pages[0].Body[1].SQL != "" {
+		t.Errorf("duplicate query should have SQL cleared, got %q", app.Pages[0].Body[1].SQL)
+	}
+	if app.Pages[0].Body[2].Name != "q1" {
+		t.Errorf("consumer should be renamed to q1, got %q", app.Pages[0].Body[2].Name)
+	}
+}
+
+func TestDeduplicate_DifferentQueries(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "q1", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeQuery, Name: "q2", SQL: "SELECT * FROM post"},
+			},
+		}},
+	}
+	deduplicateQueries(&app.Pages[0])
+	if app.Pages[0].Body[0].SQL == "" || app.Pages[0].Body[1].SQL == "" {
+		t.Error("different queries should not be deduplicated")
+	}
+}
+
+func TestDeduplicate_ConsumerInOnBlock(t *testing.T) {
+	app := &parser.App{
+		Pages: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "q1", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeQuery, Name: "q2", SQL: "SELECT * FROM user"},
+				{Type: parser.NodeOn, Children: []parser.Node{
+					{Type: parser.NodeTable, Name: "q2", Columns: []parser.TableColumn{{Field: "name"}}},
+				}},
+			},
+		}},
+	}
+	deduplicateQueries(&app.Pages[0])
+	if app.Pages[0].Body[2].Children[0].Name != "q1" {
+		t.Errorf("consumer inside NodeOn should be renamed, got %q", app.Pages[0].Body[2].Children[0].Name)
+	}
+}
+
+// --- JOIN pruning tests ---
+
+func TestPruneJoin_UnusedJoinRemoved(t *testing.T) {
+	sql := "SELECT p.title FROM post p JOIN user u ON p.author_id = u.id"
+	fields := newFieldSet()
+	fields.add("p.title")
+	got := pruneUnusedJoins(sql, fields)
+	if strings.Contains(got, "JOIN") {
+		t.Errorf("unused JOIN should be pruned, got %q", got)
+	}
+}
+
+func TestPruneJoin_UsedJoinKept(t *testing.T) {
+	sql := "SELECT p.title, u.name FROM post p JOIN user u ON p.author_id = u.id"
+	fields := newFieldSet()
+	fields.add("p.title")
+	fields.add("u.name")
+	got := pruneUnusedJoins(sql, fields)
+	if !strings.Contains(got, "JOIN") {
+		t.Errorf("used JOIN should be kept, got %q", got)
+	}
+}
+
+func TestPruneJoin_UnqualifiedFieldSkips(t *testing.T) {
+	sql := "SELECT p.title FROM post p JOIN user u ON p.author_id = u.id"
+	fields := newFieldSet()
+	fields.add("title") // unqualified, can't determine table
+	got := pruneUnusedJoins(sql, fields)
+	if got != sql {
+		t.Errorf("should not prune with unqualified fields, got %q", got)
+	}
+}
+
+func TestPruneJoin_WithoutAlias(t *testing.T) {
+	sql := "SELECT post.title FROM post JOIN user ON post.author_id = user.id"
+	fields := newFieldSet()
+	fields.add("post.title")
+	got := pruneUnusedJoins(sql, fields)
+	if strings.Contains(strings.ToLower(got), "join user") {
+		t.Errorf("JOIN without alias should still be prunable, got %q", got)
+	}
+}
+
+// --- Stream materialization tests ---
+
+func TestMarkStream_AggregateMarked(t *testing.T) {
+	app := &parser.App{
+		Streams: []parser.Stream{
+			{Path: "/stream/stats", SQL: "SELECT count(*) FROM user", IntervalSecs: 5},
+		},
+	}
+	markStreamCandidates(app)
+	if !strings.HasPrefix(app.Streams[0].SQL, "/* kilnx:materialize-candidate */") {
+		t.Errorf("aggregate stream should be marked, got %q", app.Streams[0].SQL)
+	}
+}
+
+func TestMarkStream_NonAggregateNotMarked(t *testing.T) {
+	app := &parser.App{
+		Streams: []parser.Stream{
+			{Path: "/stream/users", SQL: "SELECT * FROM user", IntervalSecs: 5},
+		},
+	}
+	markStreamCandidates(app)
+	if strings.Contains(app.Streams[0].SQL, "materialize") {
+		t.Errorf("non-aggregate stream should not be marked, got %q", app.Streams[0].SQL)
+	}
+}
+
+func TestMarkStream_NoInterval(t *testing.T) {
+	app := &parser.App{
+		Streams: []parser.Stream{
+			{Path: "/stream/stats", SQL: "SELECT count(*) FROM user", IntervalSecs: 0},
+		},
+	}
+	markStreamCandidates(app)
+	if strings.Contains(app.Streams[0].SQL, "materialize") {
+		t.Errorf("stream without interval should not be marked, got %q", app.Streams[0].SQL)
+	}
+}
+
+func TestMarkStream_AlreadyMarked(t *testing.T) {
+	app := &parser.App{
+		Streams: []parser.Stream{
+			{Path: "/stream/stats", SQL: "/* kilnx:materialize-candidate */ SELECT count(*) FROM user", IntervalSecs: 5},
+		},
+	}
+	markStreamCandidates(app)
+	count := strings.Count(app.Streams[0].SQL, "materialize-candidate")
+	if count != 1 {
+		t.Errorf("should not double-mark, got %d occurrences", count)
+	}
+}
+
+func TestMarkStream_SumAvgMinMax(t *testing.T) {
+	for _, fn := range []string{"SUM", "AVG", "MIN", "MAX"} {
+		app := &parser.App{
+			Streams: []parser.Stream{
+				{Path: "/s", SQL: "SELECT " + fn + "(value) FROM deal", IntervalSecs: 10},
+			},
+		}
+		markStreamCandidates(app)
+		if !strings.Contains(app.Streams[0].SQL, "materialize") {
+			t.Errorf("%s stream should be marked", fn)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the three missing optimizer passes (PR #11 merge was incomplete).

- **Query deduplication**: identical named queries reuse first result, consumers renamed recursively (including NodeOn blocks)
- **JOIN pruning**: removes unused JOINs, supports with/without aliases, safe skip on unqualified fields
- **Stream materialization hints**: marks aggregate stream queries for future optimization

12 new tests.

## Test plan

- [x] All optimizer tests passing
- [x] All analyzer tests passing
- [x] `go test ./...` clean