### PR TITLE
fix: preserve # characters inside html blocks

### DIFF
--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -71,13 +71,46 @@ func IsFieldConstraint(s string) bool {
 // StripComments removes # comments from source code.
 // Full-line comments (lines starting with #) are replaced with blank lines to preserve line numbers.
 // Inline comments (# after code) are stripped, respecting quoted strings.
+// Lines inside html blocks are never stripped (they may contain CSS hex colors like #fff).
 func StripComments(source string) string {
 	lines := strings.Split(source, "\n")
+	inHTML := false
+	htmlIndent := 0
+
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue
 		}
+
+		indent := 0
+		for _, ch := range line {
+			if ch == ' ' {
+				indent++
+			} else if ch == '\t' {
+				indent += 2
+			} else {
+				break
+			}
+		}
+
+		// Detect entering an html block: a line whose trimmed content is "html"
+		if !inHTML && trimmed == "html" {
+			inHTML = true
+			htmlIndent = indent
+			continue
+		}
+
+		// Inside html block: skip comment stripping until dedent
+		if inHTML {
+			if indent <= htmlIndent && trimmed != "" {
+				inHTML = false
+				// Fall through to normal comment processing for this line
+			} else {
+				continue
+			}
+		}
+
 		if trimmed[0] == '#' {
 			lines[i] = ""
 			continue

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -501,3 +501,66 @@ func TestCommentedLineNotTokenized(t *testing.T) {
 		}
 	}
 }
+
+func TestStripCommentsPreservesHexColorsInHTML(t *testing.T) {
+	source := `layout main
+  html
+    <style>
+      body { background: #09090b; color: #fafafa; }
+      a { color: #ff6e40; }
+    </style>
+    <div class="test">#not-a-comment</div>`
+
+	result := StripComments(source)
+
+	if !strings.Contains(result, "#09090b") {
+		t.Error("hex color #09090b inside html block was stripped")
+	}
+	if !strings.Contains(result, "#fafafa") {
+		t.Error("hex color #fafafa inside html block was stripped")
+	}
+	if !strings.Contains(result, "#ff6e40") {
+		t.Error("hex color #ff6e40 inside html block was stripped")
+	}
+	if !strings.Contains(result, "#not-a-comment") {
+		t.Error("text with # inside html block was stripped")
+	}
+}
+
+func TestStripCommentsStillWorksOutsideHTML(t *testing.T) {
+	source := `page /
+  html
+    <style>body { color: #fafafa; }</style>
+
+# this is a comment
+page /about
+  "About" # inline comment`
+
+	result := StripComments(source)
+
+	if !strings.Contains(result, "#fafafa") {
+		t.Error("hex color inside html block was stripped")
+	}
+	if strings.Contains(result, "this is a comment") {
+		t.Error("full-line comment outside html should be stripped")
+	}
+	if strings.Contains(result, "inline comment") {
+		t.Error("inline comment outside html should be stripped")
+	}
+}
+
+func TestStripCommentsNestedHTMLBlock(t *testing.T) {
+	source := `page /test
+  html
+    <div>#hash-in-html</div>
+page /other # comment here`
+
+	result := StripComments(source)
+
+	if !strings.Contains(result, "#hash-in-html") {
+		t.Error("hash inside html block was stripped")
+	}
+	if strings.Contains(result, "comment here") {
+		t.Error("inline comment after html block should be stripped")
+	}
+}


### PR DESCRIPTION
Closes #32

## Problem

`StripComments` treats `#` as a comment marker everywhere, including inside `html` blocks. CSS hex colors like `#09090b` get stripped, breaking inline styles.

## Fix

`StripComments` now tracks whether it is inside an `html` block by detecting lines where trimmed content is `html` and monitoring indentation. Lines inside html blocks are never stripped.

## Tests

- `TestStripCommentsPreservesHexColorsInHTML`: hex colors in `<style>` blocks survive
- `TestStripCommentsStillWorksOutsideHTML`: comments outside html are still stripped
- `TestStripCommentsNestedHTMLBlock`: html block ends correctly, comments after it are stripped