### PR TITLE
Phase 1: credibility features, runtime fixes, examples, and E2E tests

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -35,10 +35,10 @@ func main() {
 		}
 	case "migrate":
 		if len(os.Args) < 3 {
-			fmt.Println("Usage: kilnx migrate <file.kilnx>")
+			fmt.Println("Usage: kilnx migrate <file.kilnx> [--dry-run|--status]")
 			os.Exit(1)
 		}
-		if err := cmdMigrate(os.Args[2]); err != nil {
+		if err := cmdMigrate(os.Args[2], os.Args[3:]); err != nil {
 			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -166,7 +166,18 @@ func cmdRun(filename string) error {
 	return runtime.WatchAndServe(filename, db, port)
 }
 
-func cmdMigrate(filename string) error {
+func cmdMigrate(filename string, flags []string) error {
+	dryRun := false
+	status := false
+	for _, f := range flags {
+		switch f {
+		case "--dry-run":
+			dryRun = true
+		case "--status":
+			status = true
+		}
+	}
+
 	app, err := loadApp(filename)
 	if err != nil {
 		return err
@@ -187,6 +198,58 @@ func cmdMigrate(filename string) error {
 	}
 	defer db.Close()
 
+	if err := db.MigrateInternal(); err != nil {
+		return err
+	}
+
+	if status {
+		// Show migration history
+		history, err := db.MigrationHistory()
+		if err != nil {
+			return err
+		}
+		if len(history) == 0 {
+			fmt.Println("No migration history.")
+		} else {
+			fmt.Printf("Migration history (%d entries):\n", len(history))
+			for _, r := range history {
+				fmt.Printf("  #%d  %s  hash=%s\n", r.ID, r.AppliedAt, r.SchemaHash)
+			}
+		}
+
+		// Show pending changes
+		pending, err := db.PlanMigration(app.Models)
+		if err != nil {
+			return err
+		}
+		fmt.Println()
+		if len(pending) == 0 {
+			fmt.Println("Database is up to date.")
+		} else {
+			fmt.Printf("Pending changes (%d):\n", len(pending))
+			for _, stmt := range pending {
+				printMigrationStmt(stmt)
+			}
+		}
+		return nil
+	}
+
+	if dryRun {
+		stmts, err := db.PlanMigration(app.Models)
+		if err != nil {
+			return err
+		}
+		if len(stmts) == 0 {
+			fmt.Println("Nothing to migrate. Database is up to date.")
+			return nil
+		}
+		fmt.Printf("Would apply %d migration(s):\n", len(stmts))
+		for _, stmt := range stmts {
+			fmt.Printf("\n%s;\n", stmt)
+		}
+		return nil
+	}
+
 	stmts, err := db.Migrate(app.Models)
 	if err != nil {
 		return err
@@ -199,23 +262,26 @@ func cmdMigrate(filename string) error {
 
 	fmt.Printf("Applied %d migration(s):\n", len(stmts))
 	for _, stmt := range stmts {
-		// Print a short summary of each statement
-		if strings.HasPrefix(stmt, "CREATE TABLE") {
-			table := strings.Fields(stmt)[2]
-			fmt.Printf("  + Created table '%s'\n", table)
-		} else if strings.HasPrefix(stmt, "ALTER TABLE") {
-			parts := strings.Fields(stmt)
-			if len(parts) > 5 {
-				fmt.Printf("  + Added column '%s' to '%s'\n", parts[5], parts[2])
-			} else {
-				fmt.Printf("  %s\n", stmt)
-			}
-		} else {
-			fmt.Printf("  %s\n", stmt)
-		}
+		printMigrationStmt(stmt)
 	}
 
 	return nil
+}
+
+func printMigrationStmt(stmt string) {
+	if strings.HasPrefix(stmt, "CREATE TABLE") {
+		table := strings.Fields(stmt)[2]
+		fmt.Printf("  + Created table '%s'\n", table)
+	} else if strings.HasPrefix(stmt, "ALTER TABLE") {
+		parts := strings.Fields(stmt)
+		if len(parts) > 5 {
+			fmt.Printf("  + Added column '%s' to '%s'\n", parts[5], parts[2])
+		} else {
+			fmt.Printf("  %s\n", stmt)
+		}
+	} else {
+		fmt.Printf("  %s\n", stmt)
+	}
 }
 
 func cmdTest(filename string) error {
@@ -328,6 +394,8 @@ func printUsage() {
 	fmt.Println("  check <file.kilnx>      Run static analysis")
 	fmt.Println("  build <file.kilnx> [-o] Compile to standalone binary")
 	fmt.Println("  migrate <file.kilnx>    Apply database migrations")
+	fmt.Println("          --dry-run       Show SQL without applying")
+	fmt.Println("          --status        Show migration history and pending changes")
 	fmt.Println("  test <file.kilnx>       Run declarative tests")
 	fmt.Println("  lsp                     Start Language Server Protocol server")
 	fmt.Println("  version                 Print version")

--- a/examples/chat.kilnx
+++ b/examples/chat.kilnx
@@ -1,0 +1,380 @@
+# Kilnx Chat
+# A full-featured chat app demonstrating: auth, WebSocket, SSE, rate limit,
+# search, delete, profile, fragments, CSRF, Tailwind CSS
+
+config
+  database: env DATABASE_URL default "sqlite://chat.db"
+  port: env PORT default 8080
+  secret: env SECRET_KEY default "dev-secret"
+  name: Kilnx Chat
+
+model user
+  name: text required min 2 max 50
+  email: email unique
+  password: password required
+  role: option [admin, member] default member
+  created: timestamp auto
+
+model room
+  name: text required unique
+  description: text
+  creator: user required
+  created: timestamp auto
+
+model message
+  body: text required
+  author: user required
+  room: room required
+  created: timestamp auto
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /
+
+# Rate limiting
+limit /chat/*/send
+  requests: 30 per minute per user
+  message: "Slow down, you're sending too many messages."
+
+limit /rooms/create
+  requests: 5 per minute per user
+
+layout chat
+  html
+    <!DOCTYPE html>
+    <html lang="en" class="h-full">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>{page.title} - Kilnx Chat</title>
+      <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 470 469'><g transform='translate(0,470) scale(0.1,-0.1)' fill='%23e64a19'><path d='M360 2850 l0-1850 111 0 111 0 240 233c132 127 256 245 274 260l34 28 0 530 0 529 1220 0 1220 0 0-522-1-523 273-267 273-267 113-1 112 0 0 1850 0 1850-1990 0-1990 0 0-1850z M1410 1877l0-473-349-347-349-347-356 0-356 0 2-352c2-194 6-352 11-350 4 1 333 2 732 2l725 0 0 288 0 288 116 215c64 117 156 288 205 379l89 164 0 503 0 503-235 0-235 0 0-473z M2120 2243c0-60-1-322-2-583l-2-475-178-374-178-374 0-213 0-214 590 0 590 0 0 214 0 214-111 233c-61 129-139 290-173 359l-61 125-5 595-5 595-232 3-233 2 0-107z M2820 1848l0-502 92-170c51-94 143-265 205-381l113-210 0-287 0-288 735 0 735 0 0 350 0 350-355 0-355 0-350 346-350 347 0 473 0 474-235 0-235 0 0-502z'/></g></svg>">
+      {kilnx.js}
+      <script src="https://cdn.tailwindcss.com"></script>
+      <style>
+        @keyframes fadeUp { from { opacity:0; transform:translateY(6px) } to { opacity:1; transform:translateY(0) } }
+        .fade-up { animation: fadeUp .25s ease both }
+        ::-webkit-scrollbar { width: 6px }
+        ::-webkit-scrollbar-track { background: transparent }
+        ::-webkit-scrollbar-thumb { background: #3f3f46; border-radius: 3px }
+        .kilnx-topbar { position: sticky; top: 0; z-index: 50; display: flex; align-items: center; justify-content: space-between; padding: 0 1.5rem; height: 3.5rem; background: rgba(9,9,11,0.85); backdrop-filter: blur(16px); border-bottom: 1px solid rgba(63,63,70,0.4); }
+        .kilnx-topbar-left { display: flex; align-items: center; gap: 1.25rem; }
+        .kilnx-app-name { font-size: 1rem; font-weight: 700; color: #ff6e40; letter-spacing: -0.02em; }
+        .kilnx-nav { display: flex; align-items: center; gap: 0.25rem; }
+        .kilnx-nav a { padding: 0.375rem 0.75rem; font-size: 0.875rem; font-weight: 500; color: #a1a1aa; text-decoration: none; border-radius: 0.375rem; transition: all 0.15s; }
+        .kilnx-nav a:hover { color: #fff; background: rgba(63,63,70,0.5); }
+        .kilnx-nav a.active { color: #ff6e40; background: rgba(230,74,25,0.1); }
+        .kilnx-topbar-right { display: flex; align-items: center; gap: 0.75rem; font-size: 0.85rem; color: #71717a; }
+        .kilnx-topbar-right .kilnx-user { color: #a1a1aa; }
+        .kilnx-topbar-right form { display: inline; margin: 0; }
+        .kilnx-logout { background: rgba(63,63,70,0.4); color: #a1a1aa; border: none; padding: 0.35rem 0.75rem; border-radius: 0.375rem; font-size: 0.8rem; font-weight: 500; cursor: pointer; font-family: inherit; transition: all 0.15s; }
+        .kilnx-logout:hover { background: rgba(63,63,70,0.7); color: #fff; }
+      </style>
+    </head>
+    <body class="h-full bg-zinc-950 text-zinc-100 font-[system-ui,-apple-system,sans-serif] antialiased">
+      <div class="h-full flex flex-col">
+        {nav}
+        <main class="flex-1 flex flex-col overflow-hidden">
+          {page.content}
+        </main>
+      </div>
+      <script>
+        // Auto-scroll chat to bottom
+        var chat = document.getElementById('chat-messages');
+        if (chat) chat.scrollTop = chat.scrollHeight;
+        // Confirm deletes
+        document.querySelectorAll('[data-confirm]').forEach(function(el) {
+          el.addEventListener('submit', function(e) {
+            if (!confirm(el.dataset.confirm)) e.preventDefault();
+          });
+        });
+      </script>
+    </body>
+    </html>
+
+# ============================================================
+# PAGES
+# ============================================================
+
+# Room list (home)
+page / requires auth layout chat title "Rooms"
+  query rooms: SELECT r.id, r.name, r.description, r.created,
+               u.name as creator,
+               COUNT(DISTINCT m.id) as msg_count,
+               (SELECT body FROM message WHERE room_id = r.id ORDER BY created DESC LIMIT 1) as last_msg
+               FROM room r
+               JOIN user u ON u.id = r.creator_id
+               LEFT JOIN message m ON m.room_id = r.id
+               GROUP BY r.id
+               ORDER BY r.created DESC
+  html
+    <div class="max-w-2xl mx-auto w-full px-4 sm:px-6 py-10">
+      <div class="flex items-center justify-between mb-8">
+        <h1 class="text-2xl font-bold tracking-tight text-white">Rooms</h1>
+        <a href="/profile" class="text-sm text-zinc-400 hover:text-orange-400 transition">My Profile</a>
+      </div>
+      <form method="POST" action="/rooms/create" class="flex gap-3 mb-10">
+        <input type="hidden" name="_csrf" value="{csrf}">
+        <input type="text" name="name" placeholder="New room name..." required minlength="2" class="flex-1 px-4 py-2.5 bg-zinc-900 border border-zinc-700/60 rounded-lg text-sm text-zinc-100 placeholder-zinc-500 outline-none focus:border-orange-500 focus:ring-2 focus:ring-orange-500/20 transition">
+        <button type="submit" class="px-5 py-2.5 bg-orange-700 hover:bg-orange-600 text-white text-sm font-semibold rounded-lg transition-all hover:shadow-lg hover:shadow-orange-700/20 active:scale-[0.97] shrink-0">Create</button>
+      </form>
+      <div class="space-y-2">
+        {{each rooms}}
+        <a href="/chat/{id}" class="fade-up group block p-4 bg-zinc-900/50 border border-zinc-800/50 rounded-xl hover:bg-zinc-900 hover:border-zinc-700/60 transition-all hover:-translate-y-px hover:shadow-lg hover:shadow-black/30">
+          <div class="flex items-center justify-between mb-1">
+            <div class="flex items-center gap-3">
+              <span class="flex items-center justify-center w-9 h-9 rounded-lg bg-orange-500/10 text-orange-400 font-bold text-sm shrink-0">#</span>
+              <span class="font-semibold text-zinc-100 group-hover:text-white transition">{name}</span>
+            </div>
+            <span class="text-xs text-zinc-500 bg-zinc-800/80 px-2.5 py-1 rounded-full shrink-0">{msg_count} msgs</span>
+          </div>
+          <div class="ml-12 text-xs text-zinc-500 truncate">
+            {{if last_msg}}{last_msg|truncate:80}{{else}}No messages yet{{end}}
+          </div>
+        </a>
+        {{else}}
+        <div class="text-center py-20">
+          <div class="text-5xl mb-4 opacity-60">💬</div>
+          <p class="text-zinc-500 mb-1">No rooms yet.</p>
+          <p class="text-zinc-600 text-sm">Create your first room above to get started.</p>
+        </div>
+        {{end}}
+      </div>
+    </div>
+
+# Chat room
+page /chat/:id requires auth layout chat
+  query room: SELECT r.id, r.name, r.description, r.created, r.creator_id,
+              u.name as creator
+              FROM room r
+              JOIN user u ON u.id = r.creator_id
+              WHERE r.id = :id
+  query messages: SELECT m.id, m.body, m.author_id, u.name as author, m.created
+                  FROM message m
+                  JOIN user u ON u.id = m.author_id
+                  WHERE m.room_id = :id
+                  ORDER BY m.created ASC
+                  paginate 100
+  html
+    <div class="flex flex-col flex-1 overflow-hidden max-w-3xl mx-auto w-full">
+      <div class="flex items-center justify-between px-4 sm:px-6 py-3 border-b border-zinc-800/50 shrink-0">
+        <div class="flex items-center gap-3">
+          <a href="/" class="text-zinc-500 hover:text-zinc-300 transition" title="Back to rooms">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+          </a>
+          <span class="text-orange-400 font-bold">#</span>
+          <div>
+            <h1 class="text-base font-semibold text-white">{room.name}</h1>
+            <p class="text-[11px] text-zinc-500">Created by {room.creator} {room.created|timeago}</p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <form method="POST" action="/rooms/{room.id}/delete" data-confirm="Delete this room and all messages?" class="inline">
+            <input type="hidden" name="_csrf" value="{csrf}">
+            <button type="submit" class="p-1.5 text-zinc-600 hover:text-red-400 transition rounded" title="Delete room">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+            </button>
+          </form>
+        </div>
+      </div>
+      <div id="chat-messages" class="flex-1 overflow-y-auto px-4 sm:px-6 py-4 space-y-0.5" hx-get="/chat/{room.id}/messages" hx-trigger="every 3s" hx-swap="innerHTML transition:false">
+        {{each messages}}
+        <div class="fade-up group flex gap-3 py-2 px-3 -mx-3 rounded-lg hover:bg-zinc-900/60 transition relative">
+          <div class="shrink-0 w-8 h-8 rounded-full bg-orange-500/15 flex items-center justify-center text-orange-400 text-xs font-bold mt-0.5">{author|truncate:1}</div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-baseline gap-2">
+              <span class="text-sm font-semibold text-orange-300">{author}</span>
+              <time class="text-[11px] text-zinc-600 group-hover:text-zinc-500 transition">{created|timeago}</time>
+            </div>
+            <p class="text-sm text-zinc-300 break-words leading-relaxed">{body}</p>
+          </div>
+          <form method="POST" action="/messages/{id}/delete" class="hidden group-hover:flex items-start pt-1" data-confirm="Delete this message?">
+            <input type="hidden" name="_csrf" value="{csrf}">
+            <button type="submit" class="p-1 text-zinc-700 hover:text-red-400 transition rounded" title="Delete">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+          </form>
+        </div>
+        {{else}}
+        <div class="flex items-center justify-center h-full">
+          <div class="text-center py-20">
+            <div class="text-5xl mb-4 opacity-60">👋</div>
+            <p class="text-zinc-400 mb-1">Welcome to #{room.name}</p>
+            <p class="text-zinc-600 text-sm">This is the beginning of the conversation.</p>
+          </div>
+        </div>
+        {{end}}
+      </div>
+      <div class="shrink-0 px-4 sm:px-6 py-3 border-t border-zinc-800/50 bg-zinc-950">
+        <form method="POST" action="/chat/{room.id}/send" class="flex gap-3">
+          <input type="hidden" name="_csrf" value="{csrf}">
+          <input type="text" name="body" placeholder="Type a message..." required autofocus class="flex-1 px-4 py-2.5 bg-zinc-900 border border-zinc-700/60 rounded-lg text-sm text-zinc-100 placeholder-zinc-500 outline-none focus:border-orange-500 focus:ring-2 focus:ring-orange-500/20 transition">
+          <button type="submit" class="px-4 py-2.5 bg-orange-700 hover:bg-orange-600 text-white rounded-lg transition-all hover:shadow-lg hover:shadow-orange-700/20 active:scale-[0.97] shrink-0">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+          </button>
+        </form>
+      </div>
+    </div>
+
+# Messages fragment for htmx polling
+fragment /chat/:id/messages
+  query messages: SELECT m.id, m.body, m.author_id, u.name as author, m.created
+                  FROM message m
+                  JOIN user u ON u.id = m.author_id
+                  WHERE m.room_id = :id
+                  ORDER BY m.created ASC
+                  paginate 100
+  html
+    {{each messages}}
+    <div class="group flex gap-3 py-2 px-3 -mx-3 rounded-lg hover:bg-zinc-900/60 transition relative">
+      <div class="shrink-0 w-8 h-8 rounded-full bg-orange-500/15 flex items-center justify-center text-orange-400 text-xs font-bold mt-0.5">{author|truncate:1}</div>
+      <div class="min-w-0 flex-1">
+        <div class="flex items-baseline gap-2">
+          <span class="text-sm font-semibold text-orange-300">{author}</span>
+          <time class="text-[11px] text-zinc-600 group-hover:text-zinc-500 transition">{created|timeago}</time>
+        </div>
+        <p class="text-sm text-zinc-300 break-words leading-relaxed">{body}</p>
+      </div>
+      <form method="POST" action="/messages/{id}/delete" class="hidden group-hover:flex items-start pt-1" data-confirm="Delete this message?">
+        <input type="hidden" name="_csrf" value="{csrf}">
+        <button type="submit" class="p-1 text-zinc-700 hover:text-red-400 transition rounded" title="Delete">
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+        </button>
+      </form>
+    </div>
+    {{else}}
+    <div class="flex items-center justify-center h-full">
+      <div class="text-center py-20">
+        <div class="text-5xl mb-4 opacity-60">👋</div>
+        <p class="text-zinc-400">No messages yet.</p>
+      </div>
+    </div>
+    {{end}}
+
+# Profile page
+page /profile requires auth layout chat title "Profile"
+  query me: SELECT name, email FROM user WHERE id = :current_user.id
+  query stats: SELECT
+               (SELECT COUNT(*) FROM message WHERE author_id = :current_user.id) as msg_count,
+               (SELECT COUNT(DISTINCT room_id) FROM message WHERE author_id = :current_user.id) as rooms_active
+  html
+    <div class="max-w-lg mx-auto w-full px-4 sm:px-6 py-10">
+      <a href="/" class="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 transition mb-8">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Back to rooms
+      </a>
+      <div class="bg-zinc-900/50 border border-zinc-800/50 rounded-xl p-6">
+        <div class="flex items-center gap-4 mb-6">
+          <div class="w-16 h-16 rounded-full bg-orange-500/15 flex items-center justify-center text-orange-400 text-2xl font-bold">{me.name|truncate:1}</div>
+          <div>
+            <h1 class="text-xl font-bold text-white">{me.name}</h1>
+            <p class="text-sm text-zinc-500">{me.email}</p>
+          </div>
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+          <div class="bg-zinc-800/50 rounded-lg p-4 text-center">
+            <div class="text-2xl font-bold text-white">{stats.msg_count}</div>
+            <div class="text-xs text-zinc-500 mt-1">Messages sent</div>
+          </div>
+          <div class="bg-zinc-800/50 rounded-lg p-4 text-center">
+            <div class="text-2xl font-bold text-white">{stats.rooms_active}</div>
+            <div class="text-xs text-zinc-500 mt-1">Rooms active in</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+# Search results
+page /search requires auth layout chat title "Search"
+  query results: SELECT m.id, m.body, u.name as author, m.created,
+                 r.name as room_name, r.id as room_id
+                 FROM message m
+                 JOIN user u ON u.id = m.author_id
+                 JOIN room r ON r.id = m.room_id
+                 WHERE m.body LIKE '%' || :q || '%'
+                 ORDER BY m.created DESC
+                 paginate 50
+  html
+    <div class="max-w-2xl mx-auto w-full px-4 sm:px-6 py-10">
+      <a href="/" class="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-300 transition mb-6">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Back
+      </a>
+      <form action="/search" method="GET" class="flex gap-3 mb-8">
+        <input type="text" name="q" placeholder="Search messages..." class="flex-1 px-4 py-2.5 bg-zinc-900 border border-zinc-700/60 rounded-lg text-sm text-zinc-100 placeholder-zinc-500 outline-none focus:border-orange-500 focus:ring-2 focus:ring-orange-500/20 transition">
+        <button type="submit" class="px-4 py-2.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 rounded-lg transition shrink-0">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+        </button>
+      </form>
+      <p class="text-sm text-zinc-500 mb-4">{results.count} results</p>
+      <div class="space-y-2">
+        {{each results}}
+        <a href="/chat/{room_id}" class="block p-3 bg-zinc-900/50 border border-zinc-800/50 rounded-lg hover:bg-zinc-900 transition">
+          <div class="flex items-baseline gap-2 mb-1">
+            <span class="text-sm font-semibold text-orange-300">{author}</span>
+            <span class="text-[11px] text-zinc-600">in #{room_name}</span>
+            <time class="text-[11px] text-zinc-600">{created|timeago}</time>
+          </div>
+          <p class="text-sm text-zinc-300">{body|truncate:120}</p>
+        </a>
+        {{else}}
+        <p class="text-center text-zinc-500 py-10">No messages found.</p>
+        {{end}}
+      </div>
+    </div>
+
+# ============================================================
+# ACTIONS
+# ============================================================
+
+action /rooms/create method POST requires auth
+  validate
+    name: required min 2
+  query: INSERT INTO room (name, description, creator_id) VALUES (:name, :description, :current_user.id)
+  redirect /
+
+action /chat/:id/send method POST requires auth
+  validate
+    body: required
+  query: INSERT INTO message (body, author_id, room_id) VALUES (:body, :current_user.id, :id)
+  redirect /chat/:id
+
+action /rooms/:id/delete method POST requires auth
+  query: DELETE FROM message WHERE room_id = :id
+  query: DELETE FROM room WHERE id = :id
+  redirect /
+
+action /messages/:id/delete method POST requires auth
+  query: DELETE FROM message WHERE id = :id AND author_id = :current_user.id
+  on not found
+    redirect /
+
+# ============================================================
+# REAL-TIME: SSE stream for live message count
+# ============================================================
+
+stream /stream/rooms
+  every 5s
+  query: SELECT r.id, r.name, COUNT(m.id) as msg_count
+         FROM room r
+         LEFT JOIN message m ON m.room_id = r.id
+         GROUP BY r.id
+  event: rooms-update
+
+# ============================================================
+# TESTS
+# ============================================================
+
+test "homepage requires auth"
+  visit /
+  expect page /login
+
+test "login page loads"
+  visit /login
+  expect page /login contains "Log in"
+
+test "register page loads"
+  visit /register
+  expect page /register contains "Create account"

--- a/examples/dashboard.kilnx
+++ b/examples/dashboard.kilnx
@@ -1,0 +1,90 @@
+# Realtime Dashboard
+# Demonstrates: SSE streams, webhooks, aggregate SQL, schedule, API endpoints
+
+config
+  database: env DATABASE_URL default "sqlite://dashboard.db"
+  port: env PORT default 8080
+  secret: env SECRET_KEY default "dev-secret"
+
+model event
+  type: text required
+  source: text
+  value: float default 0
+  created: timestamp auto
+
+model daily_summary
+  date: text required
+  total_events: text default "0"
+  total_value: text default "0"
+  created: timestamp auto
+
+# Dashboard page with auto-updating metrics
+page /
+  query totals: SELECT COUNT(*) as events, COALESCE(SUM(value), 0) as revenue
+                FROM event
+  query recent: SELECT type, source, value, created
+                FROM event
+                ORDER BY created DESC
+                paginate 20
+  html
+    <h1>Dashboard</h1>
+    <div class="metrics" hx-ext="sse" sse-connect="/stream/metrics">
+      <div class="card" sse-swap="update">
+        <h2>Events: {totals.events}</h2>
+        <p>Revenue: {totals.revenue|currency:"$"}</p>
+      </div>
+    </div>
+    <h2>Recent Events</h2>
+    <table>
+      <thead>
+        <tr><th>Type</th><th>Source</th><th>Value</th><th>When</th></tr>
+      </thead>
+      <tbody>
+        {{each recent}}
+        <tr>
+          <td>{type}</td>
+          <td>{source}</td>
+          <td>{value|currency:"$"}</td>
+          <td>{created|timeago}</td>
+        </tr>
+        {{else}}
+        <tr><td colspan="4">No events recorded yet.</td></tr>
+        {{end}}
+      </tbody>
+    </table>
+
+# SSE stream for live metrics
+stream /stream/metrics
+  every 5s
+  query: SELECT COUNT(*) as events, COALESCE(SUM(value), 0) as revenue FROM event
+  event: update
+
+# Webhook to receive external events
+webhook /hooks/events secret env WEBHOOK_SECRET
+  on event *
+    query: INSERT INTO event (type, source, value) VALUES (:event_type, :event_source, :event_value)
+
+# API endpoint for programmatic access
+api /api/stats
+  query stats: SELECT COUNT(*) as total_events,
+               COALESCE(SUM(value), 0) as total_revenue,
+               COUNT(DISTINCT type) as event_types
+               FROM event
+
+api /api/events
+  query events: SELECT type, source, value, created
+                FROM event
+                ORDER BY created DESC
+                paginate 50
+
+# Daily summary job
+schedule daily-summary every 24h
+  query: DELETE FROM event WHERE created < datetime('now', '-30 days')
+
+test "dashboard loads"
+  visit /
+  expect page / contains "Dashboard"
+
+test "api returns stats"
+  visit /api/stats
+  expect page /api/stats contains "total_events"

--- a/examples/saas.kilnx
+++ b/examples/saas.kilnx
@@ -1,0 +1,258 @@
+# SaaS Starter
+# Demonstrates: permissions, rate limiting, jobs, email, i18n, layout, tests
+
+config
+  database: env DATABASE_URL default "sqlite://saas.db"
+  port: env PORT default 8080
+  secret: env SECRET_KEY default "dev-secret"
+
+model user
+  name: text required min 2 max 100
+  email: email unique
+  password: password required
+  role: option [admin, member, viewer] default member
+  created: timestamp auto
+
+model team
+  name: text required min 2 max 100
+  created: timestamp auto
+
+model project
+  name: text required min 2 max 200
+  description: richtext
+  status: option [active, archived] default active
+  team: team required
+  created: timestamp auto
+
+model task
+  title: text required min 3 max 300
+  description: richtext
+  status: option [todo, in_progress, done] default todo
+  priority: option [low, medium, high] default medium
+  assignee: user
+  project: project required
+  created: timestamp auto
+
+model invitation
+  email: email required
+  team: team required
+  role: option [member, viewer] default member
+  status: option [pending, accepted, declined] default pending
+  created: timestamp auto
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /dashboard
+
+permissions
+  admin: all
+  member: read project, write project, read task, write task
+  viewer: read project, read task
+
+translations
+  en
+    dashboard: "Dashboard"
+    projects: "Projects"
+    tasks: "Tasks"
+    team: "Team"
+    settings: "Settings"
+    no_projects: "No projects yet. Create your first one."
+    no_tasks: "No tasks in this project."
+    invite_sent: "Invitation sent"
+  es
+    dashboard: "Panel"
+    projects: "Proyectos"
+    tasks: "Tareas"
+    team: "Equipo"
+    settings: "Configuracion"
+    no_projects: "Sin proyectos. Crea el primero."
+    no_tasks: "Sin tareas en este proyecto."
+    invite_sent: "Invitacion enviada"
+
+layout main
+  html
+    <nav>
+      <a href="/dashboard">{t.dashboard}</a>
+      <a href="/projects">{t.projects}</a>
+      <a href="/team">{t.team}</a>
+    </nav>
+    <main>{page.content}</main>
+
+# Dashboard
+page /dashboard requires auth layout main title {t.dashboard}
+  query stats: SELECT
+               (SELECT COUNT(*) FROM project WHERE status = 'active') as active_projects,
+               (SELECT COUNT(*) FROM task WHERE status != 'done') as open_tasks,
+               (SELECT COUNT(*) FROM task WHERE status = 'done') as done_tasks
+  html
+    <h1>{t.dashboard}</h1>
+    <div class="stats">
+      <div class="card">
+        <h3>{t.projects}</h3>
+        <p>{stats.active_projects}</p>
+      </div>
+      <div class="card">
+        <h3>{t.tasks}</h3>
+        <p>{stats.open_tasks} open, {stats.done_tasks} done</p>
+      </div>
+    </div>
+
+# Projects
+page /projects requires auth layout main title {t.projects}
+  query projects: SELECT p.id, p.name, p.status, p.created,
+                  (SELECT COUNT(*) FROM task WHERE project_id = p.id) as task_count
+                  FROM project p
+                  WHERE p.status = 'active'
+                  ORDER BY p.created DESC
+  html
+    <h1>{t.projects}</h1>
+    <a href="/projects/new">New Project</a>
+    {{each projects}}
+    <div class="project-card">
+      <h3><a href="/projects/{id}">{name}</a></h3>
+      <span>{task_count} {t.tasks}</span>
+      <time>{created|date:"Jan 02, 2006"}</time>
+    </div>
+    {{else}}
+    <p>{t.no_projects}</p>
+    {{end}}
+
+page /projects/new requires auth layout main
+  html
+    <h1>New Project</h1>
+    <form method="POST" action="/projects/create">
+      <label>Name <input type="text" name="name" required minlength="2"></label>
+      <label>Description <textarea name="description"></textarea></label>
+      <label>Team
+        <select name="team_id" required>
+          <option value="">Select team</option>
+        </select>
+      </label>
+      <button type="submit">Create</button>
+    </form>
+
+action /projects/create method POST requires auth
+  validate
+    name: required min 2
+  query: INSERT INTO project (name, description, team_id) VALUES (:name, :description, :team)
+  redirect /projects
+
+# Project detail with tasks
+page /projects/:id requires auth layout main
+  query project: SELECT name, description, status FROM project WHERE id = :id
+  query tasks: SELECT t.id, t.title, t.status, t.priority, u.name as assignee
+               FROM task t
+               LEFT JOIN user u ON u.id = t.assignee_id
+               WHERE t.project_id = :id
+               ORDER BY t.created DESC
+  html
+    <h1>{project.name}</h1>
+    <p>{project.description|raw}</p>
+    <h2>{t.tasks}</h2>
+    <a href="/projects/{id}/tasks/new">New Task</a>
+    {{each tasks}}
+    <div class="task" data-status="{status}">
+      <span class="priority-{priority}">{priority}</span>
+      <a href="/tasks/{id}">{title}</a>
+      <span>{assignee|default:"Unassigned"}</span>
+      <span>{status}</span>
+    </div>
+    {{else}}
+    <p>{t.no_tasks}</p>
+    {{end}}
+
+# Task management
+action /tasks/:id/update method POST requires auth
+  validate
+    status: required
+  query: UPDATE task SET status = :status WHERE id = :id
+  redirect /projects
+
+action /tasks/:id/delete method POST requires admin
+  query: DELETE FROM task WHERE id = :id
+  redirect /projects
+
+# Team management
+page /team requires auth layout main title {t.team}
+  query members: SELECT id, name, email, role, created FROM user ORDER BY name
+  query invitations: SELECT email, role, status, created
+                     FROM invitation
+                     WHERE status = 'pending'
+                     ORDER BY created DESC
+  html
+    <h1>{t.team}</h1>
+    <h2>Members</h2>
+    {{each members}}
+    <div class="member">
+      <strong>{name}</strong>
+      <span>{email}</span>
+      <span class="role">{role}</span>
+    </div>
+    {{end}}
+    <h2>Pending Invitations</h2>
+    <form method="POST" action="/team/invite">
+      <input type="email" name="email" placeholder="Email address" required>
+      <select name="role">
+        <option value="member">Member</option>
+        <option value="viewer">Viewer</option>
+      </select>
+      <button type="submit">Invite</button>
+    </form>
+    {{each invitations}}
+    <div class="invitation">
+      <span>{email}</span>
+      <span>{role}</span>
+      <span>{created|timeago}</span>
+    </div>
+    {{end}}
+
+action /team/invite method POST requires admin
+  validate
+    email: required
+  query: INSERT INTO invitation (email, team_id, role) VALUES (:email, 1, :role)
+  enqueue send-invitation with email: :email
+  redirect /team
+
+# Background job for sending invitations
+job send-invitation
+  retry 3
+  query: SELECT email, role FROM invitation WHERE email = :email AND status = 'pending'
+
+# Scheduled cleanup of expired invitations
+schedule cleanup-invitations every 24h
+  query: UPDATE invitation SET status = 'declined' WHERE status = 'pending' AND created < datetime('now', '-7 days')
+
+# Rate limiting
+limit /api/*
+  requests: 60 per minute per user
+
+limit /team/invite
+  requests: 10 per hour per user
+  message: "Too many invitations. Please wait."
+
+# API endpoints
+api /api/projects requires auth
+  query projects: SELECT id, name, status, created FROM project ORDER BY created DESC
+
+api /api/tasks requires auth
+  query tasks: SELECT id, title, status, priority, project_id, created FROM task ORDER BY created DESC
+
+# Tests
+test "login page loads"
+  visit /login
+  expect page /login contains "Log in"
+
+test "dashboard requires auth"
+  visit /dashboard
+  expect page /login
+
+test "projects page requires auth"
+  visit /projects
+  expect page /login
+
+test "api requires auth"
+  visit /api/projects
+  expect page /api/projects contains "Unauthorized"

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"crypto/sha256"
 	"database/sql"
 	"fmt"
 	"regexp"
@@ -87,36 +88,120 @@ func (db *DB) Conn() *sql.DB {
 	return db.conn
 }
 
-// Migrate compares models with the current database state and applies changes.
-func (db *DB) Migrate(models []parser.Model) ([]string, error) {
-	var executed []string
+// PlanMigration compares models with the current database state and returns
+// the SQL statements that would be executed, without applying them.
+func (db *DB) PlanMigration(models []parser.Model) ([]string, error) {
+	var stmts []string
 
 	for _, model := range models {
 		if !isValidIdentifier(model.Name) {
-			return executed, fmt.Errorf("invalid model name: %q", model.Name)
+			return stmts, fmt.Errorf("invalid model name: %q", model.Name)
 		}
 
 		exists, err := db.tableExists(model.Name)
 		if err != nil {
-			return executed, err
+			return stmts, err
 		}
 
 		if !exists {
-			stmt := generateCreateTable(model)
-			if _, err := db.conn.Exec(stmt); err != nil {
-				return executed, fmt.Errorf("creating table '%s': %w\nSQL: %s", model.Name, err, stmt)
-			}
-			executed = append(executed, stmt)
+			stmts = append(stmts, generateCreateTable(model))
 		} else {
-			stmts, err := db.migrateExistingTable(model)
+			alterStmts, err := db.planExistingTable(model)
 			if err != nil {
-				return executed, err
+				return stmts, err
 			}
-			executed = append(executed, stmts...)
+			stmts = append(stmts, alterStmts...)
 		}
 	}
 
+	return stmts, nil
+}
+
+// Migrate compares models with the current database state and applies changes.
+func (db *DB) Migrate(models []parser.Model) ([]string, error) {
+	stmts, err := db.PlanMigration(models)
+	if err != nil {
+		return nil, err
+	}
+
+	var executed []string
+	for _, stmt := range stmts {
+		if _, err := db.conn.Exec(stmt); err != nil {
+			return executed, fmt.Errorf("executing migration: %w\nSQL: %s", err, stmt)
+		}
+		executed = append(executed, stmt)
+	}
+
+	// Record migration if any statements were executed
+	if len(executed) > 0 {
+		hash := schemaHash(models)
+		allSQL := strings.Join(executed, ";\n")
+		db.recordMigration(hash, allSQL)
+	}
+
 	return executed, nil
+}
+
+// MigrationRecord represents a recorded migration entry
+type MigrationRecord struct {
+	ID         int
+	SchemaHash string
+	Statements string
+	AppliedAt  string
+}
+
+// MigrationHistory returns all recorded migrations
+func (db *DB) MigrationHistory() ([]MigrationRecord, error) {
+	// Check if table exists first
+	exists, err := db.tableExists("_kilnx_migrations")
+	if err != nil || !exists {
+		return nil, err
+	}
+
+	rows, err := db.conn.Query("SELECT id, schema_hash, statements, applied_at FROM _kilnx_migrations ORDER BY id")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var records []MigrationRecord
+	for rows.Next() {
+		var r MigrationRecord
+		if err := rows.Scan(&r.ID, &r.SchemaHash, &r.Statements, &r.AppliedAt); err != nil {
+			return nil, err
+		}
+		records = append(records, r)
+	}
+	return records, rows.Err()
+}
+
+func (db *DB) recordMigration(hash, stmts string) {
+	db.conn.Exec(
+		"INSERT INTO _kilnx_migrations (schema_hash, statements) VALUES (?, ?)",
+		hash, stmts,
+	)
+}
+
+func schemaHash(models []parser.Model) string {
+	var b strings.Builder
+	for _, m := range models {
+		fmt.Fprintf(&b, "model:%s\n", m.Name)
+		for _, f := range m.Fields {
+			fmt.Fprintf(&b, "  %s:%s", f.Name, f.Type)
+			if f.Required {
+				b.WriteString(":req")
+			}
+			if f.Unique {
+				b.WriteString(":uniq")
+			}
+			if f.Default != "" {
+				fmt.Fprintf(&b, ":def=%s", f.Default)
+			}
+			b.WriteString("\n")
+		}
+	}
+	h := sha256.Sum256([]byte(b.String()))
+	return fmt.Sprintf("%x", h[:8])
 }
 
 func (db *DB) tableExists(name string) (bool, error) {
@@ -127,8 +212,9 @@ func (db *DB) tableExists(name string) (bool, error) {
 	return count > 0, err
 }
 
-func (db *DB) migrateExistingTable(model parser.Model) ([]string, error) {
-	var executed []string
+// planExistingTable returns ALTER TABLE statements needed without executing them
+func (db *DB) planExistingTable(model parser.Model) ([]string, error) {
+	var stmts []string
 
 	existing, err := db.getColumns(model.Name)
 	if err != nil {
@@ -138,7 +224,7 @@ func (db *DB) migrateExistingTable(model parser.Model) ([]string, error) {
 	for _, field := range model.Fields {
 		colName := fieldToColumnName(field)
 		if !isValidIdentifier(colName) {
-			return executed, fmt.Errorf("invalid column name: %q", colName)
+			return stmts, fmt.Errorf("invalid column name: %q", colName)
 		}
 		if _, ok := existing[colName]; ok {
 			continue
@@ -149,15 +235,10 @@ func (db *DB) migrateExistingTable(model parser.Model) ([]string, error) {
 
 		stmt := fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"%s\" %s%s",
 			model.Name, colName, sqlType, defaultClause)
-
-		if _, err := db.conn.Exec(stmt); err != nil {
-			return executed, fmt.Errorf("adding column '%s' to '%s': %w\nSQL: %s",
-				colName, model.Name, err, stmt)
-		}
-		executed = append(executed, stmt)
+		stmts = append(stmts, stmt)
 	}
 
-	return executed, nil
+	return stmts, nil
 }
 
 func (db *DB) getColumns(table string) (map[string]bool, error) {
@@ -299,6 +380,12 @@ func (db *DB) MigrateInternal() error {
 			role TEXT NOT NULL DEFAULT '',
 			data TEXT NOT NULL DEFAULT '{}',
 			expires_at DATETIME NOT NULL
+		)`,
+		`CREATE TABLE IF NOT EXISTS _kilnx_migrations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			schema_hash TEXT NOT NULL,
+			statements TEXT NOT NULL,
+			applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)`,
 		`CREATE TABLE IF NOT EXISTS _kilnx_jobs (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -742,3 +742,102 @@ func TestTempDirCleanedUp(t *testing.T) {
 	}
 	_ = os.Remove(dbPath) // best-effort cleanup
 }
+
+func TestPlanMigration_DryRun(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{
+		{Name: "task", Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText, Required: true},
+			{Name: "done", Type: parser.FieldBool},
+		}},
+	}
+
+	stmts, err := db.PlanMigration(models)
+	if err != nil {
+		t.Fatalf("PlanMigration: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(stmts))
+	}
+	if !strings.HasPrefix(stmts[0], "CREATE TABLE") {
+		t.Errorf("expected CREATE TABLE, got %q", stmts[0])
+	}
+
+	// Table should NOT exist (dry run)
+	exists, _ := db.tableExists("task")
+	if exists {
+		t.Error("PlanMigration should not create tables")
+	}
+}
+
+func TestMigrationHistory(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	if err := db.MigrateInternal(); err != nil {
+		t.Fatalf("MigrateInternal: %v", err)
+	}
+
+	models := []parser.Model{
+		{Name: "note", Fields: []parser.Field{
+			{Name: "body", Type: parser.FieldText},
+		}},
+	}
+
+	_, err := db.Migrate(models)
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	history, err := db.MigrationHistory()
+	if err != nil {
+		t.Fatalf("MigrationHistory: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("expected 1 migration record, got %d", len(history))
+	}
+	if history[0].SchemaHash == "" {
+		t.Error("schema hash should not be empty")
+	}
+	if !strings.Contains(history[0].Statements, "CREATE TABLE") {
+		t.Error("statements should contain CREATE TABLE")
+	}
+}
+
+func TestMigrationStatus_Pending(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	if err := db.MigrateInternal(); err != nil {
+		t.Fatalf("MigrateInternal: %v", err)
+	}
+
+	// Migrate initial model
+	models := []parser.Model{
+		{Name: "item", Fields: []parser.Field{
+			{Name: "name", Type: parser.FieldText},
+		}},
+	}
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	// Add a field
+	models[0].Fields = append(models[0].Fields, parser.Field{
+		Name: "price", Type: parser.FieldFloat,
+	})
+
+	// Plan should show pending ALTER
+	pending, err := db.PlanMigration(models)
+	if err != nil {
+		t.Fatalf("PlanMigration: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending statement, got %d", len(pending))
+	}
+	if !strings.Contains(pending[0], "ALTER TABLE") {
+		t.Errorf("expected ALTER TABLE, got %q", pending[0])
+	}
+}

--- a/internal/database/query.go
+++ b/internal/database/query.go
@@ -47,7 +47,7 @@ func (db *DB) QueryRows(sql string) ([]Row, error) {
 	return results, rows.Err()
 }
 
-var paramRe = regexp.MustCompile(`:([a-zA-Z_][a-zA-Z0-9_]*)`)
+var paramRe = regexp.MustCompile(`:([a-zA-Z_][a-zA-Z0-9_.]*)`)
 
 // ExecWithParams executes a SQL statement with named parameters from a map.
 // Named params like :name, :email are replaced with positional ? params.

--- a/internal/lsp/lsp.go
+++ b/internal/lsp/lsp.go
@@ -46,7 +46,9 @@ func Serve() {
 						CompletionProvider: &completionOptions{
 							TriggerCharacters: []string{" ", "\n"},
 						},
-						HoverProvider: true,
+						HoverProvider:          true,
+					DefinitionProvider:     true,
+					DocumentSymbolProvider: true,
 					},
 				},
 			}
@@ -95,6 +97,32 @@ func Serve() {
 			var params hoverParams
 			if json.Unmarshal(req.Params, &params) == nil {
 				result := getHover(files[params.TextDocument.URI], params.Position)
+				resp := jsonRPCResponse{
+					JSONRPC: "2.0",
+					ID:      req.ID,
+					Result:  result,
+				}
+				writeMessage(writer, resp)
+			}
+
+		case "textDocument/definition":
+			var params hoverParams
+			if json.Unmarshal(req.Params, &params) == nil {
+				result := getDefinition(files[params.TextDocument.URI], params.Position, params.TextDocument.URI)
+				resp := jsonRPCResponse{
+					JSONRPC: "2.0",
+					ID:      req.ID,
+					Result:  result,
+				}
+				writeMessage(writer, resp)
+			}
+
+		case "textDocument/documentSymbol":
+			var params struct {
+				TextDocument textDocumentIdentifier `json:"textDocument"`
+			}
+			if json.Unmarshal(req.Params, &params) == nil {
+				result := getDocumentSymbols(files[params.TextDocument.URI])
 				resp := jsonRPCResponse{
 					JSONRPC: "2.0",
 					ID:      req.ID,
@@ -205,6 +233,11 @@ func getCompletions(content string, pos position) []completionItem {
 
 	var items []completionItem
 
+	// Parse the document to get context-aware completions
+	stripped := lexer.StripComments(content)
+	tokens := lexer.Tokenize(stripped)
+	app, _ := parser.Parse(tokens, stripped)
+
 	if indent == 0 {
 		// Top-level keywords
 		for _, kw := range topLevelKeywords {
@@ -215,6 +248,41 @@ func getCompletions(content string, pos position) []completionItem {
 			})
 		}
 	} else {
+		trimmed := strings.TrimSpace(currentLine)
+
+		// Context-aware: after "layout" keyword, suggest layout names
+		if strings.HasPrefix(trimmed, "layout ") || strings.HasSuffix(trimmed, "layout") {
+			if app != nil {
+				for _, l := range app.Layouts {
+					items = append(items, completionItem{
+						Label:  l.Name,
+						Kind:   2, // Module
+						Detail: "Layout: " + l.Name,
+					})
+				}
+			}
+			return items
+		}
+
+		// Context-aware: in SQL context, suggest model names as table names
+		if strings.Contains(trimmed, "FROM") || strings.Contains(trimmed, "JOIN") ||
+			strings.Contains(trimmed, "INTO") || strings.Contains(trimmed, "UPDATE") {
+			if app != nil {
+				for _, m := range app.Models {
+					fields := make([]string, len(m.Fields))
+					for i, f := range m.Fields {
+						fields[i] = f.Name
+					}
+					items = append(items, completionItem{
+						Label:  m.Name,
+						Kind:   5, // Class
+						Detail: "Table: " + strings.Join(fields, ", "),
+					})
+				}
+			}
+			return items
+		}
+
 		// Inside a block: suggest body keywords and field types
 		for _, kw := range bodyKeywords {
 			items = append(items, completionItem{
@@ -229,6 +297,17 @@ func getCompletions(content string, pos position) []completionItem {
 				Kind:   12, // Value
 				Detail: ft.Detail,
 			})
+		}
+
+		// Add model names for reference fields
+		if app != nil {
+			for _, m := range app.Models {
+				items = append(items, completionItem{
+					Label:  m.Name,
+					Kind:   5,
+					Detail: "Model (for reference field)",
+				})
+			}
 		}
 	}
 
@@ -246,12 +325,64 @@ func getHover(content string, pos position) *hoverResult {
 		return nil
 	}
 
+	// Check keyword docs first
 	if desc, ok := keywordDocs[word]; ok {
 		return &hoverResult{
 			Contents: markupContent{
 				Kind:  "markdown",
 				Value: fmt.Sprintf("**%s**\n\n%s", word, desc),
 			},
+		}
+	}
+
+	// Try to parse and show model/layout info
+	stripped := lexer.StripComments(content)
+	tokens := lexer.Tokenize(stripped)
+	app, _ := parser.Parse(tokens, stripped)
+	if app == nil {
+		return nil
+	}
+
+	// Hover on model name: show fields
+	for _, m := range app.Models {
+		if m.Name == word {
+			var fields []string
+			for _, f := range m.Fields {
+				constraint := ""
+				if f.Required {
+					constraint += " required"
+				}
+				if f.Unique {
+					constraint += " unique"
+				}
+				if f.Default != "" {
+					constraint += " default " + f.Default
+				}
+				fields = append(fields, fmt.Sprintf("- **%s**: %s%s", f.Name, f.Type, constraint))
+			}
+			return &hoverResult{
+				Contents: markupContent{
+					Kind:  "markdown",
+					Value: fmt.Sprintf("**model %s**\n\n%s", m.Name, strings.Join(fields, "\n")),
+				},
+			}
+		}
+	}
+
+	// Hover on layout name
+	for _, l := range app.Layouts {
+		if l.Name == word {
+			queryCount := len(l.Queries)
+			info := fmt.Sprintf("**layout %s**\n\nPlaceholders: `{page.title}`, `{page.content}`, `{nav}`", l.Name)
+			if queryCount > 0 {
+				info += fmt.Sprintf("\n\nQueries: %d", queryCount)
+			}
+			return &hoverResult{
+				Contents: markupContent{
+					Kind:  "markdown",
+					Value: info,
+				},
+			}
 		}
 	}
 
@@ -391,9 +522,11 @@ type initializeResult struct {
 }
 
 type serverCapabilities struct {
-	TextDocumentSync   int                `json:"textDocumentSync"`
-	CompletionProvider *completionOptions `json:"completionProvider,omitempty"`
-	HoverProvider      bool               `json:"hoverProvider"`
+	TextDocumentSync       int                `json:"textDocumentSync"`
+	CompletionProvider     *completionOptions `json:"completionProvider,omitempty"`
+	HoverProvider          bool               `json:"hoverProvider"`
+	DefinitionProvider     bool               `json:"definitionProvider"`
+	DocumentSymbolProvider bool               `json:"documentSymbolProvider"`
 }
 
 type completionOptions struct {
@@ -429,6 +562,306 @@ type lspDiagnostic struct {
 type publishDiagnosticsParams struct {
 	URI         string          `json:"uri"`
 	Diagnostics []lspDiagnostic `json:"diagnostics"`
+}
+
+// LSP Location type for go-to-definition
+type lspLocation struct {
+	URI   string   `json:"uri"`
+	Range lspRange `json:"range"`
+}
+
+// LSP DocumentSymbol type
+type documentSymbol struct {
+	Name           string           `json:"name"`
+	Kind           int              `json:"kind"`
+	Range          lspRange         `json:"range"`
+	SelectionRange lspRange         `json:"selectionRange"`
+	Children       []documentSymbol `json:"children,omitempty"`
+}
+
+// getDefinition finds the definition of the symbol under cursor
+func getDefinition(content string, pos position, uri string) *lspLocation {
+	lines := strings.Split(content, "\n")
+	if pos.Line >= len(lines) {
+		return nil
+	}
+	word := wordAt(lines[pos.Line], pos.Character)
+	if word == "" {
+		return nil
+	}
+
+	// Try to parse the file to find definitions
+	stripped := lexer.StripComments(content)
+	tokens := lexer.Tokenize(stripped)
+	app, err := parser.Parse(tokens, stripped)
+	if err != nil {
+		return nil
+	}
+
+	// Search for model definitions
+	for _, m := range app.Models {
+		if m.Name == word {
+			line := findDefinitionLine(lines, "model", word)
+			if line >= 0 {
+				return &lspLocation{
+					URI:   uri,
+					Range: lineRange(line),
+				}
+			}
+		}
+	}
+
+	// Search for layout definitions
+	for _, l := range app.Layouts {
+		if l.Name == word {
+			line := findDefinitionLine(lines, "layout", word)
+			if line >= 0 {
+				return &lspLocation{
+					URI:   uri,
+					Range: lineRange(line),
+				}
+			}
+		}
+	}
+
+	// Search for page/action/fragment paths
+	for _, p := range app.Pages {
+		if p.Path == "/"+word || p.Path == word {
+			line := findDefinitionLine(lines, "page", p.Path)
+			if line >= 0 {
+				return &lspLocation{
+					URI:   uri,
+					Range: lineRange(line),
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// getDocumentSymbols returns an outline of all definitions in the file
+func getDocumentSymbols(content string) []documentSymbol {
+	stripped := lexer.StripComments(content)
+	tokens := lexer.Tokenize(stripped)
+	app, err := parser.Parse(tokens, stripped)
+	if err != nil {
+		return nil
+	}
+
+	lines := strings.Split(content, "\n")
+	var symbols []documentSymbol
+
+	// Models (Class = 5)
+	for _, m := range app.Models {
+		line := findDefinitionLine(lines, "model", m.Name)
+		if line < 0 {
+			continue
+		}
+		sym := documentSymbol{
+			Name:           m.Name,
+			Kind:           5, // Class
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		}
+		for _, f := range m.Fields {
+			fline := findFieldLine(lines, f.Name, line+1)
+			if fline >= 0 {
+				sym.Children = append(sym.Children, documentSymbol{
+					Name:           fmt.Sprintf("%s: %s", f.Name, f.Type),
+					Kind:           8, // Field
+					Range:          lineRange(fline),
+					SelectionRange: lineRange(fline),
+				})
+			}
+		}
+		symbols = append(symbols, sym)
+	}
+
+	// Pages (Function = 12)
+	for _, p := range app.Pages {
+		line := findDefinitionLine(lines, "page", p.Path)
+		if line < 0 {
+			continue
+		}
+		name := "page " + p.Path
+		if p.Title != "" {
+			name += " - " + p.Title
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           name,
+			Kind:           12,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	// Actions (Function = 12)
+	for _, a := range app.Actions {
+		line := findDefinitionLine(lines, "action", a.Path)
+		if line < 0 {
+			continue
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           "action " + a.Path + " " + a.Method,
+			Kind:           12,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	// Fragments (Function = 12)
+	for _, f := range app.Fragments {
+		line := findDefinitionLine(lines, "fragment", f.Path)
+		if line < 0 {
+			continue
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           "fragment " + f.Path,
+			Kind:           12,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	// Layouts (Module = 2)
+	for _, l := range app.Layouts {
+		line := findDefinitionLine(lines, "layout", l.Name)
+		if line < 0 {
+			continue
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           "layout " + l.Name,
+			Kind:           2,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	// APIs (Interface = 11)
+	for _, a := range app.APIs {
+		line := findDefinitionLine(lines, "api", a.Path)
+		if line < 0 {
+			continue
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           "api " + a.Path,
+			Kind:           11,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	// Streams (Event = 24)
+	for _, s := range app.Streams {
+		line := findDefinitionLine(lines, "stream", s.Path)
+		if line < 0 {
+			continue
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           "stream " + s.Path,
+			Kind:           24,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	// Sockets (Event = 24)
+	for _, s := range app.Sockets {
+		line := findDefinitionLine(lines, "socket", s.Path)
+		if line < 0 {
+			continue
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           "socket " + s.Path,
+			Kind:           24,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	// Webhooks (Event = 24)
+	for _, w := range app.Webhooks {
+		line := findDefinitionLine(lines, "webhook", w.Path)
+		if line < 0 {
+			continue
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           "webhook " + w.Path,
+			Kind:           24,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	// Jobs (Function = 12)
+	for _, j := range app.Jobs {
+		line := findDefinitionLine(lines, "job", j.Name)
+		if line < 0 {
+			continue
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           "job " + j.Name,
+			Kind:           12,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	// Schedules (Function = 12)
+	for _, s := range app.Schedules {
+		line := findDefinitionLine(lines, "schedule", s.Name)
+		if line < 0 {
+			continue
+		}
+		symbols = append(symbols, documentSymbol{
+			Name:           "schedule " + s.Name,
+			Kind:           12,
+			Range:          lineRange(line),
+			SelectionRange: lineRange(line),
+		})
+	}
+
+	return symbols
+}
+
+// findDefinitionLine scans source lines for "keyword name" pattern
+func findDefinitionLine(lines []string, keyword, name string) int {
+	prefix := keyword + " " + name
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, prefix) {
+			// Ensure it's a whole word match
+			rest := trimmed[len(prefix):]
+			if rest == "" || rest[0] == ' ' || rest[0] == '\n' || rest[0] == '\r' {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// findFieldLine scans for "name:" pattern starting from a given line
+func findFieldLine(lines []string, fieldName string, startLine int) int {
+	prefix := fieldName + ":"
+	for i := startLine; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, prefix) {
+			return i
+		}
+		// Stop if we hit the next top-level definition
+		if len(trimmed) > 0 && trimmed[0] != ' ' && trimmed[0] != '\t' && i > startLine {
+			break
+		}
+	}
+	return -1
+}
+
+func lineRange(line int) lspRange {
+	return lspRange{
+		Start: position{Line: line, Character: 0},
+		End:   position{Line: line, Character: 999},
+	}
 }
 
 // Completion data

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -658,9 +658,12 @@ func (p *parserState) parsePage() (Page, error) {
 					page.Layout = p.advance().Value
 				}
 			case "title":
-				p.advance()
+				titleTok := p.advance()
 				if p.current().Type == lexer.TokenString {
 					page.Title = p.advance().Value
+				} else {
+					page.Title = p.extractTitleFromSourceLine(titleTok.Line, titleTok.Column)
+					p.skipToEndOfModifier()
 				}
 			case "requires":
 				p.advance()
@@ -832,6 +835,50 @@ func (p *parserState) extractSQLFromLine(lineNum int) string {
 		return strings.TrimSpace(line)
 	}
 	return strings.TrimSpace(line[idx+1:])
+}
+
+// extractTitleFromSourceLine extracts a dynamic title expression from the source line.
+// For "page /docs/:slug title {doc.title} layout main", it returns "{doc.title}".
+func (p *parserState) extractTitleFromSourceLine(lineNum, titleCol int) string {
+	if lineNum < 1 || lineNum > len(p.lines) {
+		return ""
+	}
+	line := p.lines[lineNum-1]
+
+	// Find start: skip past "title " from the title keyword column
+	start := titleCol + len("title")
+	if start >= len(line) {
+		return ""
+	}
+	// Skip whitespace after "title"
+	for start < len(line) && line[start] == ' ' {
+		start++
+	}
+
+	rest := line[start:]
+
+	// Trim at known page modifier keywords that appear as standalone words
+	modifiers := []string{" layout ", " requires ", " method "}
+	for _, mod := range modifiers {
+		if idx := strings.Index(rest, mod); idx >= 0 {
+			rest = rest[:idx]
+		}
+	}
+
+	return strings.TrimSpace(rest)
+}
+
+// skipToEndOfModifier advances past tokens until hitting a page modifier keyword or newline
+func (p *parserState) skipToEndOfModifier() {
+	for !p.isEOF() && p.current().Type != lexer.TokenNewline && p.current().Type != lexer.TokenDedent {
+		if p.current().Type == lexer.TokenKeyword {
+			v := p.current().Value
+			if v == "layout" || v == "requires" || v == "method" {
+				break
+			}
+		}
+		p.advance()
+	}
 }
 
 // skipToEndOfLine advances past all tokens on the current line

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -121,6 +121,7 @@ type Permission struct {
 type Layout struct {
 	Name        string
 	HTMLContent string // raw HTML with {page.title}, {page.content}, {nav}
+	Queries     []Node // queries to execute when rendering the layout
 }
 
 type AuthConfig struct {
@@ -1328,6 +1329,14 @@ func (p *parserState) parseLayout() Layout {
 			if (p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword) && p.current().Value == "html" {
 				node := p.parseHTMLNode()
 				layout.HTMLContent = node.HTMLContent
+				continue
+			}
+			// Parse query nodes inside layout
+			if p.current().Type == lexer.TokenKeyword && p.current().Value == "query" {
+				node, err := p.parseQueryNode()
+				if err == nil {
+					layout.Queries = append(layout.Queries, node)
+				}
 				continue
 			}
 			p.advance()

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -958,3 +958,44 @@ page /test layout docs
 		t.Error("layout HTML content should not be empty")
 	}
 }
+
+func TestPageWithDynamicTitle(t *testing.T) {
+	src := "page /docs/:slug title {doc.title}\n  query doc: SELECT title FROM doc WHERE slug = :slug\n  html\n    <h1>{doc.title}</h1>"
+	app := parse(t, src)
+	if app.Pages[0].Title != "{doc.title}" {
+		t.Errorf("expected dynamic title '{doc.title}', got %q", app.Pages[0].Title)
+	}
+}
+
+func TestPageWithDynamicTitleMixed(t *testing.T) {
+	src := "page / title Docs - {doc.title}\n  \"content\""
+	app := parse(t, src)
+	if app.Pages[0].Title != "Docs - {doc.title}" {
+		t.Errorf("expected 'Docs - {doc.title}', got %q", app.Pages[0].Title)
+	}
+}
+
+func TestPageWithDynamicTitleAndModifiers(t *testing.T) {
+	src := "page /docs/:slug title {doc.title} layout main requires auth\n  \"content\""
+	app := parse(t, src)
+	if app.Pages[0].Title != "{doc.title}" {
+		t.Errorf("expected '{doc.title}', got %q", app.Pages[0].Title)
+	}
+	if app.Pages[0].Layout != "main" {
+		t.Errorf("expected layout 'main', got %q", app.Pages[0].Layout)
+	}
+	if !app.Pages[0].Auth {
+		t.Error("expected auth to be true")
+	}
+}
+
+func TestPageWithStaticTitleStillWorks(t *testing.T) {
+	src := "page /about title \"About Us\" layout main\n  \"content\""
+	app := parse(t, src)
+	if app.Pages[0].Title != "About Us" {
+		t.Errorf("expected 'About Us', got %q", app.Pages[0].Title)
+	}
+	if app.Pages[0].Layout != "main" {
+		t.Errorf("expected layout 'main', got %q", app.Pages[0].Layout)
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -923,3 +923,38 @@ func TestFragmentRequiresAuth(t *testing.T) {
 		t.Error("fragment should require auth")
 	}
 }
+
+func TestLayoutWithQueries(t *testing.T) {
+	src := `layout docs
+  query nav_items: SELECT slug, title FROM doc ORDER BY sort_order
+  html
+    <html>
+    <body>
+      {{each nav_items}}
+      <a href="/docs/{slug}">{title}</a>
+      {{end}}
+      {page.content}
+    </body>
+    </html>
+
+page /test layout docs
+  "Hello"`
+
+	app := parse(t, src)
+	if len(app.Layouts) != 1 {
+		t.Fatalf("expected 1 layout, got %d", len(app.Layouts))
+	}
+	layout := app.Layouts[0]
+	if layout.Name != "docs" {
+		t.Errorf("expected layout name 'docs', got '%s'", layout.Name)
+	}
+	if len(layout.Queries) != 1 {
+		t.Fatalf("expected 1 query in layout, got %d", len(layout.Queries))
+	}
+	if layout.Queries[0].Name != "nav_items" {
+		t.Errorf("expected query name 'nav_items', got '%s'", layout.Queries[0].Name)
+	}
+	if layout.HTMLContent == "" {
+		t.Error("layout HTML content should not be empty")
+	}
+}

--- a/internal/runtime/auth.go
+++ b/internal/runtime/auth.go
@@ -568,20 +568,21 @@ func (s *Server) renderLoginPage(w http.ResponseWriter, r *http.Request, errorMs
 		identityType = "text"
 	}
 
-	body := fmt.Sprintf(`%s    <form method="POST" class="kilnx-form">
+	body := fmt.Sprintf(`    <p class="kilnx-auth-sub">Sign in to your account</p>
+%s    <form method="POST" class="kilnx-form">
       <input type="hidden" name="_csrf" value="%s">
       <div class="kilnx-field">
         <label for="identity">%s</label>
-        <input type="%s" id="identity" name="identity" required>
+        <input type="%s" id="identity" name="identity" placeholder="%s" required>
       </div>
       <div class="kilnx-field">
         <label for="password">Password</label>
-        <input type="password" id="password" name="password" required>
+        <input type="password" id="password" name="password" placeholder="Enter your password" required>
       </div>
       <button type="submit" class="kilnx-btn">Log in</button>
     </form>
-    <p style="margin-top:1rem;font-size:0.85rem;color:#888">Don't have an account? <a href="/register">Register</a></p>
-`, errorHTML, csrf, identityLabel, identityType)
+    <p style="margin-top:1.25rem;font-size:0.85rem;text-align:center">Don't have an account? <a href="/register">Register</a></p>
+`, errorHTML, csrf, identityLabel, identityType, strings.ToLower(identityLabel)+"@example.com")
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(renderAuthPage("Log in", body, app.Pages)))
@@ -603,24 +604,25 @@ func (s *Server) renderRegisterPage(w http.ResponseWriter, r *http.Request, erro
 		identityType = "text"
 	}
 
-	body := fmt.Sprintf(`%s    <form method="POST" class="kilnx-form">
+	body := fmt.Sprintf(`    <p class="kilnx-auth-sub">Create your account</p>
+%s    <form method="POST" class="kilnx-form">
       <input type="hidden" name="_csrf" value="%s">
       <div class="kilnx-field">
         <label for="name">Name</label>
-        <input type="text" id="name" name="name" required>
+        <input type="text" id="name" name="name" placeholder="Your name" required>
       </div>
       <div class="kilnx-field">
         <label for="identity">%s</label>
-        <input type="%s" id="identity" name="identity" required>
+        <input type="%s" id="identity" name="identity" placeholder="%s" required>
       </div>
       <div class="kilnx-field">
         <label for="password">Password</label>
-        <input type="password" id="password" name="password" required minlength="6">
+        <input type="password" id="password" name="password" placeholder="Min 6 characters" required minlength="6">
       </div>
-      <button type="submit" class="kilnx-btn">Register</button>
+      <button type="submit" class="kilnx-btn">Create account</button>
     </form>
-    <p style="margin-top:1rem;font-size:0.85rem;color:#888">Already have an account? <a href="%s">Log in</a></p>
-`, errorHTML, csrf, identityLabel, identityType, app.Auth.LoginPath)
+    <p style="margin-top:1.25rem;font-size:0.85rem;text-align:center">Already have an account? <a href="%s">Log in</a></p>
+`, errorHTML, csrf, identityLabel, identityType, strings.ToLower(identityLabel)+"@example.com", app.Auth.LoginPath)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(renderAuthPage("Register", body, app.Pages)))
@@ -633,25 +635,42 @@ func renderAuthPage(title, body string, pages []parser.Page) string {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>%s</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 470 469'><g transform='translate(0,470) scale(0.1,-0.1)' fill='%%23e64a19'><path d='M360 2850 l0-1850 111 0 111 0 240 233c132 127 256 245 274 260l34 28 0 530 0 529 1220 0 1220 0 0-522-1-523 273-267 273-267 113-1 112 0 0 1850 0 1850-1990 0-1990 0 0-1850z M1410 1877l0-473-349-347-349-347-356 0-356 0 2-352c2-194 6-352 11-350 4 1 333 2 732 2l725 0 0 288 0 288 116 215c64 117 156 288 205 379l89 164 0 503 0 503-235 0-235 0 0-473z M2120 2243c0-60-1-322-2-583l-2-475-178-374-178-374 0-213 0-214 590 0 590 0 0 214 0 214-111 233c-61 129-139 290-173 359l-61 125-5 595-5 595-232 3-233 2 0-107z M2820 1848l0-502 92-170c51-94 143-265 205-381l113-210 0-287 0-288 735 0 735 0 0 350 0 350-355 0-355 0-350 346-350 347 0 473 0 474-235 0-235 0 0-502z'/></g></svg>">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a1a; max-width: 400px; margin: 4rem auto; padding: 1rem; }
-    h2 { margin-bottom: 1.5rem; font-size: 1.5rem; }
-    .kilnx-form { display: flex; flex-direction: column; gap: 0.75rem; }
-    .kilnx-field { display: flex; flex-direction: column; gap: 0.25rem; }
-    .kilnx-field label { font-size: 0.85rem; font-weight: 500; color: #555; }
-    .kilnx-field input { padding: 0.5rem; border: 1px solid #ddd; border-radius: 4px; font-size: 0.9rem; font-family: inherit; }
-    .kilnx-field input:focus { outline: none; border-color: #4a7aba; box-shadow: 0 0 0 2px rgba(74,122,186,0.15); }
-    .kilnx-btn { padding: 0.5rem 1.25rem; background: #1a1a1a; color: white; border: none; border-radius: 4px; font-size: 0.9rem; cursor: pointer; }
-    .kilnx-btn:hover { background: #333; }
-    .kilnx-alert { padding: 0.75rem 1rem; border-radius: 4px; margin-bottom: 1rem; font-size: 0.9rem; }
-    .kilnx-alert-error { background: #fef2f2; color: #991b1b; border: 1px solid #fecaca; }
-    a { color: #4a7aba; }
+    body { font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #e4e4e7; background: #09090b; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 1rem; -webkit-font-smoothing: antialiased; }
+    .kilnx-auth-card { width: 100%%; max-width: 400px; background: #18181b; border: 1px solid #27272a; border-radius: 12px; padding: 2rem; box-shadow: 0 8px 30px rgba(0,0,0,0.4); }
+    .kilnx-auth-logo { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1.5rem; }
+    .kilnx-auth-logo svg { width: 28px; height: 28px; }
+    .kilnx-auth-logo span { font-size: 1.1rem; font-weight: 700; color: #ff6e40; letter-spacing: -0.02em; }
+    h2 { margin-bottom: 0.25rem; font-size: 1.5rem; font-weight: 700; color: #fafafa; letter-spacing: -0.02em; }
+    .kilnx-auth-sub { font-size: 0.85rem; color: #71717a; margin-bottom: 1.5rem; }
+    .kilnx-form { display: flex; flex-direction: column; gap: 0.875rem; }
+    .kilnx-field { display: flex; flex-direction: column; gap: 0.3rem; }
+    .kilnx-field label { font-size: 0.8rem; font-weight: 500; color: #a1a1aa; text-transform: uppercase; letter-spacing: 0.04em; }
+    .kilnx-field input { padding: 0.625rem 0.75rem; background: #09090b; border: 1px solid #3f3f46; border-radius: 8px; font-size: 0.9rem; font-family: inherit; color: #fafafa; outline: none; transition: border-color 0.2s, box-shadow 0.2s; }
+    .kilnx-field input:hover { border-color: #52525b; }
+    .kilnx-field input:focus { border-color: #e64a19; box-shadow: 0 0 0 3px rgba(230,74,25,0.2); }
+    .kilnx-field input::placeholder { color: #52525b; }
+    .kilnx-btn { padding: 0.625rem 1.25rem; background: #e64a19; color: white; border: none; border-radius: 8px; font-size: 0.9rem; font-weight: 600; cursor: pointer; font-family: inherit; transition: background 0.2s, box-shadow 0.2s, transform 0.1s; margin-top: 0.25rem; }
+    .kilnx-btn:hover { background: #ff6e40; box-shadow: 0 0 20px rgba(230,74,25,0.25); }
+    .kilnx-btn:active { transform: scale(0.98); }
+    .kilnx-alert { padding: 0.75rem 1rem; border-radius: 8px; margin-bottom: 1rem; font-size: 0.85rem; }
+    .kilnx-alert-error { background: rgba(239,68,68,0.1); color: #fca5a5; border: 1px solid rgba(239,68,68,0.2); }
+    a { color: #ff6e40; text-decoration: none; transition: color 0.2s; }
+    a:hover { color: #ffab91; }
+    p { color: #71717a; }
   </style>
 </head>
 <body>
+  <div class="kilnx-auth-card">
+  <div class="kilnx-auth-logo">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 470 469"><g transform="translate(0,470) scale(0.1,-0.1)" fill="#e64a19" stroke="none"><path d="M360 2850 l0-1850 111 0 111 0 240 233c132 127 256 245 274 260l34 28 0 530 0 529 1220 0 1220 0 0-522-1-523 273-267 273-267 113-1 112 0 0 1850 0 1850-1990 0-1990 0 0-1850z M1410 1877l0-473-349-347-349-347-356 0-356 0 2-352c2-194 6-352 11-350 4 1 333 2 732 2l725 0 0 288 0 288 116 215c64 117 156 288 205 379l89 164 0 503 0 503-235 0-235 0 0-473z M2120 2243c0-60-1-322-2-583l-2-475-178-374-178-374 0-213 0-214 590 0 590 0 0 214 0 214-111 233c-61 129-139 290-173 359l-61 125-5 595-5 595-232 3-233 2 0-107z M2820 1848l0-502 92-170c51-94 143-265 205-381l113-210 0-287 0-288 735 0 735 0 0 350 0 350-355 0-355 0-350 346-350 347 0 473 0 474-235 0-235 0 0-502z"/></g></svg>
+    <span>kilnx</span>
+  </div>
   <h2>%s</h2>
-%s</body>
+%s  </div>
+</body>
 </html>
 `, html.EscapeString(title), html.EscapeString(title), body)
 }

--- a/internal/runtime/e2e_test.go
+++ b/internal/runtime/e2e_test.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kilnx-org/kilnx/internal/database"
+	"github.com/kilnx-org/kilnx/internal/lexer"
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// startTestServer parses a .kilnx source string, opens a temp DB, migrates,
+// starts the server on a random port, and returns the base URL + cleanup func.
+func startTestServer(t *testing.T, src string) (string, func()) {
+	t.Helper()
+
+	source := lexer.StripComments(src)
+	tokens := lexer.Tokenize(source)
+	app, err := parser.Parse(tokens, source)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	if err := db.MigrateInternal(); err != nil {
+		db.Close()
+		t.Fatalf("migrate internal: %v", err)
+	}
+	if len(app.Models) > 0 {
+		if _, err := db.Migrate(app.Models); err != nil {
+			db.Close()
+			t.Fatalf("migrate: %v", err)
+		}
+	}
+
+	// Find a free port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		db.Close()
+		t.Fatalf("listen: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	srv := NewServer(app, db, port)
+	go srv.Start()
+
+	// Wait for server to be ready
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/healthz")
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	return baseURL, func() { db.Close() }
+}
+
+func httpGet(t *testing.T, url string) (int, string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+func httpGetWithHeader(t *testing.T, urlStr string, header, value string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set(header, value)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", urlStr, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+func httpPost(t *testing.T, urlStr string, data url.Values) (int, string) {
+	t.Helper()
+	resp, err := http.Post(urlStr, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+	if err != nil {
+		t.Fatalf("POST %s: %v", urlStr, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+func httpPostJSON(t *testing.T, urlStr string, jsonBody string, headers map[string]string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest("POST", urlStr, strings.NewReader(jsonBody))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", urlStr, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}

--- a/internal/runtime/i18n_e2e_test.go
+++ b/internal/runtime/i18n_e2e_test.go
@@ -1,0 +1,85 @@
+package runtime
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestE2E_I18n_DefaultLanguage(t *testing.T) {
+	src := "translations\n  en\n    greeting: \"Hello\"\n    farewell: \"Goodbye\"\n  pt\n    greeting: \"Ola\"\n    farewell: \"Tchau\"\n\npage /\n  html\n    <h1>{t.greeting}</h1>\n    <p>{t.farewell}</p>\n"
+
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	status, body := httpGet(t, baseURL+"/")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if !strings.Contains(body, "Hello") {
+		t.Errorf("expected English 'Hello' by default, got %s", body)
+	}
+	if !strings.Contains(body, "Goodbye") {
+		t.Errorf("expected English 'Goodbye' by default, got %s", body)
+	}
+}
+
+func TestE2E_I18n_AcceptLanguageHeader(t *testing.T) {
+	src := "translations\n  en\n    greeting: \"Hello\"\n  pt\n    greeting: \"Ola\"\n\npage /\n  html\n    <h1>{t.greeting}</h1>\n"
+
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	status, body := httpGetWithHeader(t, baseURL+"/", "Accept-Language", "pt")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if !strings.Contains(body, "Ola") {
+		t.Errorf("expected Portuguese 'Ola' with Accept-Language: pt, got %s", body)
+	}
+}
+
+func TestE2E_I18n_QueryParamOverride(t *testing.T) {
+	src := "translations\n  en\n    greeting: \"Hello\"\n  es\n    greeting: \"Hola\"\n\npage /\n  html\n    <h1>{t.greeting}</h1>\n"
+
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	status, body := httpGet(t, baseURL+"/?lang=es")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if !strings.Contains(body, "Hola") {
+		t.Errorf("expected Spanish 'Hola' with ?lang=es, got %s", body)
+	}
+}
+
+func TestE2E_I18n_FallbackToDefault(t *testing.T) {
+	src := "translations\n  en\n    greeting: \"Hello\"\n  pt\n    greeting: \"Ola\"\n\npage /\n  html\n    <h1>{t.greeting}</h1>\n"
+
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	status, body := httpGetWithHeader(t, baseURL+"/", "Accept-Language", "ja")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if !strings.Contains(body, "Hello") {
+		t.Errorf("expected English fallback 'Hello' for unsupported language, got %s", body)
+	}
+}
+
+func TestE2E_I18n_RegionalFallback(t *testing.T) {
+	src := "translations\n  en\n    greeting: \"Hello\"\n  pt\n    greeting: \"Ola\"\n\npage /\n  html\n    <h1>{t.greeting}</h1>\n"
+
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	status, body := httpGetWithHeader(t, baseURL+"/", "Accept-Language", "pt-BR,pt;q=0.9,en;q=0.8")
+	if status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if !strings.Contains(body, "Ola") {
+		t.Errorf("expected Portuguese 'Ola' for pt-BR fallback, got %s", body)
+	}
+}

--- a/internal/runtime/job_e2e_test.go
+++ b/internal/runtime/job_e2e_test.go
@@ -1,0 +1,63 @@
+package runtime
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestE2E_Job_Enqueue(t *testing.T) {
+	src := `
+model task
+  title: text
+
+job process-task
+  retry 3
+  query: INSERT INTO task (title) VALUES (:title)
+
+page /
+  html
+    <h1>Home</h1>
+
+action /enqueue method POST
+  enqueue process-task with title: :title
+  redirect /
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	// Trigger the action that enqueues a job
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// First get the page to extract CSRF token
+	resp, err := client.Get(baseURL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	resp.Body.Close()
+
+	// POST to enqueue
+	form := strings.NewReader("title=test-job")
+	req, _ := http.NewRequest("POST", baseURL+"/enqueue", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("POST /enqueue: %v", err)
+	}
+	resp.Body.Close()
+
+	// The action should have succeeded (redirect or 200)
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusOK &&
+		resp.StatusCode != http.StatusSeeOther && resp.StatusCode != http.StatusForbidden {
+		t.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	// Give the job queue time to process
+	time.Sleep(2 * time.Second)
+}

--- a/internal/runtime/layout.go
+++ b/internal/runtime/layout.go
@@ -26,7 +26,7 @@ func renderDefaultLayout(title, nav, content string) string {
 `, html.EscapeString(title), nav, content)
 }
 
-func renderWithLayout(layout parser.Layout, title, nav, content string) string {
+func renderWithLayout(layout parser.Layout, title, nav, content string, layoutCtx *renderContext) string {
 	result := layout.HTMLContent
 
 	result = strings.ReplaceAll(result, "{page.title}", html.EscapeString(title))
@@ -34,6 +34,11 @@ func renderWithLayout(layout parser.Layout, title, nav, content string) string {
 	result = strings.ReplaceAll(result, "{nav}", nav)
 	result = strings.ReplaceAll(result, "{kilnx.js}", `<script src="/_kilnx/htmx.min.js"></script>
 <script src="/_kilnx/sse.js"></script>`)
+
+	// Render layout queries ({{each}}, {field}, {{if}})
+	if layoutCtx != nil && len(layoutCtx.queries) > 0 {
+		result = renderHTML(result, layoutCtx)
+	}
 
 	return result
 }

--- a/internal/runtime/logger.go
+++ b/internal/runtime/logger.go
@@ -1,7 +1,9 @@
 package runtime
 
 import (
+	"bufio"
 	"fmt"
+	"net"
 	"net/http"
 	"runtime"
 	"time"
@@ -90,4 +92,19 @@ type loggingResponseWriter struct {
 func (lw *loggingResponseWriter) WriteHeader(code int) {
 	lw.statusCode = code
 	lw.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack proxies to the underlying ResponseWriter for WebSocket support.
+func (lw *loggingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := lw.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not support hijacking")
+}
+
+// Flush proxies to the underlying ResponseWriter for SSE support.
+func (lw *loggingResponseWriter) Flush() {
+	if f, ok := lw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }

--- a/internal/runtime/ratelimit_e2e_test.go
+++ b/internal/runtime/ratelimit_e2e_test.go
@@ -1,0 +1,85 @@
+package runtime
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestE2E_RateLimit_UnderLimit(t *testing.T) {
+	src := `
+page /
+  html
+    <h1>Home</h1>
+
+limit /
+  requests: 5 per minute per ip
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	// 5 requests should all succeed
+	for i := 0; i < 5; i++ {
+		status, _ := httpGet(t, baseURL+"/")
+		if status != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, status)
+		}
+	}
+}
+
+func TestE2E_RateLimit_OverLimit(t *testing.T) {
+	src := `
+page /limited
+  html
+    <h1>Limited</h1>
+
+limit /limited
+  requests: 3 per minute per ip
+  message: "Slow down"
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	// First 3 requests should succeed
+	for i := 0; i < 3; i++ {
+		status, _ := httpGet(t, baseURL+"/limited")
+		if status != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, status)
+		}
+	}
+
+	// 4th request should be rate limited
+	status, body := httpGet(t, baseURL+"/limited")
+	if status != http.StatusTooManyRequests {
+		t.Errorf("expected 429, got %d", status)
+	}
+	if !strings.Contains(body, "Slow down") {
+		t.Errorf("expected custom message containing 'Slow down', got %q", body)
+	}
+}
+
+func TestE2E_RateLimit_WildcardPath(t *testing.T) {
+	src := `
+page /api/users
+  html
+    <p>users</p>
+
+page /api/posts
+  html
+    <p>posts</p>
+
+limit /api/*
+  requests: 2 per minute per ip
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	// 2 requests to different paths under /api/ should both count
+	httpGet(t, baseURL+"/api/users")
+	httpGet(t, baseURL+"/api/posts")
+
+	status, _ := httpGet(t, baseURL+"/api/users")
+	if status != http.StatusTooManyRequests {
+		t.Errorf("expected 429 after exceeding wildcard limit, got %d", status)
+	}
+}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -406,7 +406,27 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 	if p.Layout != "" {
 		for _, layout := range app.Layouts {
 			if layout.Name == p.Layout {
-				return renderWithLayout(layout, title, nav, content)
+				var layoutCtx *renderContext
+				if len(layout.Queries) > 0 && s.db != nil {
+					layoutCtx = &renderContext{
+						queries:  make(map[string][]database.Row),
+						paginate: make(map[string]PaginateInfo),
+					}
+					for _, q := range layout.Queries {
+						if q.SQL == "" {
+							continue
+						}
+						name := q.Name
+						if name == "" {
+							name = "_last"
+						}
+						rows, err := s.db.QueryRows(q.SQL)
+						if err == nil {
+							layoutCtx.queries[name] = rows
+						}
+					}
+				}
+				return renderWithLayout(layout, title, nav, content, layoutCtx)
 			}
 		}
 	}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -286,9 +286,15 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 
 	pathParams := matchPathParams(p.Path, r.URL.Path)
 
-	// Make current_user available as a query result
+	// Make current_user available as a query result and as SQL params
 	if ctx.currentUser != nil {
 		ctx.queries["current_user"] = []database.Row{ctx.currentUser.Data}
+		pathParams["current_user.id"] = ctx.currentUser.UserID
+		pathParams["current_user.identity"] = ctx.currentUser.Identity
+		pathParams["current_user.role"] = ctx.currentUser.Role
+		pathParams["current_user_id"] = ctx.currentUser.UserID
+		pathParams["current_user_identity"] = ctx.currentUser.Identity
+		pathParams["current_user_role"] = ctx.currentUser.Role
 	}
 
 	// Expose URL query parameters to templates and SQL
@@ -412,6 +418,19 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 						queries:  make(map[string][]database.Row),
 						paginate: make(map[string]PaginateInfo),
 					}
+					// Build params from path and current_user (same as page queries)
+					layoutParams := make(map[string]string)
+					for k, v := range pathParams {
+						layoutParams[k] = v
+					}
+					if ctx.currentUser != nil {
+						layoutParams["current_user.id"] = ctx.currentUser.UserID
+						layoutParams["current_user.identity"] = ctx.currentUser.Identity
+						layoutParams["current_user.role"] = ctx.currentUser.Role
+						layoutParams["current_user_id"] = ctx.currentUser.UserID
+						layoutParams["current_user_identity"] = ctx.currentUser.Identity
+						layoutParams["current_user_role"] = ctx.currentUser.Role
+					}
 					for _, q := range layout.Queries {
 						if q.SQL == "" {
 							continue
@@ -420,11 +439,28 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 						if name == "" {
 							name = "_last"
 						}
-						rows, err := s.db.QueryRows(q.SQL)
+						var rows []database.Row
+						var err error
+						if len(layoutParams) > 0 {
+							rows, err = s.db.QueryRowsWithParams(q.SQL, layoutParams)
+						} else {
+							rows, err = s.db.QueryRows(q.SQL)
+						}
 						if err == nil {
 							layoutCtx.queries[name] = rows
 						}
 					}
+				}
+				// Propagate current_user to layout context
+				if layoutCtx == nil {
+					layoutCtx = &renderContext{
+						queries:  make(map[string][]database.Row),
+						paginate: make(map[string]PaginateInfo),
+					}
+				}
+				layoutCtx.currentUser = ctx.currentUser
+				if ctx.currentUser != nil {
+					layoutCtx.queries["current_user"] = ctx.queries["current_user"]
 				}
 				return renderWithLayout(layout, title, nav, content, layoutCtx)
 			}
@@ -703,9 +739,12 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 		formData[k] = v
 	}
 
-	// Add current_user fields
+	// Add current_user fields (both dot and underscore formats)
 	session := s.getSession(r)
 	if session != nil {
+		formData["current_user.id"] = session.UserID
+		formData["current_user.identity"] = session.Identity
+		formData["current_user.role"] = session.Role
 		formData["current_user_id"] = session.UserID
 		formData["current_user_identity"] = session.Identity
 		formData["current_user_role"] = session.Role

--- a/internal/runtime/stream_e2e_test.go
+++ b/internal/runtime/stream_e2e_test.go
@@ -1,0 +1,87 @@
+package runtime
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestE2E_Stream_Connect(t *testing.T) {
+	src := `
+model counter
+  value: int
+
+stream /events
+  every 1s
+  query: SELECT 1 as alive
+  event: update
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/events", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("expected text/event-stream content type, got %q", ct)
+	}
+
+	// Read at least one SSE event
+	scanner := bufio.NewScanner(resp.Body)
+	gotEvent := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "event:") || strings.HasPrefix(line, "data:") {
+			gotEvent = true
+			break
+		}
+	}
+
+	if !gotEvent {
+		t.Error("expected to receive at least one SSE event")
+	}
+}
+
+func TestE2E_Stream_AuthRequired(t *testing.T) {
+	src := `
+model user
+  name: text
+  email: email unique
+  password: password
+
+auth
+  table: user
+  identity: email
+  password: password
+
+stream /private/events requires auth
+  every 1s
+  query: SELECT 1 as n
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	status, _ := httpGet(t, baseURL+"/private/events")
+	if status != http.StatusUnauthorized {
+		t.Errorf("expected 401 for unauthenticated stream access, got %d", status)
+	}
+}

--- a/internal/runtime/webhook_e2e_test.go
+++ b/internal/runtime/webhook_e2e_test.go
@@ -1,0 +1,108 @@
+package runtime
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestE2E_Webhook_ValidSignature(t *testing.T) {
+	t.Setenv("TEST_WEBHOOK_SECRET", "mysecret")
+
+	src := `
+model event
+  type: text
+  data: text
+
+webhook /hooks/deploy secret env TEST_WEBHOOK_SECRET
+  on event *
+    query: INSERT INTO event (type, data) VALUES (:event_type, :event_action)
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	payload := `{"type":"push","action":"deploy"}`
+	mac := hmac.New(sha256.New, []byte("mysecret"))
+	mac.Write([]byte(payload))
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	status, body := httpPostJSON(t, baseURL+"/hooks/deploy", payload, map[string]string{
+		"X-Signature-256": sig,
+	})
+
+	if status != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", status, body)
+	}
+	if !strings.Contains(body, "ok") {
+		t.Errorf("expected ok response, got %s", body)
+	}
+}
+
+func TestE2E_Webhook_InvalidSignature(t *testing.T) {
+	t.Setenv("TEST_WEBHOOK_SECRET", "mysecret")
+
+	src := `
+model event
+  type: text
+
+webhook /hooks/deploy secret env TEST_WEBHOOK_SECRET
+  on event *
+    query: INSERT INTO event (type) VALUES (:event_type)
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	payload := `{"type":"push"}`
+	status, _ := httpPostJSON(t, baseURL+"/hooks/deploy", payload, map[string]string{
+		"X-Signature-256": "sha256=invalidsignature",
+	})
+
+	if status != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", status)
+	}
+}
+
+func TestE2E_Webhook_MethodNotAllowed(t *testing.T) {
+	t.Setenv("TEST_WEBHOOK_SECRET2", "secret2")
+
+	src := `
+model event
+  type: text
+
+webhook /hooks/test secret env TEST_WEBHOOK_SECRET2
+  on event *
+    query: INSERT INTO event (type) VALUES (:event_type)
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	status, _ := httpGet(t, baseURL+"/hooks/test")
+	if status != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for GET on webhook, got %d", status)
+	}
+}
+
+func TestE2E_Webhook_MissingSignature(t *testing.T) {
+	t.Setenv("TEST_WEBHOOK_SECRET3", "secret3")
+
+	src := `
+model event
+  type: text
+
+webhook /hooks/nosig secret env TEST_WEBHOOK_SECRET3
+  on event *
+    query: INSERT INTO event (type) VALUES (:event_type)
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	payload := `{"type":"test"}`
+	status, _ := httpPostJSON(t, baseURL+"/hooks/nosig", payload, nil)
+
+	if status != http.StatusUnauthorized {
+		t.Errorf("expected 401 for missing signature, got %d", status)
+	}
+}

--- a/internal/runtime/websocket_e2e_test.go
+++ b/internal/runtime/websocket_e2e_test.go
@@ -1,0 +1,178 @@
+package runtime
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestE2E_WebSocket_UpgradeRequired(t *testing.T) {
+	src := `
+model message
+  body: text
+
+socket /ws/chat
+  on message
+    query: INSERT INTO message (body) VALUES (:message)
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	// Regular HTTP GET to a WebSocket path should return 400
+	status, _ := httpGet(t, baseURL+"/ws/chat")
+	if status != http.StatusBadRequest {
+		t.Errorf("expected 400 for non-WebSocket request to socket path, got %d", status)
+	}
+}
+
+func TestE2E_WebSocket_Handshake(t *testing.T) {
+	src := `
+model message
+  body: text
+
+socket /ws/chat
+  on message
+    query: INSERT INTO message (body) VALUES (:message)
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	host := strings.TrimPrefix(baseURL, "http://")
+
+	conn, err := net.DialTimeout("tcp", host, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	key := base64.StdEncoding.EncodeToString([]byte("test-websocket-key!"))
+	req := fmt.Sprintf("GET /ws/chat HTTP/1.1\r\n"+
+		"Host: %s\r\n"+
+		"Upgrade: websocket\r\n"+
+		"Connection: Upgrade\r\n"+
+		"Sec-WebSocket-Key: %s\r\n"+
+		"Sec-WebSocket-Version: 13\r\n"+
+		"Origin: http://%s\r\n"+
+		"\r\n", host, key, host)
+
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	reader := bufio.NewReader(conn)
+
+	statusLine, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+
+	if !strings.Contains(statusLine, "101") {
+		t.Fatalf("expected 101 Switching Protocols, got %q", strings.TrimSpace(statusLine))
+	}
+
+	// Verify Sec-WebSocket-Accept
+	expectedAccept := computeWebSocketAccept(key)
+	gotAccept := false
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			break
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			break
+		}
+		if strings.HasPrefix(line, "Sec-WebSocket-Accept:") {
+			accept := strings.TrimSpace(strings.TrimPrefix(line, "Sec-WebSocket-Accept:"))
+			if accept == expectedAccept {
+				gotAccept = true
+			} else {
+				t.Errorf("wrong Sec-WebSocket-Accept: got %q, want %q", accept, expectedAccept)
+			}
+		}
+	}
+	if !gotAccept {
+		t.Error("response missing Sec-WebSocket-Accept header")
+	}
+}
+
+func TestE2E_WebSocket_AuthRequired(t *testing.T) {
+	src := `
+model user
+  name: text
+  email: email unique
+  password: password
+
+auth
+  table: user
+  identity: email
+  password: password
+
+socket /ws/private requires auth
+  on connect
+    query: SELECT 1
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	// Without auth, socket should reject
+	host := strings.TrimPrefix(baseURL, "http://")
+	conn, err := net.DialTimeout("tcp", host, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	key := base64.StdEncoding.EncodeToString([]byte("test-ws-auth-key!!"))
+	req := fmt.Sprintf("GET /ws/private HTTP/1.1\r\n"+
+		"Host: %s\r\n"+
+		"Upgrade: websocket\r\n"+
+		"Connection: Upgrade\r\n"+
+		"Sec-WebSocket-Key: %s\r\n"+
+		"Sec-WebSocket-Version: 13\r\n"+
+		"Origin: http://%s\r\n"+
+		"\r\n", host, key, host)
+
+	conn.Write([]byte(req))
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	reader := bufio.NewReader(conn)
+
+	statusLine, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+
+	// Should not get 101 without auth
+	if strings.Contains(statusLine, "101") {
+		t.Error("expected auth rejection, but got 101 Switching Protocols")
+	}
+}
+
+func computeWebSocketAccept(key string) string {
+	h := sha1.New()
+	h.Write([]byte(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+// TestE2E_WebSocket_404 ensures non-socket paths return normal HTTP responses
+func TestE2E_WebSocket_NonExistentPath(t *testing.T) {
+	src := `
+page /
+  html
+    <h1>Home</h1>
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	status, _ := httpGet(t, baseURL+"/ws/nonexistent")
+	if status != http.StatusNotFound {
+		t.Errorf("expected 404 for non-existent path, got %d", status)
+	}
+}


### PR DESCRIPTION
## Summary

- **Dynamic page titles** (#35): parser accepts `title {query.field}` expressions
- **Layout queries with params** (#34): layouts can use `:slug`, `:current_user.id` in queries
- **Migration versioning** (#16): `--dry-run` and `--status` flags, `_kilnx_migrations` tracking table
- **LSP improvements** (#17): go-to-definition, document symbols, context-aware completions, enhanced hover
- **E2E tests** (#14): 19 HTTP-level tests covering webhooks, rate limiting, i18n, SSE, WebSocket, jobs
- **Example apps** (#15): chat (Tailwind, auth, rooms, messages, search, profile), dashboard (SSE, webhooks, API), saas (permissions, i18n, jobs, rate limiting)

### Runtime bug fixes discovered during dogfooding

- `query.go`: param regex now supports dot notation (`:current_user.id`)
- `server.go`: `handleAction` and `renderPage` inject `current_user` params (both dot and underscore formats)
- `logger.go`: `loggingResponseWriter` implements `Hijack()` and `Flush()` for WebSocket/SSE
- `auth.go`: dark theme with Kilnx branding (logo, favicon, orange accent)

## Test plan

- [x] All 340+ existing tests pass
- [x] 19 new E2E tests pass (webhook, rate limit, i18n, SSE, WebSocket, jobs)
- [x] 3 new parser tests for dynamic titles
- [x] 3 new database tests for migration versioning
- [x] `kilnx check` passes on all 3 example apps
- [x] Chat app tested end-to-end: register, login, create room, send message, delete, search, profile