### PR TITLE
fix: SQL NULL rendered as truthy (closes #44)

### DIFF
--- a/internal/database/query.go
+++ b/internal/database/query.go
@@ -39,7 +39,11 @@ func (db *DB) QueryRows(sql string) ([]Row, error) {
 
 		row := make(Row)
 		for i, col := range columns {
-			row[col] = fmt.Sprintf("%v", values[i])
+			if values[i] == nil {
+				row[col] = ""
+			} else {
+				row[col] = fmt.Sprintf("%v", values[i])
+			}
 		}
 		results = append(results, row)
 	}


### PR DESCRIPTION
## Bug

`fmt.Sprintf("%v", nil)` returns the string `"<nil>"` which template conditionals treat as truthy. Any nullable column (like `edited_at`, `attachment`) would always pass `{{if field}}` checks even when NULL.

## Fix

Check for `nil` before formatting and convert to empty string `""`.

## Impact

Any app using `{{if nullable_field}}` was affected. The chat example showed "(edited)" on every message even when never edited.

## Test plan

- [x] All tests pass
- [x] Verified: NULL column correctly treated as falsy in `{{if}}`
- [x] Non-NULL values still render correctly