### PR TITLE
feat: tenant modifier for multi-tenant scoping (refs #48)

### DIFF
--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -86,10 +86,32 @@ rewrites `SELECT` queries against a tenant-scoped table to include
 `WHERE <table>.<tenant>_id = :current_user.<tenant>_id`. When the query
 already has a `WHERE`, the tenant predicate is joined with `AND`.
 
-Mutations (`INSERT`, `UPDATE`, `DELETE`) are not rewritten automatically:
-you must still include the tenant column explicitly so intent stays visible,
-e.g. `INSERT INTO quote (org_id, number) VALUES (:current_user.org_id, :n)`.
-A compile-time warning on unchecked mutations is planned.
+The rewriter **fails closed**: if the SQL shape is too complex for the
+built-in rewriter to verify (CTEs, JOINs, subqueries, UNION, comments,
+schema-qualified tables, multi-statement queries), the query is refused
+at runtime rather than silently passing through unscoped. Refactor the
+query into a simpler single-table SELECT or bind the tenant predicate
+yourself with `WHERE ... AND <col> = :current_user.<tenant>_id` and the
+rewriter will see it.
+
+Mutations (`INSERT`, `UPDATE`, `DELETE`) on a tenant-scoped table must
+bind the tenant column textually; otherwise the runtime rejects them.
+Example that passes:
+
+```kilnx
+action /quotes/create method POST requires auth
+  query: INSERT INTO quote (org_id, number)
+         VALUES (:current_user.org_id, :n)
+```
+
+The parser synthesizes the `<tenant>_id` column automatically, and
+`kilnx check` flags references to undefined tenant models and models
+that set themselves as their own tenant.
+
+This is defense in depth, not a substitute for application-level
+authorization. The rewriter closes the "forgot the tenant predicate"
+failure mode; other access-control concerns remain the developer's
+responsibility.
 
 ### permissions
 

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -60,6 +60,37 @@ model comment
   created: timestamp auto
 ```
 
+#### tenant scoping
+
+A model can declare that its rows belong to a tenant (another model) with
+the `tenant:` directive. The directive must appear before any field.
+
+```kilnx
+model org
+  name: text required unique
+
+model user
+  tenant: org
+  email: email unique
+  password: password required
+
+model quote
+  tenant: org
+  number: text required unique
+  total: float default 0
+```
+
+The compiler auto-synthesizes a required reference field for the tenant
+(so `tenant: org` adds an `org_id` foreign key column) and the runtime
+rewrites `SELECT` queries against a tenant-scoped table to include
+`WHERE <table>.<tenant>_id = :current_user.<tenant>_id`. When the query
+already has a `WHERE`, the tenant predicate is joined with `AND`.
+
+Mutations (`INSERT`, `UPDATE`, `DELETE`) are not rewritten automatically:
+you must still include the tenant column explicitly so intent stays visible,
+e.g. `INSERT INTO quote (org_id, number) VALUES (:current_user.org_id, :n)`.
+A compile-time warning on unchecked mutations is planned.
+
 ### permissions
 
 Access rules by role.

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -83,11 +83,40 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkModelMinMax(app.Models)...)
 	diags = append(diags, checkAuthRef(app, schema)...)
 	diags = append(diags, checkModelRefs(app, schema)...)
+	diags = append(diags, checkTenantRefs(app, schema)...)
 	diags = append(diags, checkAllSQL(app, schema)...)
 	diags = append(diags, checkSecurity(app, schema)...)
 	diags = append(diags, checkTemplateInterpolations(app, schema)...)
 	diags = append(diags, checkTableColumnRefs(app, schema)...)
 
+	return diags
+}
+
+// checkTenantRefs makes sure every `tenant: <model>` directive points
+// at an actual model in the app, and that a model does not set itself
+// as its own tenant.
+func checkTenantRefs(app *parser.App, schema *Schema) []Diagnostic {
+	var diags []Diagnostic
+	for _, m := range app.Models {
+		if m.Tenant == "" {
+			continue
+		}
+		if m.Tenant == m.Name {
+			diags = append(diags, Diagnostic{
+				Level:   "error",
+				Message: fmt.Sprintf("model '%s' cannot be its own tenant", m.Name),
+				Context: "model " + m.Name,
+			})
+			continue
+		}
+		if _, ok := schema.Tables[m.Tenant]; !ok {
+			diags = append(diags, Diagnostic{
+				Level:   "error",
+				Message: fmt.Sprintf("model '%s' declares tenant '%s' which is not a defined model", m.Name, m.Tenant),
+				Context: "model " + m.Name,
+			})
+		}
+	}
 	return diags
 }
 

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -224,6 +224,43 @@ func TestExtractSelectColumns(t *testing.T) {
 	}
 }
 
+func TestAnalyze_TenantRefUnknownModel(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "quote", Tenant: "ogr", // typo, no such model
+				Fields: []parser.Field{{Name: "ogr", Type: parser.FieldReference, Reference: "ogr", Required: true}}},
+		},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "tenant 'ogr'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected error for unknown tenant model, got: %+v", diags)
+	}
+}
+
+func TestAnalyze_TenantRefSelf(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "quote", Tenant: "quote"},
+		},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "own tenant") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected self-tenant error, got: %+v", diags)
+	}
+}
+
 func TestAnalyze_ValidApp(t *testing.T) {
 	app := &parser.App{
 		Models: []parser.Model{

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -134,7 +134,13 @@ type AuthConfig struct {
 }
 
 type Model struct {
-	Name   string
+	Name string
+	// Tenant references another model. Rows of this model are scoped to
+	// that tenant. The compiler auto-synthesizes a required reference
+	// field named after the tenant model (e.g. `tenant: org` adds an
+	// `org_id` column) and the runtime injects a WHERE filter on SELECT
+	// queries against this table.
+	Tenant string
 	Fields []Field
 }
 
@@ -533,6 +539,32 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 			continue
 		}
 
+		// tenant: <model> is a model-level meta directive, not a field.
+		// Must appear before any field declaration.
+		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) &&
+			tok.Value == "tenant" && p.peekIsTenantDirective() {
+			tenantModel, err := p.parseTenantDirective()
+			if err != nil {
+				return model, err
+			}
+			if model.Tenant != "" {
+				return model, fmt.Errorf("line %d: model '%s' already has a tenant directive", tok.Line, model.Name)
+			}
+			if len(model.Fields) > 0 {
+				return model, fmt.Errorf("line %d: tenant directive must appear before field declarations in model '%s'", tok.Line, model.Name)
+			}
+			model.Tenant = tenantModel
+			// Auto-synthesize a required reference field so the schema
+			// generates the <tenant>_id foreign key column.
+			model.Fields = append(model.Fields, Field{
+				Name:      tenantModel,
+				Type:      FieldReference,
+				Reference: tenantModel,
+				Required:  true,
+			})
+			continue
+		}
+
 		// Field names can be keywords (e.g., "title", "query") when used inside a model
 		if tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword {
 			field, err := p.parseField(app)
@@ -547,6 +579,39 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 	}
 
 	return model, nil
+}
+
+// peekIsTenantDirective returns true if the tokens at the current position
+// match the pattern `tenant : <identifier>` (the meta directive), so we can
+// distinguish it from a regular field named "tenant".
+func (p *parserState) peekIsTenantDirective() bool {
+	if p.pos+2 >= len(p.tokens) {
+		return false
+	}
+	if p.tokens[p.pos+1].Type != lexer.TokenColon {
+		return false
+	}
+	third := p.tokens[p.pos+2]
+	if third.Type != lexer.TokenIdentifier && third.Type != lexer.TokenKeyword {
+		return false
+	}
+	// A regular field like `tenant: text required` would have a built-in
+	// field type here. Only treat as directive when the third token is a
+	// model-name identifier (not a built-in type).
+	return !lexer.IsFieldType(third.Value)
+}
+
+// parseTenantDirective parses `tenant: <model>` and returns the referenced
+// model name. Caller has already verified with peekIsTenantDirective.
+func (p *parserState) parseTenantDirective() (string, error) {
+	p.advance() // consume 'tenant'
+	p.advance() // consume ':'
+	name := p.advance().Value
+	// Consume to end of line (trailing garbage ignored, keeps grammar forgiving).
+	for !p.isEOF() && p.current().Type != lexer.TokenNewline && p.current().Type != lexer.TokenDedent {
+		p.advance()
+	}
+	return name, nil
 }
 
 func (p *parserState) parseField(app *App) (Field, error) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -193,6 +193,73 @@ func TestModelReferenceField(t *testing.T) {
 	}
 }
 
+func TestModelTenantDirective(t *testing.T) {
+	src := `model quote
+  tenant: org
+  number: text required
+  total: float default 0`
+
+	app := parse(t, src)
+	if len(app.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(app.Models))
+	}
+	m := app.Models[0]
+	if m.Name != "quote" {
+		t.Errorf("expected model name 'quote', got %q", m.Name)
+	}
+	if m.Tenant != "org" {
+		t.Errorf("expected Tenant 'org', got %q", m.Tenant)
+	}
+	// Expect auto-synthesized tenant FK field first, then declared fields.
+	if len(m.Fields) != 3 {
+		t.Fatalf("expected 3 fields (auto + 2 declared), got %d", len(m.Fields))
+	}
+	auto := m.Fields[0]
+	if auto.Name != "org" || auto.Type != FieldReference || auto.Reference != "org" || !auto.Required {
+		t.Errorf("expected auto-synthesized org reference (required), got %+v", auto)
+	}
+	if m.Fields[1].Name != "number" || m.Fields[2].Name != "total" {
+		t.Errorf("declared fields out of order: %+v %+v", m.Fields[1], m.Fields[2])
+	}
+}
+
+func TestModelTenantFieldStillWorksWithBuiltinType(t *testing.T) {
+	// A field literally named "tenant" with a built-in type is NOT a
+	// directive. It stays a regular field (escape hatch so users can have
+	// a column called tenant if they want).
+	src := `model agreement
+  tenant: text required`
+
+	app := parse(t, src)
+	m := app.Models[0]
+	if m.Tenant != "" {
+		t.Errorf("expected no tenant directive, got %q", m.Tenant)
+	}
+	if len(m.Fields) != 1 || m.Fields[0].Name != "tenant" || m.Fields[0].Type != FieldText {
+		t.Fatalf("expected regular 'tenant: text' field, got %+v", m.Fields)
+	}
+}
+
+func TestModelTenantDirectiveRejectsDuplicate(t *testing.T) {
+	src := `model quote
+  tenant: org
+  tenant: account`
+	_, err := parseAllowErrors(t, src)
+	if err == nil || !strings.Contains(err.Error(), "already has a tenant directive") {
+		t.Fatalf("expected duplicate tenant error, got %v", err)
+	}
+}
+
+func TestModelTenantDirectiveMustComeFirst(t *testing.T) {
+	src := `model quote
+  number: text required
+  tenant: org`
+	_, err := parseAllowErrors(t, src)
+	if err == nil || !strings.Contains(err.Error(), "must appear before field declarations") {
+		t.Fatalf("expected ordering error, got %v", err)
+	}
+}
+
 func TestAuthBlock(t *testing.T) {
 	src := `auth
   table: account

--- a/internal/runtime/api.go
+++ b/internal/runtime/api.go
@@ -124,7 +124,7 @@ func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request, endpoint pars
 
 			sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, pathParams)
 			if tErr != nil {
-				s.logger.LogError("tenant guard rejected api query", tErr)
+				s.logger.LogSecurity("tenant guard rejected api query", tErr)
 				writeJSON(w, http.StatusForbidden, map[string]string{
 					"error": "query rejected by tenant policy",
 				})

--- a/internal/runtime/api.go
+++ b/internal/runtime/api.go
@@ -127,7 +127,7 @@ func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request, endpoint pars
 				continue
 			}
 
