### PR TITLE
feat: support queries in layouts

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -121,6 +121,7 @@ type Permission struct {
 type Layout struct {
 	Name        string
 	HTMLContent string // raw HTML with {page.title}, {page.content}, {nav}
+	Queries     []Node // queries to execute when rendering the layout
 }
 
 type AuthConfig struct {
@@ -1328,6 +1329,14 @@ func (p *parserState) parseLayout() Layout {
 			if (p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword) && p.current().Value == "html" {
 				node := p.parseHTMLNode()
 				layout.HTMLContent = node.HTMLContent
+				continue
+			}
+			// Parse query nodes inside layout
+			if p.current().Type == lexer.TokenKeyword && p.current().Value == "query" {
+				node, err := p.parseQueryNode()
+				if err == nil {
+					layout.Queries = append(layout.Queries, node)
+				}
 				continue
 			}
 			p.advance()

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -923,3 +923,38 @@ func TestFragmentRequiresAuth(t *testing.T) {
 		t.Error("fragment should require auth")
 	}
 }
+
+func TestLayoutWithQueries(t *testing.T) {
+	src := `layout docs
+  query nav_items: SELECT slug, title FROM doc ORDER BY sort_order
+  html
+    <html>
+    <body>
+      {{each nav_items}}
+      <a href="/docs/{slug}">{title}</a>
+      {{end}}
+      {page.content}
+    </body>
+    </html>
+
+page /test layout docs
+  "Hello"`
+
+	app := parse(t, src)
+	if len(app.Layouts) != 1 {
+		t.Fatalf("expected 1 layout, got %d", len(app.Layouts))
+	}
+	layout := app.Layouts[0]
+	if layout.Name != "docs" {
+		t.Errorf("expected layout name 'docs', got '%s'", layout.Name)
+	}
+	if len(layout.Queries) != 1 {
+		t.Fatalf("expected 1 query in layout, got %d", len(layout.Queries))
+	}
+	if layout.Queries[0].Name != "nav_items" {
+		t.Errorf("expected query name 'nav_items', got '%s'", layout.Queries[0].Name)
+	}
+	if layout.HTMLContent == "" {
+		t.Error("layout HTML content should not be empty")
+	}
+}

--- a/internal/runtime/layout.go
+++ b/internal/runtime/layout.go
@@ -26,7 +26,7 @@ func renderDefaultLayout(title, nav, content string) string {
 `, html.EscapeString(title), nav, content)
 }
 
-func renderWithLayout(layout parser.Layout, title, nav, content string) string {
+func renderWithLayout(layout parser.Layout, title, nav, content string, layoutCtx *renderContext) string {
 	result := layout.HTMLContent
 
 	result = strings.ReplaceAll(result, "{page.title}", html.EscapeString(title))
@@ -34,6 +34,11 @@ func renderWithLayout(layout parser.Layout, title, nav, content string) string {
 	result = strings.ReplaceAll(result, "{nav}", nav)
 	result = strings.ReplaceAll(result, "{kilnx.js}", `<script src="/_kilnx/htmx.min.js"></script>
 <script src="/_kilnx/sse.js"></script>`)
+
+	// Render layout queries ({{each}}, {field}, {{if}})
+	if layoutCtx != nil && len(layoutCtx.queries) > 0 {
+		result = renderHTML(result, layoutCtx)
+	}
 
 	return result
 }

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -406,7 +406,27 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 	if p.Layout != "" {
 		for _, layout := range app.Layouts {
 			if layout.Name == p.Layout {
-				return renderWithLayout(layout, title, nav, content)
+				var layoutCtx *renderContext
+				if len(layout.Queries) > 0 && s.db != nil {
+					layoutCtx = &renderContext{
+						queries:  make(map[string][]database.Row),
+						paginate: make(map[string]PaginateInfo),
+					}
+					for _, q := range layout.Queries {
+						if q.SQL == "" {
+							continue
+						}
+						name := q.Name
+						if name == "" {
+							name = "_last"
+						}
+						rows, err := s.db.QueryRows(q.SQL)
+						if err == nil {
+							layoutCtx.queries[name] = rows
+						}
+					}
+				}
+				return renderWithLayout(layout, title, nav, content, layoutCtx)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #34

## What
Layouts can now declare `query` nodes that execute at render time. Results are available for `{{each}}` and `{field}` interpolation in the layout HTML.

## Why
Discovered during dogfood of the docs site. Shared UI elements like sidebar navigation depend on data (list of doc pages from SQLite). Without layout queries, these had to be hardcoded in HTML.

## Example
```kilnx
layout docs
  query nav: SELECT slug, title FROM doc ORDER BY sort_order
  html
    <aside>
      {{each nav}}<a href="/docs/{slug}">{title}</a>{{end}}
    </aside>
    <main>{page.content}</main>
```

## Changes
- `Layout` struct gains `Queries []Node` field (parser)
- `parseLayout` handles `query` keyword inside layout blocks (parser)
- `renderWithLayout` accepts `layoutCtx` and renders queries via `renderHTML` (runtime)
- `renderPage` executes layout queries before rendering (runtime)

## Test plan

- [x] `go test -race ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -l .` returns nothing
- [x] `kilnx check examples/blog.kilnx` passes
- [x] `kilnx test examples/blog.kilnx` passes
- [x] New test: `TestLayoutWithQueries` validates parsing