### PR TITLE
feat: serve static files directory (closes #41)

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -47,6 +47,7 @@ type AppConfig struct {
 	Database        string   // env var or default path
 	Port            int      // server port (default 8080)
 	Secret          string   // env var for session secret
+	StaticDir       string   // static files directory (served at /_static/)
 	UploadsDir      string   // upload directory
 	UploadsMaxMB    int      // max upload size in MB
 	DefaultLanguage string   // default i18n language
@@ -2536,6 +2537,8 @@ func (p *parserState) parseConfig() AppConfig {
 					fmt.Fprintf(os.Stderr, "kilnx: config secret is required but not set\n")
 					os.Exit(1)
 				}
+			case "static":
+				cfg.StaticDir = strings.Trim(rawVal, "\"' ")
 			case "uploads":
 				parts := strings.Fields(rawVal)
 				if len(parts) > 0 {

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -105,18 +106,23 @@ func (s *Server) Start() error {
 	}
 	mux.Handle("/_uploads/", http.StripPrefix("/_uploads/", http.FileServer(http.Dir(uploadsDir))))
 
-	// Serve static files directory
+	// Serve static files directory (validated to prevent path traversal)
 	staticDir := "static"
 	if s.app.Config != nil && s.app.Config.StaticDir != "" {
 		staticDir = s.app.Config.StaticDir
 	}
-	if info, err := os.Stat(staticDir); err == nil && info.IsDir() {
-		fileServer := http.FileServer(http.Dir(staticDir))
-		mux.Handle("/_static/", http.StripPrefix("/_static/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Cache-Control", "public, max-age=3600")
-			fileServer.ServeHTTP(w, r)
-		})))
-		fmt.Printf("Serving static files from %s at /_static/\n", staticDir)
+	if absStatic, err := filepath.Abs(staticDir); err == nil {
+		cwd, _ := os.Getwd()
+		if strings.HasPrefix(absStatic, cwd) {
+			if info, err := os.Stat(absStatic); err == nil && info.IsDir() {
+				fileServer := http.FileServer(http.Dir(absStatic))
+				mux.Handle("/_static/", http.StripPrefix("/_static/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Cache-Control", "public, max-age=3600")
+					fileServer.ServeHTTP(w, r)
+				})))
+				fmt.Printf("Serving static files from %s at /_static/\n", staticDir)
+			}
+		}
 	}
 
 	// Health check for PaaS platforms and load balancers (GET only)

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -105,6 +105,20 @@ func (s *Server) Start() error {
 	}
 	mux.Handle("/_uploads/", http.StripPrefix("/_uploads/", http.FileServer(http.Dir(uploadsDir))))
 
+	// Serve static files directory
+	staticDir := "static"
+	if s.app.Config != nil && s.app.Config.StaticDir != "" {
+		staticDir = s.app.Config.StaticDir
+	}
+	if info, err := os.Stat(staticDir); err == nil && info.IsDir() {
+		fileServer := http.FileServer(http.Dir(staticDir))
+		mux.Handle("/_static/", http.StripPrefix("/_static/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Cache-Control", "public, max-age=3600")
+			fileServer.ServeHTTP(w, r)
+		})))
+		fmt.Printf("Serving static files from %s at /_static/\n", staticDir)
+	}
+
 	// Health check for PaaS platforms and load balancers (GET only)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

Serves a `static/` directory at `/_static/` with cache headers. Configurable path via `config static:`. If the directory does not exist, no route is registered.

```kilnx
config
  static: ./assets

page /
  html
    <link rel="stylesheet" href="/_static/style.css">
    <script src="/_static/app.js"></script>
```

## Test plan
- [x] All tests pass
- [x] CSS and JS served correctly from static directory
- [x] No route registered when directory absent
- [x] Custom path via config works