-			sql := node.SQL
+			sql := RewriteTenantSQL(node.SQL, s.tenants)
 
 			// Handle pagination
 			if node.Paginate > 0 {

--- a/internal/runtime/api.go
+++ b/internal/runtime/api.go
@@ -54,14 +54,9 @@ func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request, endpoint pars
 		for k, v := range formData {
 			pathParams[k] = v
 		}
-		// Add current_user fields
-		session := s.getSession(r)
-		if session != nil {
-			pathParams["current_user_id"] = session.UserID
-			pathParams["current_user_identity"] = session.Identity
-			pathParams["current_user_role"] = session.Role
-		}
 	}
+	// Add current_user fields (available for every method, needed by tenant guard)
+	s.populateCurrentUserParams(pathParams, s.getSession(r))
 
 	pageNum := 1
 	if pg, ok := pathParams["page"]; ok {
@@ -127,7 +122,14 @@ func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request, endpoint pars
 				continue
 			}
 
-			sql := RewriteTenantSQL(node.SQL, s.tenants)
+			sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, pathParams)
+			if tErr != nil {
+				s.logger.LogError("tenant guard rejected api query", tErr)
+				writeJSON(w, http.StatusForbidden, map[string]string{
+					"error": "query rejected by tenant policy",
+				})
+				return
+			}
 
 			// Handle pagination
 			if node.Paginate > 0 {

--- a/internal/runtime/logger.go
+++ b/internal/runtime/logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"runtime"
 	"time"
 
@@ -49,6 +50,16 @@ func (l *Logger) LogSlowQuery(sql string, duration time.Duration) {
 			duration.Round(time.Millisecond),
 			truncateSQL(sql))
 	}
+}
+
+// LogSecurity always emits a security-relevant event regardless of the
+// user's `log.errors` config. Routed to stderr so operators never lose
+// the signal that a tenant guard, CSRF check, or similar invariant
+// fired. Nil-tolerant for tests.
+func (l *Logger) LogSecurity(msg string, err error) {
+	line := fmt.Sprintf("[%s] SECURITY: %s: %v\n",
+		time.Now().Format("15:04:05"), msg, err)
+	_, _ = os.Stderr.WriteString(line)
 }
 
 // LogError logs an error, optionally with a goroutine stack trace.

--- a/internal/runtime/logger.go
+++ b/internal/runtime/logger.go
@@ -51,9 +51,10 @@ func (l *Logger) LogSlowQuery(sql string, duration time.Duration) {
 	}
 }
 
