### PR TITLE
feat: automate Homebrew tap updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,18 @@ release:
   prerelease: auto
   name_template: "v{{ .Version }}"
 
+brews:
+  - repository:
+      owner: kilnx-org
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://kilnx.org"
+    description: "Declarative backend language for the htmx era"
+    license: "MIT"
+    test: |
+      system "#{bin}/kilnx", "version"
+
 changelog:
   use: github
   filters:

--- a/README.md
+++ b/README.md
@@ -72,10 +72,14 @@ This gives you: registration, login with bcrypt, sessions, CSRF, paginated searc
 ## Quick Start
 
 ```bash
+# macOS / Linux
+brew install kilnx-org/tap/kilnx
+
+# or via shell script
 curl -fsSL https://raw.githubusercontent.com/kilnx-org/kilnx/main/install.sh | sh
 ```
 
-Or with Go:
+Or build from source:
 
 ```bash
 git clone https://github.com/kilnx-org/kilnx.git
@@ -100,6 +104,14 @@ kilnx build app.kilnx -o myapp
 scp myapp server:~/
 ssh server './myapp'
 ```
+
+## Editor Support
+
+[VS Code extension](https://github.com/kilnx-org/vscode-kilnx) with syntax highlighting, diagnostics, completions, hover docs, and go-to-definition via the built-in LSP server.
+
+## Try It Online
+
+[kilnx.org/playground](https://kilnx.org/playground.html)
 
 ## What It Covers
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ ssh server './myapp'
 
 ## Editor Support
 
-[VS Code extension](https://github.com/kilnx-org/vscode-kilnx) with syntax highlighting, diagnostics, completions, hover docs, and go-to-definition via the built-in LSP server.
+[VS Code extension](https://marketplace.visualstudio.com/items?itemName=atoolz.kilnx-vscode-toolkit) with syntax highlighting, diagnostics, completions, hover docs, and go-to-definition via the built-in LSP server.
 
 ## Try It Online
 


### PR DESCRIPTION
## Summary
- Adds `brews` section to `.goreleaser.yml` to auto-update `kilnx-org/homebrew-tap` on each tagged release
- Adds `HOMEBREW_TAP_GITHUB_TOKEN` env to the release workflow

## Setup required
Create a GitHub PAT with `repo` scope and add it as `HOMEBREW_TAP_GITHUB_TOKEN` secret in this repo's settings.

## Install command (already live)
```bash
brew install kilnx-org/tap/kilnx
```

## Test plan
- [ ] Add `HOMEBREW_TAP_GITHUB_TOKEN` secret to repo settings
- [ ] Tag a new release and verify formula is auto-updated in `homebrew-tap`