### PR TITLE
feat: multi-file support with import (closes #20)

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -352,14 +352,64 @@ func cmdTest(filename string) error {
 }
 
 func loadApp(filename string) (*parser.App, error) {
-	raw, err := os.ReadFile(filename)
+	source, err := resolveImports(filename, nil)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", filename, err)
+		return nil, err
 	}
 
-	source := lexer.StripComments(string(raw))
+	source = lexer.StripComments(source)
 	tokens := lexer.Tokenize(source)
 	return parser.Parse(tokens, source)
+}
+
+// resolveImports reads a .kilnx file and recursively resolves import statements.
+// Import syntax: import "path/to/file.kilnx"
+// Paths are relative to the importing file's directory.
+// Circular imports are detected via the seen map.
+func resolveImports(filename string, seen map[string]bool) (string, error) {
+	absPath, err := filepath.Abs(filename)
+	if err != nil {
+		return "", fmt.Errorf("resolving path %s: %w", filename, err)
+	}
+
+	if seen == nil {
+		seen = make(map[string]bool)
+	}
+	if seen[absPath] {
+		return "", fmt.Errorf("circular import detected: %s", filename)
+	}
+	seen[absPath] = true
+
+	raw, err := os.ReadFile(filename)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", filename, err)
+	}
+
+	baseDir := filepath.Dir(filename)
+	var result strings.Builder
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "import ") {
+			// Extract path: import "file.kilnx" or import file.kilnx
+			importPath := strings.TrimPrefix(trimmed, "import ")
+			importPath = strings.Trim(importPath, "\"' ")
+			if importPath == "" {
+				continue
+			}
+			resolved := filepath.Join(baseDir, importPath)
+			imported, err := resolveImports(resolved, seen)
+			if err != nil {
+				return "", fmt.Errorf("importing %s from %s: %w", importPath, filename, err)
+			}
+			result.WriteString(imported)
+			result.WriteString("\n")
+		} else {
+			result.WriteString(line)
+			result.WriteString("\n")
+		}
+	}
+
+	return result.String(), nil
 }
 
 func dbPathFor(kilnxFile string) string {

--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -352,7 +352,12 @@ func cmdTest(filename string) error {
 }
 
 func loadApp(filename string) (*parser.App, error) {
-	source, err := resolveImports(filename, nil)
+	absEntry, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, fmt.Errorf("resolving path %s: %w", filename, err)
+	}
+	projectRoot := filepath.Dir(absEntry)
+	source, err := resolveImports(absEntry, projectRoot, nil, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -362,44 +367,56 @@ func loadApp(filename string) (*parser.App, error) {
 	return parser.Parse(tokens, source)
 }
 
+const maxImportDepth = 64
+
 // resolveImports reads a .kilnx file and recursively resolves import statements.
 // Import syntax: import "path/to/file.kilnx"
 // Paths are relative to the importing file's directory.
-// Circular imports are detected via the seen map.
-func resolveImports(filename string, seen map[string]bool) (string, error) {
-	absPath, err := filepath.Abs(filename)
-	if err != nil {
-		return "", fmt.Errorf("resolving path %s: %w", filename, err)
+// Security: imported files must have .kilnx extension and stay within projectRoot.
+// Circular imports are detected via the seen map. Depth is limited to 64 levels.
+func resolveImports(absPath, projectRoot string, seen map[string]bool, depth int) (string, error) {
+	if depth > maxImportDepth {
+		return "", fmt.Errorf("import depth exceeds %d levels", maxImportDepth)
 	}
 
 	if seen == nil {
 		seen = make(map[string]bool)
 	}
 	if seen[absPath] {
-		return "", fmt.Errorf("circular import detected: %s", filename)
+		return "", fmt.Errorf("circular import detected: %s", absPath)
 	}
 	seen[absPath] = true
 
-	raw, err := os.ReadFile(filename)
+	raw, err := os.ReadFile(absPath)
 	if err != nil {
-		return "", fmt.Errorf("reading %s: %w", filename, err)
+		return "", fmt.Errorf("reading %s: %w", absPath, err)
 	}
 
-	baseDir := filepath.Dir(filename)
+	baseDir := filepath.Dir(absPath)
 	var result strings.Builder
 	for _, line := range strings.Split(string(raw), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "import ") {
-			// Extract path: import "file.kilnx" or import file.kilnx
 			importPath := strings.TrimPrefix(trimmed, "import ")
 			importPath = strings.Trim(importPath, "\"' ")
 			if importPath == "" {
 				continue
 			}
-			resolved := filepath.Join(baseDir, importPath)
-			imported, err := resolveImports(resolved, seen)
+			// Enforce .kilnx extension
+			if !strings.HasSuffix(importPath, ".kilnx") {
+				return "", fmt.Errorf("import must be a .kilnx file: %s", importPath)
+			}
+			resolved, err := filepath.Abs(filepath.Join(baseDir, importPath))
 			if err != nil {
-				return "", fmt.Errorf("importing %s from %s: %w", importPath, filename, err)
+				return "", fmt.Errorf("resolving import path %s: %w", importPath, err)
+			}
+			// Prevent path traversal outside project root
+			if !strings.HasPrefix(resolved, projectRoot+string(filepath.Separator)) && resolved != projectRoot {
+				return "", fmt.Errorf("import escapes project directory: %s", importPath)
+			}
+			imported, err := resolveImports(resolved, projectRoot, seen, depth+1)
+			if err != nil {
+				return "", fmt.Errorf("importing %s: %w", importPath, err)
 			}
 			result.WriteString(imported)
 			result.WriteString("\n")


### PR DESCRIPTION
## Summary

Adds `import` statement for splitting apps across multiple `.kilnx` files:

```kilnx
import "models.kilnx"
import "pages/chat.kilnx"

page / requires auth
  html
    <h1>Home</h1>
```

### Behavior
- Paths resolved relative to the importing file
- Circular imports detected and reported
- Text-level inclusion before lexing/parsing
- Single-file apps continue to work unchanged
- Works with `run`, `check`, `build`, `test`, `migrate`

### Example structure
```
my-app/
  app.kilnx              # config + imports
  models.kilnx            # model definitions
  auth.kilnx              # auth config
  pages/
    dashboard.kilnx       # dashboard page
    settings.kilnx        # settings page
```

## Test plan
- [x] All tests pass
- [x] Multi-file app with 3 files: check passes, models and auth resolved correctly
- [x] Circular import detected with clear error message
- [x] Single-file apps unaffected