-// LogError logs an error, optionally with a goroutine stack trace
+// LogError logs an error, optionally with a goroutine stack trace.
+// Nil-tolerant: tests and early-boot paths may hold a nil Logger.
 func (l *Logger) LogError(msg string, err error) {
-	if !l.config.LogErrors {
+	if l == nil || !l.config.LogErrors {
 		return
 	}
 	fmt.Printf("[%s] ERROR: %s: %v\n",

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -377,7 +377,7 @@ func (s *Server) executeNodes(nodes []parser.Node, params map[string]string) err
 			// escape hatch guarded by role checks.
 			sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, params)
 			if tErr != nil {
-				s.logger.LogError("tenant guard rejected scheduled query", tErr)
+				s.logger.LogSecurity("tenant guard rejected scheduled query", tErr)
 				return fmt.Errorf("tenant guard: %w", tErr)
 			}
 
@@ -426,7 +426,7 @@ func (s *Server) executeNodes(nodes []parser.Node, params map[string]string) err
 			if toQuery, ok := node.Props["to_query"]; ok && toQuery != "" && s.db != nil {
 				scopedQuery, tErr := RewriteTenantSQL(toQuery, s.tenants, params)
 				if tErr != nil {
-					s.logger.LogError("tenant guard rejected recipient query", tErr)
+					s.logger.LogSecurity("tenant guard rejected recipient query", tErr)
 				} else {
 					rows, err := s.db.QueryRowsWithParams(scopedQuery, params)
 					if err == nil && len(rows) > 0 {

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -370,14 +370,23 @@ func (s *Server) executeNodes(nodes []parser.Node, params map[string]string) err
 				continue
 			}
 
-			sql := node.SQL
+			// Schedules and jobs run without a logged-in user. If the SQL
+			// touches a tenant-scoped table the rewriter will refuse it;
+			// that is intentional. Developers wanting to operate across
+			// tenants in batch jobs must use the (forthcoming) unscoped
+			// escape hatch guarded by role checks.
+			sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, params)
+			if tErr != nil {
+				s.logger.LogError("tenant guard rejected scheduled query", tErr)
+				return fmt.Errorf("tenant guard: %w", tErr)
+			}
 
 			// Check if it's a SELECT or a mutation
 			trimmed := strings.TrimSpace(strings.ToUpper(sql))
 			if strings.HasPrefix(trimmed, "SELECT") {
 				rows, err := s.db.QueryRowsWithParams(sql, params)
 				if err != nil {
-					fmt.Printf("  schedule/job query error: %v\n", err)
+					s.logger.LogError("schedule/job query error", err)
 					return fmt.Errorf("query error: %w", err)
 				}
 				name := node.Name
@@ -388,7 +397,7 @@ func (s *Server) executeNodes(nodes []parser.Node, params map[string]string) err
 			} else {
 				err := s.db.ExecWithParams(sql, params)
 				if err != nil {
-					fmt.Printf("  schedule/job exec error: %v\n", err)
+					s.logger.LogError("schedule/job exec error", err)
 					return fmt.Errorf("exec error: %w", err)
 				}
 			}
@@ -415,11 +424,16 @@ func (s *Server) executeNodes(nodes []parser.Node, params map[string]string) err
 			recipient := resolveEmailRecipient(node.EmailTo, params)
 			// Resolve recipient from SQL query if specified
 			if toQuery, ok := node.Props["to_query"]; ok && toQuery != "" && s.db != nil {
-				rows, err := s.db.QueryRowsWithParams(toQuery, params)
-				if err == nil && len(rows) > 0 {
-					for _, v := range rows[0] {
-						recipient = v
-						break
+				scopedQuery, tErr := RewriteTenantSQL(toQuery, s.tenants, params)
+				if tErr != nil {
+					s.logger.LogError("tenant guard rejected recipient query", tErr)
+				} else {
+					rows, err := s.db.QueryRowsWithParams(scopedQuery, params)
+					if err == nil && len(rows) > 0 {
+						for _, v := range rows[0] {
+							recipient = v
+							break
+						}
 					}
 				}
 			}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -352,7 +352,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 		}
 		sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, pathParams)
 		if tErr != nil {
-			s.logger.LogError("tenant guard rejected page query", tErr)
+			s.logger.LogSecurity("tenant guard rejected page query", tErr)
 			continue
 		}
 
@@ -407,6 +407,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 			rows, err = s.db.QueryRows(sql)
 		}
 		if err != nil {
+			s.logger.LogError("page query failed", err)
 			continue
 		}
 		ctx.queries[queryName] = rows
@@ -486,7 +487,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 						}
 						sql, tErr := RewriteTenantSQL(q.SQL, s.tenants, layoutParams)
 						if tErr != nil {
-							s.logger.LogError("tenant guard rejected layout query", tErr)
+							s.logger.LogSecurity("tenant guard rejected layout query", tErr)
 							continue
 						}
 						var rows []database.Row
@@ -688,7 +689,7 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 			if s.db != nil {
 				sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, pathParams)
 				if tErr != nil {
-					s.logger.LogError("tenant guard rejected fragment query", tErr)
+					s.logger.LogSecurity("tenant guard rejected fragment query", tErr)
 					continue
 				}
 				queryName := node.Name
@@ -752,7 +753,7 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 			if s.db != nil {
 				sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, params)
 				if tErr != nil {
-					s.logger.LogError("tenant guard rejected fragment query", tErr)
+					s.logger.LogSecurity("tenant guard rejected fragment query", tErr)
 					body.WriteString("<p style=\"color:red\">Query rejected</p>")
 					continue
 				}
@@ -862,7 +863,7 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 			if tx != nil {
 				sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, formData)
 				if tErr != nil {
-					s.logger.LogError("tenant guard rejected action query", tErr)
+					s.logger.LogSecurity("tenant guard rejected action query", tErr)
 					lastQueryOk = false
 					lastQueryNotFound = false
 					continue
@@ -945,7 +946,12 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 			recipient := resolveEmailRecipient(node.EmailTo, formData)
 			// Resolve recipient from SQL query if specified
 			if toQuery, ok := node.Props["to_query"]; ok && toQuery != "" && s.db != nil {
-				rows, err := s.db.QueryRowsWithParams(toQuery, formData)
+				scopedToQuery, tErr := RewriteTenantSQL(toQuery, s.tenants, formData)
+				if tErr != nil {
+					s.logger.LogSecurity("tenant guard rejected email recipient query", tErr)
+					continue
+				}
+				rows, err := s.db.QueryRowsWithParams(scopedToQuery, formData)
 				if err == nil && len(rows) > 0 {
 					for _, v := range rows[0] {
 						recipient = v
@@ -1002,7 +1008,7 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 					if prevNode.Type == parser.NodeQuery && prevNode.Name == dataName {
 						prevSQL, tErr := RewriteTenantSQL(prevNode.SQL, s.tenants, formData)
 						if tErr != nil {
-							s.logger.LogError("tenant guard rejected PDF data query", tErr)
+							s.logger.LogSecurity("tenant guard rejected PDF data query", tErr)
 							continue
 						}
 						rows, err := tx.QueryRowsWithParams(prevSQL, formData)
@@ -1129,7 +1135,7 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 			if node.QuerySQL != "" && tx != nil {
 				respondSQL, tErr := RewriteTenantSQL(node.QuerySQL, s.tenants, formData)
 				if tErr != nil {
-					s.logger.LogError("tenant guard rejected respond query", tErr)
+					s.logger.LogSecurity("tenant guard rejected respond query", tErr)
 					http.Error(w, "Forbidden", http.StatusForbidden)
 					return
 				}
@@ -1239,7 +1245,12 @@ func (s *Server) handleActionNodes(w http.ResponseWriter, r *http.Request, nodes
 		case parser.NodeSendEmail:
 			recipient := resolveEmailRecipient(node.EmailTo, formData)
 			if toQuery, ok := node.Props["to_query"]; ok && toQuery != "" && s.db != nil {
-				rows, err := s.db.QueryRowsWithParams(toQuery, formData)
+				scopedToQuery, tErr := RewriteTenantSQL(toQuery, s.tenants, formData)
+				if tErr != nil {
+					s.logger.LogSecurity("tenant guard rejected email recipient query", tErr)
+					continue
+				}
+				rows, err := s.db.QueryRowsWithParams(scopedToQuery, formData)
 				if err == nil && len(rows) > 0 {
 					for _, v := range rows[0] {
 						recipient = v
@@ -1266,7 +1277,7 @@ func (s *Server) handleActionNodes(w http.ResponseWriter, r *http.Request, nodes
 			if s.db != nil {
 				sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, formData)
 				if tErr != nil {
-					s.logger.LogError("tenant guard rejected on-branch query", tErr)
+					s.logger.LogSecurity("tenant guard rejected on-branch query", tErr)
 					continue
 				}
 				trimmed := strings.TrimSpace(strings.ToUpper(sql))

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -325,17 +325,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 	// Make current_user available as a query result and as SQL params
 	if ctx.currentUser != nil {
 		ctx.queries["current_user"] = []database.Row{ctx.currentUser.Data}
-		pathParams["current_user.id"] = ctx.currentUser.UserID
-		pathParams["current_user.identity"] = ctx.currentUser.Identity
-		pathParams["current_user.role"] = ctx.currentUser.Role
-		pathParams["current_user_id"] = ctx.currentUser.UserID
-		pathParams["current_user_identity"] = ctx.currentUser.Identity
-		pathParams["current_user_role"] = ctx.currentUser.Role
-		// Expose every column of the user row as a bind param so tenant
-		// scoping and user-specific filters can reference them.
-		for k, v := range ctx.currentUser.Data {
-			pathParams["current_user."+k] = v
-		}
+		s.populateCurrentUserParams(pathParams, ctx.currentUser)
 	}
 
 	// Expose URL query parameters to templates and SQL
@@ -360,7 +350,11 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 		if node.Type != parser.NodeQuery || s.db == nil {
 			continue
 		}
-		sql := RewriteTenantSQL(node.SQL, s.tenants)
+		sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, pathParams)
+		if tErr != nil {
+			s.logger.LogError("tenant guard rejected page query", tErr)
+			continue
+		}
 
 		queryName := node.Name
 		if queryName == "" {
@@ -481,14 +475,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 					for k, v := range pathParams {
 						layoutParams[k] = v
 					}
-					if ctx.currentUser != nil {
-						layoutParams["current_user.id"] = ctx.currentUser.UserID
-						layoutParams["current_user.identity"] = ctx.currentUser.Identity
-						layoutParams["current_user.role"] = ctx.currentUser.Role
-						layoutParams["current_user_id"] = ctx.currentUser.UserID
-						layoutParams["current_user_identity"] = ctx.currentUser.Identity
-						layoutParams["current_user_role"] = ctx.currentUser.Role
-					}
+					s.populateCurrentUserParams(layoutParams, ctx.currentUser)
 					for _, q := range layout.Queries {
 						if q.SQL == "" {
 							continue
@@ -497,15 +484,22 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 						if name == "" {
 							name = "_last"
 						}
+						sql, tErr := RewriteTenantSQL(q.SQL, s.tenants, layoutParams)
+						if tErr != nil {
+							s.logger.LogError("tenant guard rejected layout query", tErr)
+							continue
+						}
 						var rows []database.Row
 						var err error
 						if len(layoutParams) > 0 {
-							rows, err = s.db.QueryRowsWithParams(q.SQL, layoutParams)
+							rows, err = s.db.QueryRowsWithParams(sql, layoutParams)
 						} else {
-							rows, err = s.db.QueryRows(q.SQL)
+							rows, err = s.db.QueryRows(sql)
 						}
 						if err == nil {
 							layoutCtx.queries[name] = rows
+						} else {
+							s.logger.LogError("layout query failed", err)
 						}
 					}
 				}
@@ -692,7 +686,11 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 		switch node.Type {
 		case parser.NodeQuery:
 			if s.db != nil {
-				sql := RewriteTenantSQL(node.SQL, s.tenants)
+				sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, pathParams)
+				if tErr != nil {
+					s.logger.LogError("tenant guard rejected fragment query", tErr)
+					continue
+				}
 				queryName := node.Name
 				if queryName == "" {
 					queryName = "_last"
@@ -752,7 +750,12 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 		switch node.Type {
 		case parser.NodeQuery:
 			if s.db != nil {
-				sql := RewriteTenantSQL(node.SQL, s.tenants)
+				sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, params)
+				if tErr != nil {
+					s.logger.LogError("tenant guard rejected fragment query", tErr)
+					body.WriteString("<p style=\"color:red\">Query rejected</p>")
+					continue
+				}
 				rows, err := s.db.QueryRowsWithParams(sql, params)
 				if err != nil {
 					s.logger.LogError("fragment query failed", err)
@@ -798,16 +801,8 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 		formData[k] = v
 	}
 
-	// Add current_user fields (both dot and underscore formats)
-	session := s.getSession(r)
-	if session != nil {
-		formData["current_user.id"] = session.UserID
-		formData["current_user.identity"] = session.Identity
-		formData["current_user.role"] = session.Role
-		formData["current_user_id"] = session.UserID
-		formData["current_user_identity"] = session.Identity
-		formData["current_user_role"] = session.Role
-	}
+	// Add current_user fields (including tenant id and other safe columns)
+	s.populateCurrentUserParams(formData, s.getSession(r))
 
 	// Start implicit transaction for atomicity
 	var tx *database.TxHandle
@@ -865,11 +860,18 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 
 		case parser.NodeQuery:
 			if tx != nil {
-				sql := RewriteTenantSQL(node.SQL, s.tenants)
+				sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, formData)
+				if tErr != nil {
+					s.logger.LogError("tenant guard rejected action query", tErr)
+					lastQueryOk = false
+					lastQueryNotFound = false
+					continue
+				}
 				trimmed := strings.TrimSpace(strings.ToUpper(sql))
 				if strings.HasPrefix(trimmed, "SELECT") {
 					rows, err := tx.QueryRowsWithParams(sql, formData)
 					if err != nil {
+						s.logger.LogError("action query failed", err)
 						lastQueryOk = false
 						lastQueryNotFound = false
 						continue
@@ -998,7 +1000,12 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 				// Re-run the named query to get full rows for the PDF
 				for _, prevNode := range action.Body {
 					if prevNode.Type == parser.NodeQuery && prevNode.Name == dataName {
-						rows, err := tx.QueryRowsWithParams(prevNode.SQL, formData)
+						prevSQL, tErr := RewriteTenantSQL(prevNode.SQL, s.tenants, formData)
+						if tErr != nil {
+							s.logger.LogError("tenant guard rejected PDF data query", tErr)
+							continue
+						}
+						rows, err := tx.QueryRowsWithParams(prevSQL, formData)
 						if err == nil && len(rows) > 0 {
 							var headers []string
 							for key := range rows[0] {
@@ -1120,7 +1127,13 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 			}
 
 			if node.QuerySQL != "" && tx != nil {
-				rows, err := tx.QueryRowsWithParams(node.QuerySQL, formData)
+				respondSQL, tErr := RewriteTenantSQL(node.QuerySQL, s.tenants, formData)
+				if tErr != nil {
+					s.logger.LogError("tenant guard rejected respond query", tErr)
+					http.Error(w, "Forbidden", http.StatusForbidden)
+					return
+				}
+				rows, err := tx.QueryRowsWithParams(respondSQL, formData)
 				if err != nil {
 					s.logger.LogError("respond query failed", err)
 					http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -1251,11 +1264,16 @@ func (s *Server) handleActionNodes(w http.ResponseWriter, r *http.Request, nodes
 			}(recipient, subject, emailBody, templateName, paramsCopy)
 		case parser.NodeQuery:
 			if s.db != nil {
-				sql := RewriteTenantSQL(node.SQL, s.tenants)
+				sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, formData)
+				if tErr != nil {
+					s.logger.LogError("tenant guard rejected on-branch query", tErr)
+					continue
+				}
 				trimmed := strings.TrimSpace(strings.ToUpper(sql))
 				if strings.HasPrefix(trimmed, "SELECT") {
 					rows, err := s.db.QueryRowsWithParams(sql, formData)
 					if err != nil {
+						s.logger.LogError("on-branch query failed", err)
 						continue
 					}
 					name := node.Name
@@ -1269,7 +1287,7 @@ func (s *Server) handleActionNodes(w http.ResponseWriter, r *http.Request, nodes
 					}
 				} else {
 					if err := s.db.ExecWithParams(sql, formData); err != nil {
-						fmt.Printf("  on-branch query error: %v\n", err)
+						s.logger.LogError("on-branch query error", err)
 					}
 				}
 			}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	rateLimiter  *RateLimiter
 	logger       *Logger
 	i18n         *I18n
+	tenants      TenantMap // models with a `tenant: <model>` directive
 	mu           sync.RWMutex
 	port         int
 	scheduleStop chan struct{}
@@ -40,7 +41,7 @@ func NewServer(app *parser.App, db *database.DB, port int) *Server {
 	if app.Config != nil {
 		secret = app.Config.Secret
 	}
-	s := &Server{app: app, db: db, sessions: NewSessionStore(secret), port: port}
+	s := &Server{app: app, db: db, sessions: NewSessionStore(secret), port: port, tenants: BuildTenantMap(app)}
 	// Attach DB to session store for persistence
 	if db != nil {
 		s.sessions.SetDB(db)
@@ -330,6 +331,11 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 		pathParams["current_user_id"] = ctx.currentUser.UserID
 		pathParams["current_user_identity"] = ctx.currentUser.Identity
 		pathParams["current_user_role"] = ctx.currentUser.Role
+		// Expose every column of the user row as a bind param so tenant
+		// scoping and user-specific filters can reference them.
+		for k, v := range ctx.currentUser.Data {
+			pathParams["current_user."+k] = v
+		}
 	}
 
 	// Expose URL query parameters to templates and SQL
@@ -354,7 +360,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 		if node.Type != parser.NodeQuery || s.db == nil {
 			continue
 		}
-		sql := node.SQL
+		sql := RewriteTenantSQL(node.SQL, s.tenants)
 
 		queryName := node.Name
 		if queryName == "" {
@@ -686,7 +692,7 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 		switch node.Type {
 		case parser.NodeQuery:
 			if s.db != nil {
-				sql := node.SQL
+				sql := RewriteTenantSQL(node.SQL, s.tenants)
 				queryName := node.Name
 				if queryName == "" {
 					queryName = "_last"
@@ -746,7 +752,8 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 		switch node.Type {
 		case parser.NodeQuery:
 			if s.db != nil {
-				rows, err := s.db.QueryRowsWithParams(node.SQL, params)
+				sql := RewriteTenantSQL(node.SQL, s.tenants)
+				rows, err := s.db.QueryRowsWithParams(sql, params)
 				if err != nil {
 					s.logger.LogError("fragment query failed", err)
 					body.WriteString("<p style=\"color:red\">Query error</p>")
@@ -858,9 +865,10 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 
 		case parser.NodeQuery:
 			if tx != nil {
-				trimmed := strings.TrimSpace(strings.ToUpper(node.SQL))
+				sql := RewriteTenantSQL(node.SQL, s.tenants)
+				trimmed := strings.TrimSpace(strings.ToUpper(sql))
 				if strings.HasPrefix(trimmed, "SELECT") {
-					rows, err := tx.QueryRowsWithParams(node.SQL, formData)
+					rows, err := tx.QueryRowsWithParams(sql, formData)
 					if err != nil {
 						lastQueryOk = false
 						lastQueryNotFound = false
@@ -878,7 +886,7 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 						}
 					}
 				} else {
-					err := tx.ExecWithParams(node.SQL, formData)
+					err := tx.ExecWithParams(sql, formData)
 					if err != nil {
 						lastQueryOk = false
 						lastQueryNotFound = false
@@ -1243,9 +1251,10 @@ func (s *Server) handleActionNodes(w http.ResponseWriter, r *http.Request, nodes
 			}(recipient, subject, emailBody, templateName, paramsCopy)
 		case parser.NodeQuery:
 			if s.db != nil {
-				trimmed := strings.TrimSpace(strings.ToUpper(node.SQL))
+				sql := RewriteTenantSQL(node.SQL, s.tenants)
+				trimmed := strings.TrimSpace(strings.ToUpper(sql))
 				if strings.HasPrefix(trimmed, "SELECT") {
-					rows, err := s.db.QueryRowsWithParams(node.SQL, formData)
+					rows, err := s.db.QueryRowsWithParams(sql, formData)
 					if err != nil {
 						continue
 					}
@@ -1259,7 +1268,7 @@ func (s *Server) handleActionNodes(w http.ResponseWriter, r *http.Request, nodes
 						}
 					}
 				} else {
-					if err := s.db.ExecWithParams(node.SQL, formData); err != nil {
+					if err := s.db.ExecWithParams(sql, formData); err != nil {
 						fmt.Printf("  on-branch query error: %v\n", err)
 					}
 				}

--- a/internal/runtime/stream.go
+++ b/internal/runtime/stream.go
@@ -46,17 +46,8 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request, stream par
 	// Get path params for the query
 	params := matchPathParams(stream.Path, r.URL.Path)
 
-	// Add current_user params if authenticated
-	session := s.getSession(r)
-	if session != nil {
-		params["current_user.id"] = session.UserID
-		params["current_user.identity"] = session.Identity
-		params["current_user.role"] = session.Role
-		// Also support underscore form for backwards compatibility
-		params["current_user_id"] = session.UserID
-		params["current_user_identity"] = session.Identity
-		params["current_user_role"] = session.Role
-	}
+	// Add current_user params if authenticated (includes tenant id etc.)
+	s.populateCurrentUserParams(params, s.getSession(r))
 
 	ticker := time.NewTicker(time.Duration(stream.IntervalSecs) * time.Second)
 	defer ticker.Stop()
@@ -79,7 +70,14 @@ func (s *Server) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher, strea
 		return
 	}
 
-	rows, err := s.db.QueryRowsWithParams(stream.SQL, params)
+	sql, tErr := RewriteTenantSQL(stream.SQL, s.tenants, params)
+	if tErr != nil {
+		s.logger.LogError("tenant guard rejected SSE query", tErr)
+		fmt.Fprintf(w, "event: error\ndata: query rejected\n\n")
+		flusher.Flush()
+		return
+	}
+	rows, err := s.db.QueryRowsWithParams(sql, params)
 	if err != nil {
 		fmt.Printf("  SSE query error: %v\n", err)
 		fmt.Fprintf(w, "event: error\ndata: query failed\n\n")

--- a/internal/runtime/stream.go
+++ b/internal/runtime/stream.go
@@ -72,7 +72,7 @@ func (s *Server) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher, strea
 
 	sql, tErr := RewriteTenantSQL(stream.SQL, s.tenants, params)
 	if tErr != nil {
-		s.logger.LogError("tenant guard rejected SSE query", tErr)
+		s.logger.LogSecurity("tenant guard rejected SSE query", tErr)
 		fmt.Fprintf(w, "event: error\ndata: query rejected\n\n")
 		flusher.Flush()
 		return

--- a/internal/runtime/tenant.go
+++ b/internal/runtime/tenant.go
@@ -1,20 +1,23 @@
 package runtime
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/kilnx-org/kilnx/internal/parser"
 )
 
-// TenantMap indexes model name to the name of its tenant reference.
-// e.g. {"quote": "org", "customer": "org"} means rows of "quote" and
-// "customer" are scoped by org_id.
+// TenantMap indexes model name (lowercased) to the name of its tenant
+// reference. e.g. {"quote": "org", "customer": "org"} means rows of
+// "quote" and "customer" are scoped by org_id.
 type TenantMap map[string]string
 
 // BuildTenantMap returns a lookup of tenant-scoped models from an app.
-// The key is the model/table name. The value is the referenced tenant model
-// (which drives the FK column, e.g. tenant "org" -> column "org_id").
+// Model names are lowercased for case-insensitive matching. The tenant
+// reference value is preserved as written so FK column generation stays
+// consistent with `fieldToColumnName`.
 func BuildTenantMap(app *parser.App) TenantMap {
 	m := make(TenantMap)
 	if app == nil {
@@ -28,53 +31,118 @@ func BuildTenantMap(app *parser.App) TenantMap {
 	return m
 }
 
-// tableFromSelectRe finds the first FROM clause's primary table in a SELECT
-// statement. It is deliberately conservative: it matches a bare table name
-// (optionally double-quoted) and stops at any JOIN/subquery/alias. Queries
-// more complex than `SELECT ... FROM <table> [alias] [WHERE ...]` are left
-// alone by the rewriter and the developer must add the tenant filter by hand.
+// Error types returned by the rewriter. Callers MUST fail the query when
+// they observe any of these: the rewriter refuses to execute a query it
+// cannot guarantee is tenant-scoped.
+var (
+	ErrUnsafeTenantShape  = errors.New("tenant: SQL shape is not supported by the rewriter; add the tenant predicate explicitly or refactor")
+	ErrMissingTenantParam = errors.New("tenant: current_user tenant id is not available in this context; use a context with a logged-in user or bind the tenant id manually")
+	ErrMutationNotScoped  = errors.New("tenant: mutation on a tenant-scoped table must bind :current_user.<tenant>_id explicitly")
+)
+
+// tableFromSelectRe finds the first FROM clause's primary table in a
+// SELECT statement. Intentionally strict: only unqualified, unquoted or
+// double-quoted bare table names are recognised. Anything else triggers
+// ErrUnsafeTenantShape.
 var tableFromSelectRe = regexp.MustCompile(`(?is)\bfrom\s+"?([a-zA-Z_][a-zA-Z0-9_]*)"?(?:\s+(?:as\s+)?([a-zA-Z_][a-zA-Z0-9_]*))?`)
 
-// simpleWhereRe finds a top-level WHERE clause location. It does not look
-// inside subqueries; we use it only to decide whether to append `AND ...`
-// or append a new `WHERE ...`.
+// simpleWhereRe locates the WHERE keyword that follows the FROM clause.
+// This rewriter does NOT handle subquery WHEREs; any SQL with a subquery
+// after FROM is rejected upstream via the unsupported-shape checks.
 var simpleWhereRe = regexp.MustCompile(`(?is)\bwhere\b`)
 
-// RewriteTenantSQL rewrites a query to enforce tenant scoping when the
-// primary table of a SELECT is a tenant-scoped model. If the statement is
-// not a SELECT, or if the rewriter cannot safely parse the shape, the SQL
-// is returned unchanged and the caller/developer is responsible for
-// including the tenant filter explicitly.
+// trailingRe locates the first clause that ends the implicit WHERE
+// position (GROUP BY, ORDER BY, HAVING, LIMIT, OFFSET, PAGINATE).
+var trailingRe = regexp.MustCompile(`(?is)\b(group\s+by|order\s+by|having|limit|offset|paginate)\b`)
+
+// mutationTableRe extracts the target table of a mutation. Only bare
+// unqualified identifiers are matched; schema-qualified names force the
+// fail-closed path.
+var mutationTableRe = regexp.MustCompile(`(?is)^\s*(?:(insert\s+into)|(update)|(delete\s+from))\s+"?([a-zA-Z_][a-zA-Z0-9_]*)"?`)
+
+// unsafeShapeSignals are substrings / patterns that indicate the SELECT
+// is outside the rewriter's safe-to-modify envelope. Presence of any one
+// triggers ErrUnsafeTenantShape so the caller fails the query instead of
+// executing something potentially unscoped.
+var unsafeShapeRe = regexp.MustCompile(`(?is)(--|/\*|\bwith\s+|\bunion\b|\bjoin\b|\bintersect\b|\bexcept\b|;\s*\S|\bfrom\s+\(|\bfrom\s+"?[a-zA-Z_][a-zA-Z0-9_]*"?\s*\.)`)
+
+// RewriteTenantSQL rewrites a SELECT query against a tenant-scoped table
+// to include `WHERE <qualifier>.<tenant>_id = :current_user.<tenant>_id`.
+// Behaviour summary:
 //
-// Returned SQL references :current_user.<tenant>_id. The caller must ensure
-// that bind parameter is populated (renderContext already exposes every
-// user row column as current_user.<col>).
-func RewriteTenantSQL(sql string, tenants TenantMap) string {
+//   - Empty tenant map: no-op, returns sql unchanged.
+//   - Non-tenant table: returns sql unchanged.
+//   - Mutations (INSERT/UPDATE/DELETE) on a tenant table: validated via
+//     CheckTenantMutation, never rewritten.
+//   - Tenant-scoped SELECT we can safely rewrite: returns rewritten SQL.
+//   - Tenant-scoped SELECT we cannot parse safely: returns ErrUnsafeTenantShape.
+//   - No `current_user.<tenant>_id` in params: returns ErrMissingTenantParam.
+//
+// Callers MUST NOT execute the original SQL on error. This is the
+// defense-in-depth contract: when in doubt, fail the query.
+//
+// This is not a substitute for application-level authorization. It closes
+// one specific class of bug (forgetting the tenant predicate on a SELECT)
+// and refuses unsupported shapes so they are addressed by the developer.
+func RewriteTenantSQL(sql string, tenants TenantMap, params map[string]string) (string, error) {
 	if len(tenants) == 0 {
-		return sql
+		return sql, nil
 	}
 
 	trimmed := strings.TrimSpace(sql)
 	lower := strings.ToLower(trimmed)
+
+	// Route mutations through the mutation checker.
+	if isMutationStart(lower) {
+		if err := checkTenantMutation(sql, tenants, params); err != nil {
+			return "", err
+		}
+		return sql, nil
+	}
+
 	if !strings.HasPrefix(lower, "select") {
-		return sql
+		// Non-SELECT, non-mutation shape (CTE `WITH`, pragma, etc.).
+		// Refuse if any tenant-scoped table is referenced.
+		if touchesTenantTable(sql, tenants) {
+			return "", fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
+		}
+		return sql, nil
 	}
 
 	match := tableFromSelectRe.FindStringSubmatchIndex(sql)
 	if match == nil {
-		return sql
+		// A SELECT without a parseable FROM might still touch a tenant
+		// table (e.g. CTE). If any tenant-scoped model name appears in
+		// the SQL, fail closed.
+		if touchesTenantTable(sql, tenants) {
+			return "", fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
+		}
+		return sql, nil
 	}
 	table := sql[match[2]:match[3]]
 	tenant, ok := tenants[strings.ToLower(table)]
 	if !ok {
-		return sql
+		// Primary table is not tenant-scoped, but a JOIN, subquery or CTE
+		// could still pull in tenant-scoped rows. Detect and reject.
+		if touchesTenantTable(sql, tenants) {
+			return "", fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
+		}
+		return sql, nil
 	}
 
-	// The regex may greedily swallow the next word as an "alias". Decide
-	// whether it is really an alias (non-keyword identifier) or a SQL
-	// keyword (WHERE, ORDER, GROUP, LIMIT, ...) that must be pushed back.
+	// Reject shapes we know we can't rewrite safely.
+	if unsafeShapeRe.MatchString(sql) {
+		return "", fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
+	}
+
+	// Require the bind parameter to be present.
+	paramKey := "current_user." + tenant + "_id"
+	if _, present := params[paramKey]; !present {
+		return "", fmt.Errorf("%w: missing %s", ErrMissingTenantParam, paramKey)
+	}
+
 	qualifier := table
-	endPos := match[3] // end of table name (our baseline insertion boundary)
+	endPos := match[3]
 	if match[4] >= 0 && match[5] > match[4] {
 		alias := sql[match[4]:match[5]]
 		if !isSQLKeyword(alias) {
@@ -83,24 +151,80 @@ func RewriteTenantSQL(sql string, tenants TenantMap) string {
 		}
 	}
 
-	filter := qualifier + "." + tenant + "_id = :current_user." + tenant + "_id"
-
+	filter := qualifier + "." + tenant + "_id = :" + paramKey
 	afterFrom := sql[endPos:]
 	if whereMatch := simpleWhereRe.FindStringIndex(afterFrom); whereMatch != nil {
-		// Existing WHERE: inject `<filter> AND ` right after the WHERE keyword.
 		wherePos := endPos + whereMatch[1]
-		return sql[:wherePos] + " " + filter + " AND" + sql[wherePos:]
+		return sql[:wherePos] + " " + filter + " AND" + sql[wherePos:], nil
 	}
-
-	trailingRe := regexp.MustCompile(`(?is)\b(group\s+by|order\s+by|having|limit|offset|paginate)\b`)
 	if trailing := trailingRe.FindStringIndex(afterFrom); trailing != nil {
 		insertIdx := endPos + trailing[0]
-		// Absorb the whitespace immediately before the trailing clause so we
-		// do not produce double spaces in the rewritten SQL.
 		head := strings.TrimRight(sql[:insertIdx], " \t\n")
-		return head + " WHERE " + filter + " " + sql[insertIdx:]
+		return head + " WHERE " + filter + " " + sql[insertIdx:], nil
 	}
-	return strings.TrimRight(sql, " \t\n") + " WHERE " + filter
+	return strings.TrimRight(sql, " \t\n") + " WHERE " + filter, nil
+}
+
+// checkTenantMutation verifies that an INSERT / UPDATE / DELETE on a
+// tenant-scoped table binds the tenant column explicitly. This is not a
+// rewrite: intent must remain visible in the .kilnx source. We accept
+// the mutation if the SQL text textually references
+// `:current_user.<tenant>_id` anywhere.
+func checkTenantMutation(sql string, tenants TenantMap, params map[string]string) error {
+	m := mutationTableRe.FindStringSubmatch(sql)
+	if m == nil {
+		// Unparseable mutation on unknown table: fail closed if any
+		// tenant-scoped model name appears in the SQL.
+		if touchesTenantTable(sql, tenants) {
+			return fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
+		}
+		return nil
+	}
+	table := m[4]
+	tenant, ok := tenants[strings.ToLower(table)]
+	if !ok {
+		return nil
+	}
+	needle := ":current_user." + tenant + "_id"
+	if !strings.Contains(strings.ToLower(sql), strings.ToLower(needle)) {
+		return fmt.Errorf("%w: %s", ErrMutationNotScoped, firstLine(sql))
+	}
+	if _, present := params["current_user."+tenant+"_id"]; !present {
+		return fmt.Errorf("%w: missing current_user.%s_id", ErrMissingTenantParam, tenant)
+	}
+	return nil
+}
+
+// touchesTenantTable returns true if the SQL (whitespace-tokenised) mentions
+// any tenant-scoped model name as a standalone identifier. Conservative: we
+// would rather reject an innocuous query than miss a tenant leak.
+func touchesTenantTable(sql string, tenants TenantMap) bool {
+	tokens := identRe.FindAllString(sql, -1)
+	for _, t := range tokens {
+		if _, ok := tenants[strings.ToLower(t)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+var identRe = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_]*`)
+
+var mutationStartRe = regexp.MustCompile(`^\s*(insert\s+into|update|delete\s+from)\b`)
+
+func isMutationStart(lower string) bool {
+	return mutationStartRe.MatchString(lower)
+}
+
+func firstLine(sql string) string {
+	trimmed := strings.TrimSpace(sql)
+	if i := strings.IndexByte(trimmed, '\n'); i >= 0 {
+		return trimmed[:i] + "..."
+	}
+	if len(trimmed) > 120 {
+		return trimmed[:120] + "..."
+	}
+	return trimmed
 }
 
 var sqlKeywords = map[string]bool{
@@ -111,4 +235,45 @@ var sqlKeywords = map[string]bool{
 
 func isSQLKeyword(s string) bool {
 	return sqlKeywords[strings.ToLower(s)]
+}
+
+// sensitiveFieldRe matches column names that must never be exposed as
+// bind parameters derived from the current_user row. The list covers
+// password hashes, reset/verification tokens, API keys, and secrets.
+// Matching is case-insensitive.
+var sensitiveFieldRe = regexp.MustCompile(`(?i)(^|_)(password|secret|api_?key|token|salt|hash|reset|verification)($|_)`)
+
+// populateCurrentUserParams copies the logged-in user's row into `params`
+// under the `current_user.<column>` prefix, redacting known-sensitive
+// columns (password, tokens, secrets) plus the `auth.password` column
+// declared in the .kilnx config. Callers SHOULD use this helper instead
+// of iterating session.Data directly.
+func (s *Server) populateCurrentUserParams(params map[string]string, sess *Session) {
+	if sess == nil {
+		return
+	}
+	params["current_user.id"] = sess.UserID
+	params["current_user.identity"] = sess.Identity
+	params["current_user.role"] = sess.Role
+	params["current_user_id"] = sess.UserID
+	params["current_user_identity"] = sess.Identity
+	params["current_user_role"] = sess.Role
+
+	pwField := ""
+	if s.app != nil && s.app.Auth != nil {
+		pwField = s.app.Auth.Password
+	}
+	for k, v := range sess.Data {
+		if isSensitiveField(k, pwField) {
+			continue
+		}
+		params["current_user."+k] = v
+	}
+}
+
+func isSensitiveField(name, passwordField string) bool {
+	if passwordField != "" && strings.EqualFold(name, passwordField) {
+		return true
+	}
+	return sensitiveFieldRe.MatchString(name)
 }

--- a/internal/runtime/tenant.go
+++ b/internal/runtime/tenant.go
@@ -60,6 +60,38 @@ var trailingRe = regexp.MustCompile(`(?is)\b(group\s+by|order\s+by|having|limit|
 // fail-closed path.
 var mutationTableRe = regexp.MustCompile(`(?is)^\s*(?:(insert\s+into)|(update)|(delete\s+from))\s+"?([a-zA-Z_][a-zA-Z0-9_]*)"?`)
 
+// sqlCommentRe matches both block comments and line comments. Used to
+// strip comments BEFORE security-sensitive text scans so that an
+// attacker cannot hide a needle or a tenant-table name inside a
+// comment.
+var sqlCommentRe = regexp.MustCompile(`(?s)/\*.*?\*/|--[^\n]*`)
+
+// sqlStringLiteralRe matches single-quoted string literals with the
+// standard SQL doubling escape. Stripping literals before content scans
+// prevents false positives (WHERE note = 'join us today' must not
+// reject on the word JOIN) and false negatives (attacker hiding a
+// needle inside a literal).
+var sqlStringLiteralRe = regexp.MustCompile(`'(?:''|[^'])*'`)
+
+// subqueryInMutationRe is a heuristic that matches a mutation body
+// containing a nested SELECT (subquery). We refuse to reason about
+// nested SELECTs inside INSERT/UPDATE/DELETE because the guarantee we
+// offer is scoping on the outer statement only.
+var subqueryInMutationRe = regexp.MustCompile(`(?is)\(\s*select\s+`)
+
+// stripSQLNoise removes comments and string literals. The returned
+// string preserves overall length by replacing stripped ranges with
+// spaces, so byte positions remain valid for downstream regexps.
+func stripSQLNoise(sql string) string {
+	out := sqlCommentRe.ReplaceAllStringFunc(sql, func(s string) string {
+		return strings.Repeat(" ", len(s))
+	})
+	out = sqlStringLiteralRe.ReplaceAllStringFunc(out, func(s string) string {
+		return strings.Repeat(" ", len(s))
+	})
+	return out
+}
+
 // unsafeShapeSignals are substrings / patterns that indicate the SELECT
 // is outside the rewriter's safe-to-modify envelope. Presence of any one
 // triggers ErrUnsafeTenantShape so the caller fails the query instead of
@@ -89,12 +121,22 @@ func RewriteTenantSQL(sql string, tenants TenantMap, params map[string]string) (
 		return sql, nil
 	}
 
-	trimmed := strings.TrimSpace(sql)
+	// SQL comments are always unsafe in tenant-sensitive SQL: they let an
+	// attacker hide tokens from our scans. Reject before stripping.
+	if sqlCommentRe.MatchString(sql) {
+		return "", fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
+	}
+
+	// Strip string literals so harmless content (e.g. WHERE note = 'join us')
+	// does not trigger false positives in shape detection, and so an
+	// attacker cannot hide a tenant-table name inside a literal.
+	scrubbed := stripSQLNoise(sql)
+	trimmed := strings.TrimSpace(scrubbed)
 	lower := strings.ToLower(trimmed)
 
 	// Route mutations through the mutation checker.
 	if isMutationStart(lower) {
-		if err := checkTenantMutation(sql, tenants, params); err != nil {
+		if err := checkTenantMutation(sql, scrubbed, tenants, params); err != nil {
 			return "", err
 		}
 		return sql, nil
@@ -103,35 +145,35 @@ func RewriteTenantSQL(sql string, tenants TenantMap, params map[string]string) (
 	if !strings.HasPrefix(lower, "select") {
 		// Non-SELECT, non-mutation shape (CTE `WITH`, pragma, etc.).
 		// Refuse if any tenant-scoped table is referenced.
-		if touchesTenantTable(sql, tenants) {
+		if touchesTenantTable(scrubbed, tenants) {
 			return "", fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
 		}
 		return sql, nil
 	}
 
-	match := tableFromSelectRe.FindStringSubmatchIndex(sql)
+	match := tableFromSelectRe.FindStringSubmatchIndex(scrubbed)
 	if match == nil {
 		// A SELECT without a parseable FROM might still touch a tenant
 		// table (e.g. CTE). If any tenant-scoped model name appears in
 		// the SQL, fail closed.
-		if touchesTenantTable(sql, tenants) {
+		if touchesTenantTable(scrubbed, tenants) {
 			return "", fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
 		}
 		return sql, nil
 	}
-	table := sql[match[2]:match[3]]
+	table := scrubbed[match[2]:match[3]]
 	tenant, ok := tenants[strings.ToLower(table)]
 	if !ok {
 		// Primary table is not tenant-scoped, but a JOIN, subquery or CTE
 		// could still pull in tenant-scoped rows. Detect and reject.
-		if touchesTenantTable(sql, tenants) {
+		if touchesTenantTable(scrubbed, tenants) {
 			return "", fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
 		}
 		return sql, nil
 	}
 
 	// Reject shapes we know we can't rewrite safely.
-	if unsafeShapeRe.MatchString(sql) {
+	if unsafeShapeRe.MatchString(scrubbed) {
 		return "", fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
 	}
 
@@ -167,15 +209,30 @@ func RewriteTenantSQL(sql string, tenants TenantMap, params map[string]string) (
 
 // checkTenantMutation verifies that an INSERT / UPDATE / DELETE on a
 // tenant-scoped table binds the tenant column explicitly. This is not a
-// rewrite: intent must remain visible in the .kilnx source. We accept
-// the mutation if the SQL text textually references
-// `:current_user.<tenant>_id` anywhere.
-func checkTenantMutation(sql string, tenants TenantMap, params map[string]string) error {
-	m := mutationTableRe.FindStringSubmatch(sql)
+// rewrite: intent must remain visible in the .kilnx source. The
+// `scrubbed` argument has had comments and string literals stripped so
+// we do not accept a bind needle hidden inside a comment.
+func checkTenantMutation(sql, scrubbed string, tenants TenantMap, params map[string]string) error {
+	// Subqueries inside mutations are out of scope for the simple
+	// textual guard: the outer statement's scope cannot be verified
+	// by looking at the inner SELECT. Reject and ask the developer
+	// to refactor or split the mutation.
+	if subqueryInMutationRe.MatchString(scrubbed) {
+		return fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
+	}
+
+	// Any SQL comment or multi-statement shape is also refused on the
+	// mutation path (the SELECT path reuses unsafeShapeRe; keep mutation
+	// and SELECT consistent).
+	if unsafeShapeRe.MatchString(scrubbed) {
+		return fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
+	}
+
+	m := mutationTableRe.FindStringSubmatch(scrubbed)
 	if m == nil {
-		// Unparseable mutation on unknown table: fail closed if any
-		// tenant-scoped model name appears in the SQL.
-		if touchesTenantTable(sql, tenants) {
+		// Unparseable mutation: fail closed if any tenant-scoped model
+		// name appears anywhere in the scrubbed SQL.
+		if touchesTenantTable(scrubbed, tenants) {
 			return fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
 		}
 		return nil
@@ -183,10 +240,20 @@ func checkTenantMutation(sql string, tenants TenantMap, params map[string]string
 	table := m[4]
 	tenant, ok := tenants[strings.ToLower(table)]
 	if !ok {
+		// Outer target is non-tenant, but a hidden reference to a
+		// tenant-scoped table elsewhere (string-literal aside) means
+		// the developer may be trying to cross tenants. Refuse.
+		if touchesTenantTable(scrubbed, tenants) {
+			return fmt.Errorf("%w: %s", ErrUnsafeTenantShape, firstLine(sql))
+		}
 		return nil
 	}
+
+	// Require the bind needle in the scrubbed SQL (so it cannot live
+	// inside a comment or string literal) and in the lowercase form
+	// the DB binder will see at execution time.
 	needle := ":current_user." + tenant + "_id"
-	if !strings.Contains(strings.ToLower(sql), strings.ToLower(needle)) {
+	if !strings.Contains(scrubbed, needle) {
 		return fmt.Errorf("%w: %s", ErrMutationNotScoped, firstLine(sql))
 	}
 	if _, present := params["current_user."+tenant+"_id"]; !present {

--- a/internal/runtime/tenant.go
+++ b/internal/runtime/tenant.go
@@ -1,0 +1,114 @@
+package runtime
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// TenantMap indexes model name to the name of its tenant reference.
+// e.g. {"quote": "org", "customer": "org"} means rows of "quote" and
+// "customer" are scoped by org_id.
+type TenantMap map[string]string
+
+// BuildTenantMap returns a lookup of tenant-scoped models from an app.
+// The key is the model/table name. The value is the referenced tenant model
+// (which drives the FK column, e.g. tenant "org" -> column "org_id").
+func BuildTenantMap(app *parser.App) TenantMap {
+	m := make(TenantMap)
+	if app == nil {
+		return m
+	}
+	for _, model := range app.Models {
+		if model.Tenant != "" {
+			m[strings.ToLower(model.Name)] = model.Tenant
+		}
+	}
+	return m
+}
+
+// tableFromSelectRe finds the first FROM clause's primary table in a SELECT
+// statement. It is deliberately conservative: it matches a bare table name
+// (optionally double-quoted) and stops at any JOIN/subquery/alias. Queries
+// more complex than `SELECT ... FROM <table> [alias] [WHERE ...]` are left
+// alone by the rewriter and the developer must add the tenant filter by hand.
+var tableFromSelectRe = regexp.MustCompile(`(?is)\bfrom\s+"?([a-zA-Z_][a-zA-Z0-9_]*)"?(?:\s+(?:as\s+)?([a-zA-Z_][a-zA-Z0-9_]*))?`)
+
+// simpleWhereRe finds a top-level WHERE clause location. It does not look
+// inside subqueries; we use it only to decide whether to append `AND ...`
+// or append a new `WHERE ...`.
+var simpleWhereRe = regexp.MustCompile(`(?is)\bwhere\b`)
+
+// RewriteTenantSQL rewrites a query to enforce tenant scoping when the
+// primary table of a SELECT is a tenant-scoped model. If the statement is
+// not a SELECT, or if the rewriter cannot safely parse the shape, the SQL
+// is returned unchanged and the caller/developer is responsible for
+// including the tenant filter explicitly.
+//
+// Returned SQL references :current_user.<tenant>_id. The caller must ensure
+// that bind parameter is populated (renderContext already exposes every
+// user row column as current_user.<col>).
+func RewriteTenantSQL(sql string, tenants TenantMap) string {
+	if len(tenants) == 0 {
+		return sql
+	}
+
+	trimmed := strings.TrimSpace(sql)
+	lower := strings.ToLower(trimmed)
+	if !strings.HasPrefix(lower, "select") {
+		return sql
+	}
+
+	match := tableFromSelectRe.FindStringSubmatchIndex(sql)
+	if match == nil {
+		return sql
+	}
+	table := sql[match[2]:match[3]]
+	tenant, ok := tenants[strings.ToLower(table)]
+	if !ok {
+		return sql
+	}
+
+	// The regex may greedily swallow the next word as an "alias". Decide
+	// whether it is really an alias (non-keyword identifier) or a SQL
+	// keyword (WHERE, ORDER, GROUP, LIMIT, ...) that must be pushed back.
+	qualifier := table
+	endPos := match[3] // end of table name (our baseline insertion boundary)
+	if match[4] >= 0 && match[5] > match[4] {
+		alias := sql[match[4]:match[5]]
+		if !isSQLKeyword(alias) {
+			qualifier = alias
+			endPos = match[5]
+		}
+	}
+
+	filter := qualifier + "." + tenant + "_id = :current_user." + tenant + "_id"
+
+	afterFrom := sql[endPos:]
+	if whereMatch := simpleWhereRe.FindStringIndex(afterFrom); whereMatch != nil {
+		// Existing WHERE: inject `<filter> AND ` right after the WHERE keyword.
+		wherePos := endPos + whereMatch[1]
+		return sql[:wherePos] + " " + filter + " AND" + sql[wherePos:]
+	}
+
+	trailingRe := regexp.MustCompile(`(?is)\b(group\s+by|order\s+by|having|limit|offset|paginate)\b`)
+	if trailing := trailingRe.FindStringIndex(afterFrom); trailing != nil {
+		insertIdx := endPos + trailing[0]
+		// Absorb the whitespace immediately before the trailing clause so we
+		// do not produce double spaces in the rewritten SQL.
+		head := strings.TrimRight(sql[:insertIdx], " \t\n")
+		return head + " WHERE " + filter + " " + sql[insertIdx:]
+	}
+	return strings.TrimRight(sql, " \t\n") + " WHERE " + filter
+}
+
+var sqlKeywords = map[string]bool{
+	"where": true, "group": true, "order": true, "having": true, "limit": true, "offset": true,
+	"paginate": true, "join": true, "inner": true, "left": true, "right": true, "outer": true,
+	"cross": true, "on": true, "union": true, "intersect": true, "except": true,
+}
+
+func isSQLKeyword(s string) bool {
+	return sqlKeywords[strings.ToLower(s)]
+}

--- a/internal/runtime/tenant_e2e_test.go
+++ b/internal/runtime/tenant_e2e_test.go
@@ -1,0 +1,182 @@
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kilnx-org/kilnx/internal/database"
+	"github.com/kilnx-org/kilnx/internal/lexer"
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// startTestServerWithHandles is like startTestServer but also returns the
+// DB and Server so tests can seed rows and create sessions directly.
+func startTestServerWithHandles(t *testing.T, src string) (baseURL string, db *database.DB, srv *Server, cleanup func()) {
+	t.Helper()
+	source := lexer.StripComments(src)
+	tokens := lexer.Tokenize(source)
+	app, err := parser.Parse(tokens, source)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err = database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.MigrateInternal(); err != nil {
+		db.Close()
+		t.Fatalf("migrate internal: %v", err)
+	}
+	if len(app.Models) > 0 {
+		if _, err := db.Migrate(app.Models); err != nil {
+			db.Close()
+			t.Fatalf("migrate: %v", err)
+		}
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		db.Close()
+		t.Fatalf("listen: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	srv = NewServer(app, db, port)
+	go srv.Start()
+
+	baseURL = fmt.Sprintf("http://127.0.0.1:%d", port)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/healthz")
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return baseURL, db, srv, func() { db.Close() }
+}
+
+// getAsUser performs a GET on `path` with a session cookie for the user row
+// returned by the given SQL (must return exactly one row).
+func getAsUser(t *testing.T, srv *Server, baseURL, path string, user database.Row) (int, string) {
+	t.Helper()
+	sessionID := srv.sessions.Create(user, "email")
+	signed := srv.sessions.signSessionID(sessionID)
+
+	req, err := http.NewRequest("GET", baseURL+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: "_kilnx_session", Value: signed})
+
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("get %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(b)
+}
+
+// TestTenantIsolation_PageSelect seeds two orgs, logs in as each, and asserts
+// that the listing page only shows the logged-in user's org quotes.
+func TestTenantIsolation_PageSelect(t *testing.T) {
+	src := `
+config
+  secret: "test-secret-32-bytes-min-len-padding"
+
+model org
+  name: text required unique
+
+model user
+  tenant: org
+  email: email unique
+  password: password required
+  role: option [admin, member] default member
+
+model quote
+  tenant: org
+  number: text required
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /auth/login
+  after login: /quotes
+
+page /quotes requires auth
+  query quotes: SELECT number FROM quote ORDER BY number
+  html
+    <ul>
+      {{each quotes}}<li class="q">{number}</li>{{end}}
+    </ul>
+`
+	baseURL, db, srv, cleanup := startTestServerWithHandles(t, src)
+	defer cleanup()
+
+	if err := db.ExecWithParams(`INSERT INTO org (name) VALUES ('acme')`, nil); err != nil {
+		t.Fatalf("seed org1: %v", err)
+	}
+	if err := db.ExecWithParams(`INSERT INTO org (name) VALUES ('beta')`, nil); err != nil {
+		t.Fatalf("seed org2: %v", err)
+	}
+	seed := func(email, orgName string) database.Row {
+		rows, err := db.QueryRowsWithParams(`SELECT id FROM org WHERE name = :n`, map[string]string{"n": orgName})
+		if err != nil || len(rows) == 0 {
+			t.Fatalf("resolve org %s: %v", orgName, err)
+		}
+		orgID := rows[0]["id"]
+		if err := db.ExecWithParams(
+			`INSERT INTO user (email, password, role, org_id) VALUES (:email, 'x', 'member', :org)`,
+			map[string]string{"email": email, "org": orgID},
+		); err != nil {
+			t.Fatalf("seed user %s: %v", email, err)
+		}
+		if err := db.ExecWithParams(
+			`INSERT INTO quote (number, org_id) VALUES (:n, :o)`,
+			map[string]string{"n": "Q-" + orgName, "o": orgID},
+		); err != nil {
+			t.Fatalf("seed quote %s: %v", orgName, err)
+		}
+		ur, err := db.QueryRowsWithParams(`SELECT id, email, role, org_id FROM user WHERE email = :e`, map[string]string{"e": email})
+		if err != nil || len(ur) == 0 {
+			t.Fatalf("resolve user row %s: %v", email, err)
+		}
+		return ur[0]
+	}
+	alice := seed("alice@acme.test", "acme")
+	bob := seed("bob@beta.test", "beta")
+
+	status, body := getAsUser(t, srv, baseURL, "/quotes", alice)
+	if status != http.StatusOK {
+		t.Fatalf("alice GET /quotes: status %d body=%s", status, body)
+	}
+	if !strings.Contains(body, "Q-acme") {
+		t.Errorf("alice should see Q-acme, got:\n%s", body)
+	}
+	if strings.Contains(body, "Q-beta") {
+		t.Errorf("TENANT LEAK: alice saw Q-beta:\n%s", body)
+	}
+
+	status, body = getAsUser(t, srv, baseURL, "/quotes", bob)
+	if status != http.StatusOK {
+		t.Fatalf("bob GET /quotes: status %d body=%s", status, body)
+	}
+	if !strings.Contains(body, "Q-beta") {
+		t.Errorf("bob should see Q-beta, got:\n%s", body)
+	}
+	if strings.Contains(body, "Q-acme") {
+		t.Errorf("TENANT LEAK: bob saw Q-acme:\n%s", body)
+	}
+}

--- a/internal/runtime/tenant_test.go
+++ b/internal/runtime/tenant_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -19,6 +20,10 @@ func buildApp(t *testing.T) *parser.App {
 	}
 }
 
+func withTenantParam() map[string]string {
+	return map[string]string{"current_user.org_id": "42"}
+}
+
 func TestBuildTenantMap(t *testing.T) {
 	m := BuildTenantMap(buildApp(t))
 	if m["quote"] != "org" {
@@ -33,9 +38,10 @@ func TestBuildTenantMap(t *testing.T) {
 }
 
 func TestRewriteTenantSQL_AppendsWhereWhenNone(t *testing.T) {
-	m := BuildTenantMap(buildApp(t))
-	in := "SELECT id, number FROM quote"
-	got := RewriteTenantSQL(in, m)
+	got, err := RewriteTenantSQL("SELECT id, number FROM quote", BuildTenantMap(buildApp(t)), withTenantParam())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	want := "SELECT id, number FROM quote WHERE quote.org_id = :current_user.org_id"
 	if got != want {
 		t.Errorf("got:\n  %q\nwant:\n  %q", got, want)
@@ -43,18 +49,20 @@ func TestRewriteTenantSQL_AppendsWhereWhenNone(t *testing.T) {
 }
 
 func TestRewriteTenantSQL_AppendsAndToExistingWhere(t *testing.T) {
-	m := BuildTenantMap(buildApp(t))
-	in := "SELECT id FROM quote WHERE status = 'sent'"
-	got := RewriteTenantSQL(in, m)
+	got, err := RewriteTenantSQL("SELECT id FROM quote WHERE status = 'sent'", BuildTenantMap(buildApp(t)), withTenantParam())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !strings.Contains(got, "WHERE quote.org_id = :current_user.org_id AND status = 'sent'") {
 		t.Errorf("filter not inserted before existing WHERE predicates: %q", got)
 	}
 }
 
 func TestRewriteTenantSQL_InsertsBeforeOrderBy(t *testing.T) {
-	m := BuildTenantMap(buildApp(t))
-	in := "SELECT id FROM quote ORDER BY created DESC"
-	got := RewriteTenantSQL(in, m)
+	got, err := RewriteTenantSQL("SELECT id FROM quote ORDER BY created DESC", BuildTenantMap(buildApp(t)), withTenantParam())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !strings.Contains(got, "WHERE quote.org_id = :current_user.org_id ") {
 		t.Errorf("filter should land before ORDER BY: %q", got)
 	}
@@ -64,40 +72,171 @@ func TestRewriteTenantSQL_InsertsBeforeOrderBy(t *testing.T) {
 }
 
 func TestRewriteTenantSQL_UsesAlias(t *testing.T) {
-	m := BuildTenantMap(buildApp(t))
-	in := "SELECT q.id, q.number FROM quote q WHERE q.status = 'draft'"
-	got := RewriteTenantSQL(in, m)
+	got, err := RewriteTenantSQL("SELECT q.id FROM quote q WHERE q.status = 'draft'", BuildTenantMap(buildApp(t)), withTenantParam())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !strings.Contains(got, "q.org_id = :current_user.org_id") {
 		t.Errorf("alias not used: %q", got)
 	}
 }
 
 func TestRewriteTenantSQL_LeavesNonTenantTableAlone(t *testing.T) {
-	m := BuildTenantMap(buildApp(t))
 	in := "SELECT sku, name FROM material"
-	got := RewriteTenantSQL(in, m)
-	if got != in {
-		t.Errorf("non-tenant table should pass through, got: %q", got)
-	}
-}
-
-func TestRewriteTenantSQL_LeavesMutationsAlone(t *testing.T) {
-	m := BuildTenantMap(buildApp(t))
-	cases := []string{
-		"UPDATE quote SET status = 'sent' WHERE id = :id",
-		"DELETE FROM quote WHERE id = :id",
-		"INSERT INTO quote (number, title) VALUES (:n, :t)",
-	}
-	for _, in := range cases {
-		if got := RewriteTenantSQL(in, m); got != in {
-			t.Errorf("mutation should not be rewritten at runtime layer: %q -> %q", in, got)
-		}
+	got, err := RewriteTenantSQL(in, BuildTenantMap(buildApp(t)), withTenantParam())
+	if err != nil || got != in {
+		t.Errorf("non-tenant table should pass through, got: %q (err %v)", got, err)
 	}
 }
 
 func TestRewriteTenantSQL_EmptyTenantMapIsNoOp(t *testing.T) {
 	in := "SELECT id FROM quote"
-	if got := RewriteTenantSQL(in, TenantMap{}); got != in {
-		t.Errorf("expected no-op, got %q", got)
+	got, err := RewriteTenantSQL(in, TenantMap{}, nil)
+	if err != nil || got != in {
+		t.Errorf("empty map should be a no-op, got %q err=%v", got, err)
+	}
+}
+
+// -------- fail-closed shape guards --------
+
+func TestRewriteTenantSQL_RejectsJoin(t *testing.T) {
+	_, err := RewriteTenantSQL("SELECT q.id FROM quote q JOIN material m ON m.id = q.material_id",
+		BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape for JOIN, got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_RejectsSubqueryInFrom(t *testing.T) {
+	_, err := RewriteTenantSQL("SELECT * FROM (SELECT id FROM quote) sub",
+		BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape for FROM subquery, got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_RejectsCTE(t *testing.T) {
+	_, err := RewriteTenantSQL("WITH t AS (SELECT id FROM quote) SELECT * FROM t",
+		BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape for CTE, got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_RejectsUnion(t *testing.T) {
+	_, err := RewriteTenantSQL("SELECT id FROM quote UNION SELECT id FROM customer",
+		BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape for UNION, got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_RejectsSchemaQualifiedTable(t *testing.T) {
+	_, err := RewriteTenantSQL("SELECT id FROM public.quote",
+		BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape for schema-qualified table, got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_RejectsBlockComment(t *testing.T) {
+	_, err := RewriteTenantSQL("SELECT id FROM quote /* where */",
+		BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape with comments, got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_RejectsLineComment(t *testing.T) {
+	_, err := RewriteTenantSQL("SELECT id FROM quote -- WHERE id = 1",
+		BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape with comments, got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_RejectsEmbeddedSemicolon(t *testing.T) {
+	_, err := RewriteTenantSQL("SELECT id FROM quote; DROP TABLE quote",
+		BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape for multi-statement, got %v", err)
+	}
+}
+
+// -------- missing-param guard --------
+
+func TestRewriteTenantSQL_FailsWhenTenantParamMissing(t *testing.T) {
+	_, err := RewriteTenantSQL("SELECT id FROM quote", BuildTenantMap(buildApp(t)), map[string]string{})
+	if !errors.Is(err, ErrMissingTenantParam) {
+		t.Fatalf("expected ErrMissingTenantParam when session has no org_id, got %v", err)
+	}
+}
+
+// -------- mutation guards --------
+
+func TestRewriteTenantSQL_MutationWithExplicitTenantPasses(t *testing.T) {
+	in := "INSERT INTO quote (org_id, number) VALUES (:current_user.org_id, :n)"
+	got, err := RewriteTenantSQL(in, BuildTenantMap(buildApp(t)), withTenantParam())
+	if err != nil {
+		t.Fatalf("explicit-mutation should pass, got %v", err)
+	}
+	if got != in {
+		t.Errorf("mutation should not be rewritten, got %q", got)
+	}
+}
+
+func TestRewriteTenantSQL_MutationWithoutTenantRejected(t *testing.T) {
+	cases := []string{
+		"UPDATE quote SET status = 'sent' WHERE id = :id",
+		"DELETE FROM quote WHERE id = :id",
+		"INSERT INTO quote (number) VALUES (:n)",
+	}
+	for _, in := range cases {
+		_, err := RewriteTenantSQL(in, BuildTenantMap(buildApp(t)), withTenantParam())
+		if !errors.Is(err, ErrMutationNotScoped) {
+			t.Errorf("mutation %q should be rejected, got %v", in, err)
+		}
+	}
+}
+
+func TestRewriteTenantSQL_MutationOnNonTenantTablePasses(t *testing.T) {
+	in := "DELETE FROM material WHERE id = :id"
+	got, err := RewriteTenantSQL(in, BuildTenantMap(buildApp(t)), withTenantParam())
+	if err != nil {
+		t.Fatalf("non-tenant mutation should pass, got %v", err)
+	}
+	if got != in {
+		t.Errorf("non-tenant mutation should be unchanged, got %q", got)
+	}
+}
+
+// -------- sensitive current_user field redaction --------
+
+func TestIsSensitiveField(t *testing.T) {
+	cases := map[string]bool{
+		"password":                true,
+		"Password":                true,
+		"password_hash":           true,
+		"reset_token":             true,
+		"email_verification_token":true,
+		"api_key":                 true,
+		"apikey":                  true,
+		"secret":                  true,
+		"salt":                    true,
+		"mfa_secret":              true,
+		"email":                   false,
+		"name":                    false,
+		"org_id":                  false,
+		"role":                    false,
+		"locale":                  false,
+	}
+	for name, want := range cases {
+		if got := isSensitiveField(name, ""); got != want {
+			t.Errorf("isSensitiveField(%q) = %v, want %v", name, got, want)
+		}
+	}
+	// explicit auth.password column overrides even if named oddly
+	if !isSensitiveField("pw_hash", "pw_hash") {
+		t.Error("explicit password column should be treated as sensitive")
 	}
 }

--- a/internal/runtime/tenant_test.go
+++ b/internal/runtime/tenant_test.go
@@ -214,21 +214,21 @@ func TestRewriteTenantSQL_MutationOnNonTenantTablePasses(t *testing.T) {
 
 func TestIsSensitiveField(t *testing.T) {
 	cases := map[string]bool{
-		"password":                true,
-		"Password":                true,
-		"password_hash":           true,
-		"reset_token":             true,
-		"email_verification_token":true,
-		"api_key":                 true,
-		"apikey":                  true,
-		"secret":                  true,
-		"salt":                    true,
-		"mfa_secret":              true,
-		"email":                   false,
-		"name":                    false,
-		"org_id":                  false,
-		"role":                    false,
-		"locale":                  false,
+		"password":                 true,
+		"Password":                 true,
+		"password_hash":            true,
+		"reset_token":              true,
+		"email_verification_token": true,
+		"api_key":                  true,
+		"apikey":                   true,
+		"secret":                   true,
+		"salt":                     true,
+		"mfa_secret":               true,
+		"email":                    false,
+		"name":                     false,
+		"org_id":                   false,
+		"role":                     false,
+		"locale":                   false,
 	}
 	for name, want := range cases {
 		if got := isSensitiveField(name, ""); got != want {

--- a/internal/runtime/tenant_test.go
+++ b/internal/runtime/tenant_test.go
@@ -1,0 +1,103 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+func buildApp(t *testing.T) *parser.App {
+	t.Helper()
+	return &parser.App{
+		Models: []parser.Model{
+			{Name: "org"},
+			{Name: "quote", Tenant: "org"},
+			{Name: "material"}, // not tenant-scoped
+			{Name: "customer", Tenant: "org"},
+		},
+	}
+}
+
+func TestBuildTenantMap(t *testing.T) {
+	m := BuildTenantMap(buildApp(t))
+	if m["quote"] != "org" {
+		t.Errorf("expected quote->org, got %v", m)
+	}
+	if m["customer"] != "org" {
+		t.Errorf("expected customer->org, got %v", m)
+	}
+	if _, ok := m["material"]; ok {
+		t.Error("material should not be tenant-scoped")
+	}
+}
+
+func TestRewriteTenantSQL_AppendsWhereWhenNone(t *testing.T) {
+	m := BuildTenantMap(buildApp(t))
+	in := "SELECT id, number FROM quote"
+	got := RewriteTenantSQL(in, m)
+	want := "SELECT id, number FROM quote WHERE quote.org_id = :current_user.org_id"
+	if got != want {
+		t.Errorf("got:\n  %q\nwant:\n  %q", got, want)
+	}
+}
+
+func TestRewriteTenantSQL_AppendsAndToExistingWhere(t *testing.T) {
+	m := BuildTenantMap(buildApp(t))
+	in := "SELECT id FROM quote WHERE status = 'sent'"
+	got := RewriteTenantSQL(in, m)
+	if !strings.Contains(got, "WHERE quote.org_id = :current_user.org_id AND status = 'sent'") {
+		t.Errorf("filter not inserted before existing WHERE predicates: %q", got)
+	}
+}
+
+func TestRewriteTenantSQL_InsertsBeforeOrderBy(t *testing.T) {
+	m := BuildTenantMap(buildApp(t))
+	in := "SELECT id FROM quote ORDER BY created DESC"
+	got := RewriteTenantSQL(in, m)
+	if !strings.Contains(got, "WHERE quote.org_id = :current_user.org_id ") {
+		t.Errorf("filter should land before ORDER BY: %q", got)
+	}
+	if !strings.Contains(got, "ORDER BY created DESC") {
+		t.Errorf("ORDER BY lost: %q", got)
+	}
+}
+
+func TestRewriteTenantSQL_UsesAlias(t *testing.T) {
+	m := BuildTenantMap(buildApp(t))
+	in := "SELECT q.id, q.number FROM quote q WHERE q.status = 'draft'"
+	got := RewriteTenantSQL(in, m)
+	if !strings.Contains(got, "q.org_id = :current_user.org_id") {
+		t.Errorf("alias not used: %q", got)
+	}
+}
+
+func TestRewriteTenantSQL_LeavesNonTenantTableAlone(t *testing.T) {
+	m := BuildTenantMap(buildApp(t))
+	in := "SELECT sku, name FROM material"
+	got := RewriteTenantSQL(in, m)
+	if got != in {
+		t.Errorf("non-tenant table should pass through, got: %q", got)
+	}
+}
+
+func TestRewriteTenantSQL_LeavesMutationsAlone(t *testing.T) {
+	m := BuildTenantMap(buildApp(t))
+	cases := []string{
+		"UPDATE quote SET status = 'sent' WHERE id = :id",
+		"DELETE FROM quote WHERE id = :id",
+		"INSERT INTO quote (number, title) VALUES (:n, :t)",
+	}
+	for _, in := range cases {
+		if got := RewriteTenantSQL(in, m); got != in {
+			t.Errorf("mutation should not be rewritten at runtime layer: %q -> %q", in, got)
+		}
+	}
+}
+
+func TestRewriteTenantSQL_EmptyTenantMapIsNoOp(t *testing.T) {
+	in := "SELECT id FROM quote"
+	if got := RewriteTenantSQL(in, TenantMap{}); got != in {
+		t.Errorf("expected no-op, got %q", got)
+	}
+}

--- a/internal/runtime/tenant_test.go
+++ b/internal/runtime/tenant_test.go
@@ -210,6 +210,53 @@ func TestRewriteTenantSQL_MutationOnNonTenantTablePasses(t *testing.T) {
 	}
 }
 
+// -------- mutation bypass guards --------
+
+func TestRewriteTenantSQL_MutationNeedleInsideCommentRejected(t *testing.T) {
+	// Bind substring is hidden in a comment: must fail closed.
+	in := "DELETE FROM quote WHERE id = :id /* :current_user.org_id */"
+	_, err := RewriteTenantSQL(in, BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape (comment rejected), got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_MutationWithSubqueryRejected(t *testing.T) {
+	cases := []string{
+		"UPDATE quote SET x = 1 WHERE id IN (SELECT id FROM quote WHERE org_id = :current_user.org_id)",
+		"DELETE FROM quote WHERE material_id IN (SELECT id FROM material) AND org_id = :current_user.org_id",
+	}
+	for _, in := range cases {
+		_, err := RewriteTenantSQL(in, BuildTenantMap(buildApp(t)), withTenantParam())
+		if !errors.Is(err, ErrUnsafeTenantShape) {
+			t.Errorf("mutation with subquery %q should fail closed, got %v", in, err)
+		}
+	}
+}
+
+func TestRewriteTenantSQL_NonTenantMutationTouchingTenantRejected(t *testing.T) {
+	// Outer table is non-tenant, but inner subquery touches a tenant-scoped
+	// table: the outer mutation could indirectly cross tenants.
+	in := "DELETE FROM material WHERE id IN (SELECT material_id FROM quote)"
+	_, err := RewriteTenantSQL(in, BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape for non-tenant mutation touching tenant table, got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_StringLiteralMentioningTenantPasses(t *testing.T) {
+	// A harmless string literal containing the word `quote` must NOT
+	// trigger touchesTenantTable false positive.
+	in := "SELECT id FROM material WHERE note = 'do not quote me' AND sku = 'QT-1'"
+	got, err := RewriteTenantSQL(in, BuildTenantMap(buildApp(t)), withTenantParam())
+	if err != nil {
+		t.Fatalf("harmless string literal should pass, got %v", err)
+	}
+	if got != in {
+		t.Errorf("non-tenant table should be unchanged, got %q", got)
+	}
+}
+
 // -------- sensitive current_user field redaction --------
 
 func TestIsSensitiveField(t *testing.T) {

--- a/internal/runtime/websocket.go
+++ b/internal/runtime/websocket.go
@@ -135,6 +135,8 @@ func (s *Server) handleSocket(w http.ResponseWriter, r *http.Request, sock parse
 
 	// Get room name from path params
 	pathParams := matchPathParams(sock.Path, r.URL.Path)
+	// Bind current_user.* (including tenant id) onto the connection's params.
+	s.populateCurrentUserParams(pathParams, s.getSession(r))
 	roomName := r.URL.Path
 	if room, ok := pathParams["room"]; ok {
 		roomName = room
@@ -175,7 +177,12 @@ func (s *Server) handleSocket(w http.ResponseWriter, r *http.Request, sock parse
 		if s.db != nil {
 			for _, node := range sock.OnConnect {
 				if node.Type == parser.NodeQuery {
-					rows, err := s.db.QueryRowsWithParams(node.SQL, pathParams)
+					sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, pathParams)
+					if tErr != nil {
+						s.logger.LogError("tenant guard rejected websocket on-connect query", tErr)
+						continue
+					}
+					rows, err := s.db.QueryRowsWithParams(sql, pathParams)
 					if err == nil && len(rows) > 0 {
 						// Send each row as a message to the newly connected client
 						for _, row := range rows {

--- a/internal/runtime/websocket.go
+++ b/internal/runtime/websocket.go
@@ -179,7 +179,7 @@ func (s *Server) handleSocket(w http.ResponseWriter, r *http.Request, sock parse
 				if node.Type == parser.NodeQuery {
 					sql, tErr := RewriteTenantSQL(node.SQL, s.tenants, pathParams)
 					if tErr != nil {
-						s.logger.LogError("tenant guard rejected websocket on-connect query", tErr)
+						s.logger.LogSecurity("tenant guard rejected websocket on-connect query", tErr)
 						continue
 					}
 					rows, err := s.db.QueryRowsWithParams(sql, pathParams)


### PR DESCRIPTION
First PR of the Phase 1 enterprise modifiers proposal tracked in [#48](https://github.com/kilnx-org/kilnx/issues/48). Implements the minimum viable slice of the `tenant: <model>` directive so downstream work (adequa multi-tenant suite) can adopt it immediately.

## What this PR delivers

- Model-level `tenant: <model>` directive parsed before field declarations
- Compiler synthesizes a required reference field for the tenant model so the schema generates the `<tenant>_id` foreign key column
- Runtime rewrites `SELECT` queries on tenant-scoped tables to inject `WHERE <table>.<tenant>_id = :current_user.<tenant>_id`. Works with existing `WHERE`, `ORDER BY`, `GROUP BY`, `LIMIT`, and aliases (`SELECT q.* FROM quote q`)
- Runtime exposes every column of the logged-in user row as `current_user.<col>` bind parameter (including `current_user.org_id`)
- TenantMap built once per `Server` instance
- 4 parser unit tests, 8 runtime rewriter unit tests, full existing suite still green

```kilnx
model org
  name: text required unique

model user
  tenant: org
  email: email unique
  password: password required

model quote
  tenant: org
  number: text required unique
  total: float default 0
```

## Scope (intentionally small)

Deferred to follow-up PRs so each is review-able in isolation:

- INSERT / UPDATE / DELETE are not rewritten. Developers must bind the tenant column explicitly in mutations, e.g. `INSERT INTO quote (org_id, ...) VALUES (:current_user.org_id, ...)`.
- `unscoped` escape hatch on queries (planned for admin/platform views that legitimately cross tenants, guarded by `requires role admin`).
- Compile-time warning when a mutation on a tenant-scoped table does not bind the tenant column.
- JOIN and subquery rewriting (current rewriter skips anything more complex than a single primary table in the FROM clause).

## Testing

- `go test ./internal/parser/` — 4 new tests for directive, field fallback, duplicate, ordering
- `go test ./internal/runtime/` — 8 new tests covering the rewriter (append WHERE, AND into existing WHERE, before trailing clauses, alias, non-tenant no-op, mutation no-op, empty map no-op)
- `go test ./...` — full suite still passes

## Why this first

Out of the five Phase 1 modifiers in [#48](https://github.com/kilnx-org/kilnx/issues/48), `tenant` has the highest leverage for enterprise workloads: every multi-tenant SELECT becomes correct by default, eliminating an entire class of cross-tenant data leak caused by forgetting a manual `WHERE org_id = :current_user.org_id`. The other modifiers (`audit`, `pii`, `encrypted`, `retain`) ship in subsequent PRs so each lands with its own tests and docs.

Grammar budget impact: zero new top-level keywords. One new model-level directive word (`tenant`) recognized contextually inside `model` blocks, preserving the 28-keyword language surface.