### PR TITLE
docs: add CHANGELOG, llms.txt, and agent instructions

### DIFF
--- a/.cursor/rules/kilnx.mdc
+++ b/.cursor/rules/kilnx.mdc
@@ -1,0 +1,24 @@
+---
+description: Kilnx language conventions and hard rules for generated .kilnx code
+alwaysApply: true
+---
+
+Authoritative references (read before writing):
+
+- [AGENTS.md](mdc:AGENTS.md) — hard rules for agents in this repo
+- [PRINCIPLES.md](mdc:PRINCIPLES.md) — 11 constitutional rules
+- [GRAMMAR.md](mdc:GRAMMAR.md) — complete syntax specification
+- [FEATURES.md](mdc:FEATURES.md) — working feature catalogue
+- [llms.txt](mdc:llms.txt) / [llms-full.txt](mdc:llms-full.txt) — LLM-oriented index and concatenation
+
+Hard rules when generating `.kilnx` code:
+
+- Keywords are finite. Top-level blocks: `config`, `model`, `auth`, `permissions`, `layout`, `page`, `action`, `fragment`, `stream`, `socket`, `api`, `webhook`, `job`, `schedule`, `test`.
+- Field types are finite: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`.
+- Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`.
+- SQL is inline via `query name: SELECT ...`. No ORMs. No string concatenation into SQL.
+- Security (CSRF, bcrypt, session HMAC, HTML escaping, SQL binding) is built in. Do not reimplement it in user code.
+- No JavaScript in generated apps. htmx only for interactivity.
+- No external runtime dependencies in user code. One `.kilnx` file, optionally split via `import` statements.
+
+If the grammar is silent on a construct you want, it does not exist. Propose an RFC issue rather than inventing syntax.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](../AGENTS.md) for authoritative instructions when working in this repository or generating Kilnx code. Read [PRINCIPLES.md](../PRINCIPLES.md) and [GRAMMAR.md](../GRAMMAR.md) before writing `.kilnx` source. Do not invent keywords or field types outside those defined there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent and LLM Instructions
+
+This file targets any coding agent (Claude, Cursor, Copilot, Aider, others) working in this repository or generating `.kilnx` code. Treat it as authoritative.
+
+## Before writing any `.kilnx` code
+
+Read, in order:
+
+1. [PRINCIPLES.md](PRINCIPLES.md) — 11 constitutional rules. They override any heuristic.
+2. [GRAMMAR.md](GRAMMAR.md) — complete syntax. Do not invent keywords, field types, or modifiers.
+3. [FEATURES.md](FEATURES.md) — working feature catalogue with runnable examples.
+4. [llms.txt](llms.txt) — index of the above for quick navigation.
+5. [llms-full.txt](llms-full.txt) — single-file concatenation when a full context load is needed.
+
+## Hard rules
+
+- **No JavaScript in generated apps.** htmx only for interactivity. If a task seems to require JS, it almost certainly does not.
+- **No ORMs, no query builders.** SQL is inline. Use `query name: SELECT ...` inside `page`, `action`, `fragment`, `stream`, `socket`, `api`.
+- **Security is built in.** Do not add CSRF tokens, bcrypt hashing, session middleware, or SQL escaping manually. The runtime handles all of that. Adding your own opens holes.
+- **Do not import external runtime dependencies.** Kilnx apps are a single `.kilnx` file plus optional imports of other `.kilnx` files. No npm, no pip, no go modules in user code.
+- **Respect the keyword set.** Top-level blocks: `config`, `model`, `auth`, `permissions`, `layout`, `page`, `action`, `fragment`, `stream`, `socket`, `api`, `webhook`, `job`, `schedule`, `test`. Anything outside this set is wrong.
+- **Field types are finite.** `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`. No others.
+- **One file can be a complete app.** Default to keeping things in one file. Split into additional `.kilnx` files via `import` only when the size genuinely warrants it.
+
+## When editing the compiler (Go source)
+
+- `internal/lexer/`, `internal/parser/`, `internal/analyzer/`, `internal/runtime/`, `internal/database/`, `internal/lsp/`, `internal/build/` are the module boundaries. Respect them.
+- Run `go test -race ./...` before declaring work complete. Target is all 311 tests green.
+- Never skip pre-commit hooks (no `--no-verify`).
+- Commits follow Conventional Commits. Never add `Co-Authored-By` or any mention of the generating model.
+
+## When in doubt
+
+Read the grammar. If the grammar is silent on the construct you want, the construct does not exist; propose an RFC issue instead of inventing syntax.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to Kilnx are documented in this file.
+
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `tenant` modifier on `model` for multi-tenant scoping with fail-closed guards across every query path (refs [#48](https://github.com/kilnx-org/kilnx/issues/48), [#52](https://github.com/kilnx-org/kilnx/pull/52))
+- PostgreSQL support via `Dialect` abstraction; switch engines with `database: postgres://...` ([#46](https://github.com/kilnx-org/kilnx/pull/46))
+- Multi-file support via `import` statement with `.kilnx` extension enforcement and path traversal protection (closes [#20](https://github.com/kilnx-org/kilnx/issues/20), [#43](https://github.com/kilnx-org/kilnx/pull/43))
+- `static` directive to serve files from a directory, validated to stay within project root ([#42](https://github.com/kilnx-org/kilnx/pull/42))
+- `fetch` keyword for outbound HTTP from actions, jobs, and webhooks ([#39](https://github.com/kilnx-org/kilnx/pull/39))
+- Inline fragment rendering on htmx action redirect: matching fragment is returned in the same response when redirecting to a page that defines it
+
+### Fixed
+- SQL `NULL` no longer rendered as truthy in template conditionals ([#44](https://github.com/kilnx-org/kilnx/pull/44))
+- Filters inside `{{each}}` blocks now resolve from the current row, not the outer scope ([#40](https://github.com/kilnx-org/kilnx/pull/40))
+- `import` treated as directive only at column 0, allowing the token to appear elsewhere
+- Timezone-aware time formats parsed in `date` and `timeago` filters
+- Named parameter error messages clarified
+- `#` characters preserved inside `html` blocks (closes [#32](https://github.com/kilnx-org/kilnx/issues/32), [#33](https://github.com/kilnx-org/kilnx/pull/33))
+
+### Security
+- Mutation bypass via SQL comment, subquery, and string literal closed
+- Tenant guard fails closed and redacts sensitive user fields when rendering
+- Static directory traversal and import traversal blocked; import depth limited
+
+## [0.1.1] - 2026-03-31
+
+### Added
+- Governance files, issue templates, and repo automation
+- Auto-assignment of PRs to CODEOWNER as reviewer and assignee
+- Phase 1 credibility batch ([#38](https://github.com/kilnx-org/kilnx/pull/38))
+
+### Fixed
+- `#` characters preserved inside `html` blocks (closes [#32](https://github.com/kilnx-org/kilnx/issues/32))
+
+## [0.1.0] - 2026-03-28
+
+Initial public release. 27 keywords, 2 runtime dependencies (SQLite + bcrypt), single-binary output.
+
+### Added
+- Declarative constructs: `config`, `model`, `auth`, `permissions`, `layout`, `page`, `action`, `fragment`, `stream`, `socket`, `api`, `webhook`, `job`, `schedule`, `test`
+- Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`
+- Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`
+- CLI: `kilnx run`, `build`, `check`, `test`, `migrate`, `lsp`, `version`
+- SQLite runtime with automatic migrations
+- Declarative auth with bcrypt password hashing and HMAC-signed sessions
+- htmx-aware fragment rendering with `hx-target` / `hx-swap` semantics
+- Server-Sent Events via `stream`, WebSockets via `socket`
+- Background jobs and cron-style `schedule`
+- Declarative `test` blocks with automatic test database (`app.kilnx.test`)
+- Template engine for full HTML control, logical operators, comments
+- Static analyzer: type checking, multi-table column validation, subquery analysis, CSRF and security linting
+- Query deduplication, JOIN pruning, stream materialization hints ([#12](https://github.com/kilnx-org/kilnx/pull/12))
+- Language Server Protocol via `kilnx lsp`
+- Docker image published at `ghcr.io/kilnx-org/kilnx:0.1.0`
+- Install script and GoReleaser-built pre-compiled binaries for macOS and Linux
+
+### Security
+All 14 hardening items from the pre-release security review landed in this version:
+- CSRF protection enabled by default on every mutation path; linter flags missing `csrf` tokens
+- Parameterized SQL with strict binding; injection paths in string literals, comments, and subqueries closed
+- HTML output escaped by default; raw output requires explicit opt-in
+- bcrypt password hashing with per-install cost; constant-time credential comparison
+- HMAC-signed session cookies with `HttpOnly`, `Secure`, `SameSite=Lax`
+- Rate limiting primitives on auth and action endpoints
+- `.kilnx` import sandbox: extension check, project root containment, depth limit
+- Sensitive field redaction in logs and error output
+
+[Unreleased]: https://github.com/kilnx-org/kilnx/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/kilnx-org/kilnx/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/kilnx-org/kilnx/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versio
 - `import` treated as directive only at column 0, allowing the token to appear elsewhere
 - Timezone-aware time formats parsed in `date` and `timeago` filters
 - Named parameter error messages clarified
-- `#` characters preserved inside `html` blocks (closes [#32](https://github.com/kilnx-org/kilnx/issues/32), [#33](https://github.com/kilnx-org/kilnx/pull/33))
 
 ### Security
-- Mutation bypass via SQL comment, subquery, and string literal closed
-- Tenant guard fails closed and redacts sensitive user fields when rendering
-- Static directory traversal and import traversal blocked; import depth limited
+- Mutation bypass via SQL comment, subquery, and string literal closed ([#52](https://github.com/kilnx-org/kilnx/pull/52))
+- Tenant guard fails closed and redacts sensitive user fields when rendering ([#52](https://github.com/kilnx-org/kilnx/pull/52))
+- Static directory traversal blocked ([#42](https://github.com/kilnx-org/kilnx/pull/42)); import traversal blocked and depth limited ([#43](https://github.com/kilnx-org/kilnx/pull/43))
 
 ## [0.1.1] - 2026-03-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for authoritative instructions when working in this repository or generating Kilnx code. That file is model-agnostic and kept in sync.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1006,12 +1006,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versio
 - `import` treated as directive only at column 0, allowing the token to appear elsewhere
 - Timezone-aware time formats parsed in `date` and `timeago` filters
 - Named parameter error messages clarified
-- `#` characters preserved inside `html` blocks (closes [#32](https://github.com/kilnx-org/kilnx/issues/32), [#33](https://github.com/kilnx-org/kilnx/pull/33))
 
 ### Security
-- Mutation bypass via SQL comment, subquery, and string literal closed
-- Tenant guard fails closed and redacts sensitive user fields when rendering
-- Static directory traversal and import traversal blocked; import depth limited
+- Mutation bypass via SQL comment, subquery, and string literal closed ([#52](https://github.com/kilnx-org/kilnx/pull/52))
+- Tenant guard fails closed and redacts sensitive user fields when rendering ([#52](https://github.com/kilnx-org/kilnx/pull/52))
+- Static directory traversal blocked ([#42](https://github.com/kilnx-org/kilnx/pull/42)); import traversal blocked and depth limited ([#43](https://github.com/kilnx-org/kilnx/pull/43))
 
 ## [0.1.1] - 2026-03-31
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,1061 @@
+# Kilnx — Full Documentation for LLMs
+
+Concatenated reference: PRINCIPLES, GRAMMAR, FEATURES, CHANGELOG. Source: https://github.com/kilnx-org/kilnx
+
+---
+
+# Kilnx Design Principles
+
+These principles are constitutional. If any future design decision contradicts a principle, the principle wins.
+
+## 0. The complexity is the tool's fault, not the problem's
+
+Most web apps are not complex. They are lists, forms, dashboards, CRUDs. The complexity comes from the tools we use, not from the problem we are solving. Kilnx exists to prove this.
+
+## 1. Zero decisions before the first useful line
+
+The developer does not choose a framework, does not configure anything, does not install dependencies. They create a file, write business logic, run it. Just like htmx is a script tag and done.
+
+## 2. SQL is a first-class citizen
+
+SQL is not something you "call" from inside another language. SQL IS part of the language. Queries live inline, not in strings, not in ORMs, not in separate files. The database is the heart, not an accessory.
+
+## 3. HTML is the native output
+
+The language thinks in HTML. Not JSON, not XML, not protobuf. It exists to serve HTML to the browser (and to htmx). If someone needs JSON, fine, but it is not the default case.
+
+## 4. Declarative first, imperative when necessary
+
+You declare what you want, not how to do it. "This page requires auth" instead of 30 lines of middleware. "This field is required" instead of if/else with manual validation. But when custom logic is needed, the language allows it without expelling you to another language.
+
+## 5. One file can be a complete app
+
+Just like a `.html` can be a website and a `.sql` in SQLPage can be a page, a single `.kilnx` file can be a functional web app. Complexity is opt-in, not mandatory.
+
+## 6. The binary is the deploy
+
+Compile, get an executable. Copy to the server, run. No runtime, no mandatory container, no 200MB of node_modules. Just like htmx is a file you link and done.
+
+## 7. Fragments are first-class
+
+The language natively understands the concept of "a piece of HTML" that htmx will swap in the DOM. Not full page or nothing. Fragments, partials, pieces are the basic unit of response.
+
+## 8. Security is default, not opt-in
+
+CSRF, SQL injection, XSS, session management come solved by default. The developer needs to make effort to be insecure, not to be secure.
+
+## 9. Zero dependencies for the user
+
+The language may use Go, C, or whatever underneath. But the user never sees it. Never installs anything besides the compiler/binary. Just like htmx users never install npm.
+
+## 10. htmx awareness without htmx coupling
+
+The language understands htmx concepts (fragments, swaps, triggers, SSE) and makes it easy to serve these patterns. But it does not depend on htmx. If someone wants to use a different frontend, it works. htmx is the natural pair, not a hard dependency.
+
+---
+
+# Kilnx Grammar Reference
+
+Kilnx has 27 keywords. The entire language fits on a single page.
+
+For comparison: Python has 35 keywords and does none of these things without importing libraries. JavaScript has 64. Java has 67. Kilnx has 27 and delivers a complete web app from database to browser.
+
+## Hello World
+
+```kilnx
+page /
+  "Hello World"
+```
+
+One useful line. That's it.
+
+---
+
+## Keywords
+
+### config
+
+Global configuration. Database, port, secrets, upload limits.
+
+```kilnx
+config
+  database: env DATABASE_URL default "sqlite://app.db"
+  port: env PORT default 8080
+  secret: env SECRET_KEY required
+  uploads: ./uploads max 50mb
+```
+
+### model
+
+Defines data types and structure. The single source of truth. From a model, the language generates: CREATE TABLE, server validation, HTML forms, client validation, and listing fragments.
+
+```kilnx
+model user
+  name: text required min 2 max 100
+  email: email unique
+  role: option [admin, editor, viewer] default viewer
+  active: bool default true
+  created: timestamp auto
+```
+
+Relationships between models:
+
+```kilnx
+model post
+  title: text required min 5
+  body: richtext required
+  status: option [draft, published, archived] default draft
+  author: user required
+  created: timestamp auto
+  published_at: timestamp optional
+
+model comment
+  body: text required
+  post: post required
+  author: user required
+  created: timestamp auto
+```
+
+#### tenant scoping
+
+A model can declare that its rows belong to a tenant (another model) with
+the `tenant:` directive. The directive must appear before any field.
+
+```kilnx
+model org
+  name: text required unique
+
+model user
+  tenant: org
+  email: email unique
+  password: password required
+
+model quote
+  tenant: org
+  number: text required unique
+  total: float default 0
+```
+
+The compiler auto-synthesizes a required reference field for the tenant
+(so `tenant: org` adds an `org_id` foreign key column) and the runtime
+rewrites `SELECT` queries against a tenant-scoped table to include
+`WHERE <table>.<tenant>_id = :current_user.<tenant>_id`. When the query
+already has a `WHERE`, the tenant predicate is joined with `AND`.
+
+The rewriter **fails closed**: if the SQL shape is too complex for the
+built-in rewriter to verify (CTEs, JOINs, subqueries, UNION, comments,
+schema-qualified tables, multi-statement queries), the query is refused
+at runtime rather than silently passing through unscoped. Refactor the
+query into a simpler single-table SELECT or bind the tenant predicate
+yourself with `WHERE ... AND <col> = :current_user.<tenant>_id` and the
+rewriter will see it.
+
+Mutations (`INSERT`, `UPDATE`, `DELETE`) on a tenant-scoped table must
+bind the tenant column textually; otherwise the runtime rejects them.
+Example that passes:
+
+```kilnx
+action /quotes/create method POST requires auth
+  query: INSERT INTO quote (org_id, number)
+         VALUES (:current_user.org_id, :n)
+```
+
+The parser synthesizes the `<tenant>_id` column automatically, and
+`kilnx check` flags references to undefined tenant models and models
+that set themselves as their own tenant.
+
+This is defense in depth, not a substitute for application-level
+authorization. The rewriter closes the "forgot the tenant predicate"
+failure mode; other access-control concerns remain the developer's
+responsibility.
+
+### permissions
+
+Access rules by role.
+
+```kilnx
+permissions
+  admin: all
+  editor: read post, write post where author = current_user
+  viewer: read post where status = published
+```
+
+### auth
+
+Authentication configuration. Declarative, not code.
+
+```kilnx
+auth
+  table: users
+  identity: email
+  password: password_hash
+  login: /login
+  after login: /dashboard
+```
+
+### layout
+
+Page wrapper templates. Four placeholders are available:
+
+- `{page.title}` - the page title (HTML-escaped)
+- `{page.content}` - the rendered page body
+- `{nav}` - auto-generated navigation bar
+- `{kilnx.js}` - **required** htmx and SSE scripts. Without this, htmx functionality breaks.
+
+```kilnx
+layout main
+  html
+    <html>
+    <head>
+      <title>{page.title}</title>
+      {kilnx.js}
+    </head>
+    <body>
+      {nav}
+      {page.content}
+    </body>
+    </html>
+```
+
+### page
+
+GET route that returns full HTML. The basic unit of the language.
+
+```kilnx
+page /users layout main title "Users"
+  query users: select name, email from user
+  html
+    {{each users}}
+    <div class="user">
+      <strong>{name}</strong>
+      <span>{email}</span>
+    </div>
+    {{end}}
+```
+
+With auth:
+
+```kilnx
+page /dashboard requires auth
+  query stats: select count(*) as total from orders
+  "Welcome back. You have {stats.total} orders."
+```
+
+### action
+
+POST/PUT/DELETE route that mutates data.
+
+```kilnx
+action /users/:id/archive method POST requires auth
+  query: update users set archived = true where id = :id
+  respond fragment user-card with query:
+    select name, email from users where id = :id
+```
+
+### fragment
+
+Reusable piece of HTML for htmx to swap in the DOM.
+
+```kilnx
+fragment /users/:id/card
+  query user: select name, email from users where id = :id
+  html
+    <div class="card">
+      <h3>{user.name}</h3>
+      <p>{user.email}</p>
+    </div>
+```
+
+### stream
+
+Server-Sent Events for realtime updates.
+
+```kilnx
+stream /notifications requires auth
+  query: select message, created_at from notifications
+         where user_id = :current_user.id
+         and seen = false
+  every 5s
+```
+
+### socket
+
+Bidirectional WebSocket.
+
+```kilnx
+socket /chat/:room requires auth
+  on connect
+    query: select message, author.name, created
+           from chat_message
+           where room = :room
+           order by created desc
+           limit 50
+    send history
+
+  on message
+    validate
+      body: required max 500
+    query: insert into chat_message (body, author, room)
+           values (:body, :current_user.id, :room)
+    broadcast to :room fragment chat-bubble
+```
+
+### api
+
+JSON endpoint. Same grammar as page, but returns JSON instead of HTML.
+
+```kilnx
+api /api/v1/posts requires auth
+  query posts: select id, title, status, author.name, created
+               from post
+               where status = published
+               order by created desc
+               paginate 50
+
+api /api/v1/posts method POST requires editor
+  validate
+    title: required min 5
+    body: required
+  query: insert into post (title, body, author, status)
+         values (:title, :body, :current_user.id, draft)
+  respond status 201
+```
+
+### webhook
+
+Receives external events.
+
+```kilnx
+webhook /stripe/payment secret env STRIPE_SECRET
+  on event payment_intent.succeeded
+    query: update order set status = paid
+           where stripe_id = :event.id
+    send email to query: select email from user
+                         where id = :event.customer_id
+      template: payment-received
+      subject: "Payment confirmed"
+```
+
+Use `on event *` as a catch-all to match any event type:
+
+```kilnx
+webhook /github secret env GITHUB_SECRET
+  on event *
+    query: insert into webhook_log (event, payload, received)
+           values (:event.type, :event.body, now())
+```
+
+### schedule
+
+Timed tasks running inside the same binary.
+
+```kilnx
+schedule cleanup every 24h
+  query: delete from session where expires_at < now()
+
+schedule report every monday at 9:00
+  query stats: select count(*) as new_users from user
+               where created > now() - interval 7 days
+  send email to query: select email from user where role = admin
+    template: weekly-report
+    subject: "Weekly report: {stats.new_users} new users"
+```
+
+### job
+
+Asynchronous background work.
+
+```kilnx
+job generate-report
+  query data: select * from order
+              where created > :start_date
+              and created < :end_date
+  generate pdf from template report with data
+  send email to :requested_by
+    template: report-ready
+    attach: generated pdf
+    subject: "Your report is ready"
+```
+
+### query / queries
+
+SQL inline or named. Queries can be defined at the top of a file and referenced by name.
+
+```kilnx
+queries
+  active-users: select u.name, u.email, count(o.id) as orders
+                from users u
+                left join orders o on o.user_id = u.id
+                where u.active = true
+                group by u.id
+
+page /users
+  query users: active-users
+  html
+    {{each users}}
+    <div class="user">
+      <strong>{name}</strong>
+      <span>{orders} orders</span>
+    </div>
+    {{end}}
+```
+
+### validate
+
+Declarative validation rules.
+
+```kilnx
+action /users/new method POST
+  validate
+    name: required
+    email: required, is email
+  query: insert into users (name, email) values (:name, :email)
+  redirect /users
+```
+
+### paginate
+
+Automatic pagination. The language generates pagination controls with htmx.
+
+```kilnx
+page /posts
+  query posts: select title, author.name from post
+               where status = published
+               order by published_at desc
+               paginate 20
+  html
+    {{each posts}}
+    <article>
+      <h2>{title}</h2>
+      <span>{author.name}</span>
+    </article>
+    {{end}}
+```
+
+### send email
+
+Declarative email sending.
+
+```kilnx
+action /users/invite method POST requires admin
+  validate
+    email: required, is email
+  query: insert into user (email, role, active)
+         values (:email, viewer, false)
+  send email to :email
+    template: invite
+    subject: "You've been invited"
+```
+
+### redirect
+
+Redirects to another route.
+
+```kilnx
+action /users/create method POST
+  validate user
+  query: insert into user (name, email) values (:name, :email)
+  redirect /users
+```
+
+### on
+
+Result handling for success, error, not found, forbidden.
+
+```kilnx
+action /users/:id/delete method POST requires auth
+  query: delete from users where id = :id
+  on success: redirect /users
+  on error: alert "Could not delete user"
+  on forbidden: redirect /login
+```
+
+### limit
+
+Rate limiting. Declarative.
+
+```kilnx
+limit /api/*
+  requests: 100 per minute per user
+  on exceeded: status 429 message "Too many requests"
+
+limit /login
+  requests: 5 per minute per ip
+  on exceeded: status 429 message "Too many attempts"
+    delay 30s
+```
+
+### log
+
+Observability built in.
+
+```kilnx
+log
+  level: env LOG_LEVEL default info
+  queries: slow > 100ms
+  requests: all
+  errors: all with stacktrace
+```
+
+### test
+
+Declarative tests in the same language.
+
+```kilnx
+test "user can create post"
+  as user with role editor
+  visit /posts/new
+  fill title with "Test Post"
+  fill body with "Content here"
+  submit
+  expect page /posts contains "Test Post"
+  expect query: select count(*) from post
+                where title = 'Test Post'
+         returns 1
+```
+
+### translations
+
+Internationalization.
+
+```kilnx
+translations
+  en
+    welcome: "Welcome back"
+    users: "Users"
+  pt
+    welcome: "Bem vindo de volta"
+    users: "Usuários"
+
+config
+  default language: en
+  detect language: header accept-language
+
+page /dashboard requires auth
+  "{t.welcome}, {current_user.name}"
+```
+
+### enqueue
+
+Dispatches an async job.
+
+```kilnx
+action /reports/generate method POST requires admin
+  validate
+    start_date: required, is date
+    end_date: required, is date
+  enqueue generate-report with
+    start_date: :start_date
+    end_date: :end_date
+    requested_by: :current_user.email
+  respond fragment ".reports" with
+    alert success "Report is being generated"
+```
+
+### broadcast
+
+Sends data to all connected WebSocket clients in a room. The fragment receives the same params that the socket handler received.
+
+```kilnx
+socket /chat/:room requires auth
+  on message
+    query: insert into chat_message (body, author, room)
+           values (:body, :current_user.id, :room)
+    broadcast to :room fragment chat-bubble
+```
+
+---
+
+## Complete App Example
+
+```kilnx
+config
+  database: env DATABASE_URL default "sqlite://app.db"
+  port: 8080
+  secret: env SECRET_KEY required
+
+model user
+  name: text required
+  email: email unique
+  password: password required
+  role: option [admin, user] default user
+  created: timestamp auto
+
+model task
+  title: text required
+  done: bool default false
+  owner: user required
+  created: timestamp auto
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /tasks
+
+layout main
+  html
+    <html>
+    <head>
+      <title>Tasks</title>
+      {kilnx.js}
+    </head>
+    <body>
+      {nav}
+      {page.content}
+    </body>
+    </html>
+
+page /tasks layout main requires auth
+  query tasks: select id, title, done from task
+               where owner = :current_user.id
+               order by created desc
+               paginate 20
+  html
+    <input type="search" name="q" placeholder="Search tasks..."
+           hx-get="/tasks" hx-trigger="keyup changed delay:300ms"
+           hx-target="#task-list">
+    <table id="task-list">
+      <tr><th>Title</th><th>Done</th><th></th></tr>
+      {{each tasks}}
+      <tr>
+        <td>{title}</td>
+        <td>{{if done}}Yes{{end}}</td>
+        <td><button hx-post="/tasks/{id}/delete" hx-target="closest tr" hx-swap="outerHTML">Delete</button></td>
+      </tr>
+      {{end}}
+    </table>
+
+page /tasks/new layout main requires auth
+  html
+    <form method="POST" action="/tasks/create">
+      <label>Title <input type="text" name="title" required></label>
+      <button type="submit">Create</button>
+    </form>
+
+action /tasks/create method POST requires auth
+  validate task
+  query: insert into task (title, owner)
+         values (:title, :current_user.id)
+  redirect /tasks
+
+action /tasks/:id/delete method POST requires auth
+  query: delete from task where id = :id and owner = :current_user.id
+  respond fragment ".task-list" with query:
+    select id, title, done from task
+    where owner = :current_user.id
+    order by created desc
+```
+
+---
+
+# Features
+
+Every feature below works today. See [GRAMMAR.md](GRAMMAR.md) for the full syntax reference.
+
+## Models
+
+Define data once. Kilnx generates the database table, server validation, and client-side validation attributes.
+
+```kilnx
+model user
+  name: text required min 2 max 100
+  email: email unique
+  role: option [admin, editor, viewer] default viewer
+  active: bool default true
+  created: timestamp auto
+
+model post
+  title: text required min 5
+  body: richtext required
+  author: user required
+  status: option [draft, published] default draft
+  created: timestamp auto
+```
+
+Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`. Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`.
+
+## Auth
+
+Six lines. Registration, login, logout, bcrypt hashing, session cookies, and `current_user` available everywhere.
+
+```kilnx
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /dashboard
+```
+
+Protect any route with `requires auth` or `requires admin`.
+
+## Permissions
+
+```kilnx
+permissions
+  admin: all
+  editor: read post, write post where author = current_user
+  viewer: read post where status = published
+```
+
+## Pages
+
+GET routes returning full HTML. Queries run inline. Templates loop and branch.
+
+```kilnx
+page /dashboard requires auth
+  query stats: SELECT count(*) as total_users FROM user
+  query posts: SELECT p.title, u.name as author
+               FROM post p
+               LEFT JOIN user u ON u.id = p.author_id
+               WHERE p.status = 'published'
+               ORDER BY p.created DESC
+               paginate 10
+  html
+    <p>Total users: {stats.total_users}</p>
+    {{each posts}}
+    <article><h3>{title}</h3><span>by {author}</span></article>
+    {{end}}
+```
+
+## Actions
+
+POST/PUT/DELETE mutations with validation, branching, and redirects.
+
+```kilnx
+action /posts/create method POST requires auth
+  validate
+    title: required min 5
+    body: required
+  query: INSERT INTO post (title, body, author)
+         VALUES (:title, :body, :current_user.id)
+  on success
+    redirect /posts
+  on error
+    alert "Could not create post"
+```
+
+## Fragments
+
+Partial HTML for htmx to swap into the DOM. No JavaScript.
+
+```kilnx
+fragment /users/:id/card
+  query user: SELECT name, email FROM user WHERE id = :id
+  html
+    <div class="card">
+      <strong>{user.name}</strong>
+      <span>{user.email}</span>
+    </div>
+```
+
+## JSON API
+
+Same grammar, JSON output. One keyword difference.
+
+```kilnx
+api /api/v1/users requires auth
+  query users: SELECT id, name, email FROM user
+               ORDER BY id DESC paginate 50
+```
+
+Returns `{"data": [...], "pagination": {"page": 1, "total": 42, ...}}`.
+
+## Server-Sent Events
+
+Realtime polling with the embedded htmx SSE extension.
+
+```kilnx
+stream /notifications requires auth
+  query: SELECT message FROM notification
+         WHERE user_id = :current_user.id AND seen = false
+  every 5s
+```
+
+## WebSockets
+
+Bidirectional communication with rooms and broadcast.
+
+```kilnx
+socket /chat/:room requires auth
+  on connect
+    query: SELECT message, author FROM chat_message
+           WHERE room = :room ORDER BY created DESC LIMIT 50
+  on message
+    query: INSERT INTO chat_message (body, author, room)
+           VALUES (:body, :current_user.id, :room)
+    broadcast to :room
+```
+
+## Webhooks
+
+External event receivers with HMAC signature verification. Supports GitHub and Stripe formats.
+
+```kilnx
+webhook /stripe secret env STRIPE_SECRET
+  on event payment_intent.succeeded
+    query: UPDATE order SET status = 'paid'
+           WHERE stripe_id = :event_id
+  on event *
+    query: INSERT INTO webhook_log (event, payload)
+           VALUES (:event.type, :event.body)
+```
+
+## Background Jobs
+
+Async work dispatched from actions and executed in the same binary.
+
+```kilnx
+job send-welcome
+  query data: SELECT name, email FROM user WHERE id = :user_id
+  send email to :email
+    subject: "Welcome {data.name}"
+
+action /users/create method POST
+  query: INSERT INTO user (name, email) VALUES (:name, :email)
+  enqueue send-welcome with user_id: :id
+  redirect /users
+```
+
+## Schedules
+
+Timed tasks running inside the same binary. No Redis, no cron.
+
+```kilnx
+schedule cleanup every 24h
+  query: DELETE FROM session WHERE expires_at < datetime('now')
+
+schedule report every monday at 9:00
+  query stats: SELECT count(*) as new_users FROM user
+               WHERE created > datetime('now', '-7 days')
+  send email to "admin@example.com"
+    subject: "Weekly report: {stats.new_users} new users"
+```
+
+## Rate Limiting
+
+Declarative. Per user or per IP. Wildcard paths.
+
+```kilnx
+limit /api/*
+  requests: 100 per minute per user
+
+limit /login
+  requests: 5 per minute per ip
+  on exceeded: status 429 message "Too many attempts"
+```
+
+## Internationalization
+
+Translations with `{t.key}` interpolation. Language detected from `Accept-Language` header or `?lang=` param.
+
+```kilnx
+translations
+  en
+    welcome: "Welcome back"
+  pt
+    welcome: "Bem vindo de volta"
+
+config
+  default language: en
+  detect language: header accept-language
+
+page /dashboard requires auth
+  "{t.welcome}, {current_user.name}"
+```
+
+## Email
+
+SMTP with templates and attachments.
+
+```kilnx
+action /users/invite method POST requires admin
+  validate
+    email: required, is email
+  query: INSERT INTO user (email, role) VALUES (:email, 'viewer')
+  send email to :email
+    template: invite
+    subject: "You've been invited"
+```
+
+## PDF Generation
+
+Generate PDFs from templates with query data.
+
+```kilnx
+job generate-report
+  query data: SELECT * FROM order WHERE created > :start_date
+  generate pdf from template report with data
+  send email to :requested_by
+    attach: generated pdf
+    subject: "Your report is ready"
+```
+
+## Declarative Tests
+
+Test your app in the same language. No Selenium, no Cypress.
+
+```kilnx
+test "user can register"
+  visit /register
+  fill name with "Alice"
+  fill identity with "alice@test.com"
+  fill password with "secret123"
+  submit
+  expect page /login contains "Log in"
+
+test "homepage loads"
+  visit /
+  expect status 200
+  expect page / contains "Blog"
+```
+
+```bash
+$ kilnx test app.kilnx
+Running 2 test(s):
+  PASS  user can register
+  PASS  homepage loads
+All 2 test(s) passed.
+```
+
+## Template Filters
+
+Built-in filters for formatting output in `html` blocks.
+
+```
+{name|upcase}                    → ALICE
+{name|truncate:20}               → Alice Wonderla...
+{created|date:"Jan 02, 2006"}   → Mar 27, 2026
+{created|timeago}                → 3 hours ago
+{price|currency:"$"}             → $1,234.56
+{count|pluralize:"item","items"} → 3 items
+{bio|raw}                        → unescaped HTML
+{role|default:"viewer"}          → viewer (if empty)
+```
+
+## Layouts
+
+Page wrapper templates.
+
+```kilnx
+layout main
+  html
+    <html>
+    <head>
+      <title>{page.title}</title>
+      {kilnx.js}
+    </head>
+    <body>
+      {nav}
+      {page.content}
+    </body>
+    </html>
+
+page /users layout main title "Users"
+  query users: SELECT name FROM user
+  html
+    {{each users}}<div>{name}</div>{{end}}
+```
+
+## Query Optimization
+
+The optimizer rewrites queries based on template usage:
+
+- **SELECT \* rewriting**: replaces `SELECT *` with only the columns referenced in `{field}` interpolations
+- **JOIN pruning**: removes JOINs when no columns from the joined table are used
+- **Query deduplication**: identical named queries are executed once
+
+## Static Analysis
+
+`kilnx check` runs compile-time validation:
+
+- SQL column and table references match declared models
+- Type compatibility in WHERE clauses (text vs numeric vs bool)
+- Unprotected mutations without auth
+- Password fields exposed in public queries
+- Missing CSRF protection
+- Webhooks without signature verification
+
+## LSP Server
+
+`kilnx lsp` provides IDE integration with completions, diagnostics, and hover documentation.
+
+---
+
+# Changelog
+
+All notable changes to Kilnx are documented in this file.
+
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `tenant` modifier on `model` for multi-tenant scoping with fail-closed guards across every query path (refs [#48](https://github.com/kilnx-org/kilnx/issues/48), [#52](https://github.com/kilnx-org/kilnx/pull/52))
+- PostgreSQL support via `Dialect` abstraction; switch engines with `database: postgres://...` ([#46](https://github.com/kilnx-org/kilnx/pull/46))
+- Multi-file support via `import` statement with `.kilnx` extension enforcement and path traversal protection (closes [#20](https://github.com/kilnx-org/kilnx/issues/20), [#43](https://github.com/kilnx-org/kilnx/pull/43))
+- `static` directive to serve files from a directory, validated to stay within project root ([#42](https://github.com/kilnx-org/kilnx/pull/42))
+- `fetch` keyword for outbound HTTP from actions, jobs, and webhooks ([#39](https://github.com/kilnx-org/kilnx/pull/39))
+- Inline fragment rendering on htmx action redirect: matching fragment is returned in the same response when redirecting to a page that defines it
+
+### Fixed
+- SQL `NULL` no longer rendered as truthy in template conditionals ([#44](https://github.com/kilnx-org/kilnx/pull/44))
+- Filters inside `{{each}}` blocks now resolve from the current row, not the outer scope ([#40](https://github.com/kilnx-org/kilnx/pull/40))
+- `import` treated as directive only at column 0, allowing the token to appear elsewhere
+- Timezone-aware time formats parsed in `date` and `timeago` filters
+- Named parameter error messages clarified
+- `#` characters preserved inside `html` blocks (closes [#32](https://github.com/kilnx-org/kilnx/issues/32), [#33](https://github.com/kilnx-org/kilnx/pull/33))
+
+### Security
+- Mutation bypass via SQL comment, subquery, and string literal closed
+- Tenant guard fails closed and redacts sensitive user fields when rendering
+- Static directory traversal and import traversal blocked; import depth limited
+
+## [0.1.1] - 2026-03-31
+
+### Added
+- Governance files, issue templates, and repo automation
+- Auto-assignment of PRs to CODEOWNER as reviewer and assignee
+- Phase 1 credibility batch ([#38](https://github.com/kilnx-org/kilnx/pull/38))
+
+### Fixed
+- `#` characters preserved inside `html` blocks (closes [#32](https://github.com/kilnx-org/kilnx/issues/32))
+
+## [0.1.0] - 2026-03-28
+
+Initial public release. 27 keywords, 2 runtime dependencies (SQLite + bcrypt), single-binary output.
+
+### Added
+- Declarative constructs: `config`, `model`, `auth`, `permissions`, `layout`, `page`, `action`, `fragment`, `stream`, `socket`, `api`, `webhook`, `job`, `schedule`, `test`
+- Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`
+- Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`
+- CLI: `kilnx run`, `build`, `check`, `test`, `migrate`, `lsp`, `version`
+- SQLite runtime with automatic migrations
+- Declarative auth with bcrypt password hashing and HMAC-signed sessions
+- htmx-aware fragment rendering with `hx-target` / `hx-swap` semantics
+- Server-Sent Events via `stream`, WebSockets via `socket`
+- Background jobs and cron-style `schedule`
+- Declarative `test` blocks with automatic test database (`app.kilnx.test`)
+- Template engine for full HTML control, logical operators, comments
+- Static analyzer: type checking, multi-table column validation, subquery analysis, CSRF and security linting
+- Query deduplication, JOIN pruning, stream materialization hints ([#12](https://github.com/kilnx-org/kilnx/pull/12))
+- Language Server Protocol via `kilnx lsp`
+- Docker image published at `ghcr.io/kilnx-org/kilnx:0.1.0`
+- Install script and GoReleaser-built pre-compiled binaries for macOS and Linux
+
+### Security
+All 14 hardening items from the pre-release security review landed in this version:
+- CSRF protection enabled by default on every mutation path; linter flags missing `csrf` tokens
+- Parameterized SQL with strict binding; injection paths in string literals, comments, and subqueries closed
+- HTML output escaped by default; raw output requires explicit opt-in
+- bcrypt password hashing with per-install cost; constant-time credential comparison
+- HMAC-signed session cookies with `HttpOnly`, `Secure`, `SameSite=Lax`
+- Rate limiting primitives on auth and action endpoints
+- `.kilnx` import sandbox: extension check, project root containment, depth limit
+- Sensitive field redaction in logs and error output
+
+[Unreleased]: https://github.com/kilnx-org/kilnx/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/kilnx-org/kilnx/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/kilnx-org/kilnx/releases/tag/v0.1.0

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,43 @@
+# Kilnx
+
+> Kilnx is a declarative backend language that compiles `.kilnx` source files to a single standalone binary. Models, routes, queries, auth, jobs, WebSockets, SSE, and tests live in one file. SQLite and PostgreSQL are first-class. Zero JavaScript, zero runtime dependencies for the user, built for the htmx era. 27 keywords, 2 runtime dependencies (SQLite + bcrypt), ~15MB binary.
+
+Authoritative references live in this repository. When reasoning about Kilnx code, read the grammar before guessing syntax. Security (CSRF, SQL binding, HTML escaping, session HMAC, bcrypt) is built in and must not be re-implemented by user code.
+
+## Core references
+
+- [Grammar](https://github.com/kilnx-org/kilnx/blob/main/GRAMMAR.md): complete syntax specification, every construct and modifier
+- [Features](https://github.com/kilnx-org/kilnx/blob/main/FEATURES.md): working feature catalogue with runnable examples
+- [Principles](https://github.com/kilnx-org/kilnx/blob/main/PRINCIPLES.md): 11 constitutional design rules that override any ad-hoc decision
+- [Changelog](https://github.com/kilnx-org/kilnx/blob/main/CHANGELOG.md): version history and breaking-change notes
+- [README](https://github.com/kilnx-org/kilnx/blob/main/README.md): short overview and install instructions
+
+## Language constructs
+
+Top-level blocks: `config`, `model`, `auth`, `permissions`, `layout`, `page`, `action`, `fragment`, `stream`, `socket`, `api`, `webhook`, `job`, `schedule`, `test`.
+
+Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`.
+
+Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`.
+
+## CLI
+
+- `kilnx run <file.kilnx>`: dev server with hot reload
+- `kilnx build <file.kilnx> -o <binary>`: compile to standalone binary
+- `kilnx check <file.kilnx>`: static analysis (types, security, SQL)
+- `kilnx test <file.kilnx>`: run declarative `test` blocks
+- `kilnx migrate <file.kilnx> [--dry-run|--status]`: schema migration
+- `kilnx lsp`: Language Server Protocol endpoint
+
+## Example apps
+
+- [CRM](https://github.com/kilnx-org/kilnx/blob/main/examples/crm/app.kilnx): JOINs, Tailwind, 813 LOC
+- [Chat](https://github.com/kilnx-org/kilnx/blob/main/examples/chat/app.kilnx): WebSocket, SSE, reactions, threads
+- [Dashboard](https://github.com/kilnx-org/kilnx/blob/main/examples/dashboard/app.kilnx): webhooks, SSE, aggregated SQL
+- [SaaS](https://github.com/kilnx-org/kilnx/blob/main/examples/saas/app.kilnx): roles, i18n, jobs, rate limiting
+
+## Optional
+
+- [Issue tracker](https://github.com/kilnx-org/kilnx/issues): active roadmap (RFCs, enhancements, bugs)
+- [Contributing guide](https://github.com/kilnx-org/kilnx/blob/main/CONTRIBUTING.md)
+- [Docs site](https://docs.kilnx.org)

--- a/llms.txt
+++ b/llms.txt
@@ -31,10 +31,9 @@ Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`.
 
 ## Example apps
 
-- [CRM](https://github.com/kilnx-org/kilnx/blob/main/examples/crm/app.kilnx): JOINs, Tailwind, 813 LOC
-- [Chat](https://github.com/kilnx-org/kilnx/blob/main/examples/chat/app.kilnx): WebSocket, SSE, reactions, threads
-- [Dashboard](https://github.com/kilnx-org/kilnx/blob/main/examples/dashboard/app.kilnx): webhooks, SSE, aggregated SQL
-- [SaaS](https://github.com/kilnx-org/kilnx/blob/main/examples/saas/app.kilnx): roles, i18n, jobs, rate limiting
+- [hello.kilnx](https://github.com/kilnx-org/kilnx/blob/main/examples/hello.kilnx): minimal single-file app
+- [blog.kilnx](https://github.com/kilnx-org/kilnx/blob/main/examples/blog.kilnx): models, auth, pages, actions
+- [kilnx-example-chat](https://github.com/kilnx-org/kilnx-example-chat): multi-file app with WebSocket, SSE, auth, static assets, Dockerfile
 
 ## Optional
 


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` (Keep-a-Changelog) covering v0.1.0, v0.1.1, and Unreleased. Closes #13.
- Add `llms.txt` + `llms-full.txt` (llmstxt.org format) pointing at principles, grammar, features. Addresses #19.
- Add `AGENTS.md` with hard rules for any coding agent, plus shim files (`CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/kilnx.mdc`) that delegate to it.

## Test plan
- [ ] `kilnx` CLI still builds (`go build ./cmd/kilnx/`)
- [ ] All doc links resolve (CHANGELOG PR/issue refs, llms.txt example links)
- [ ] `llms-full.txt` concatenation order: PRINCIPLES, GRAMMAR, FEATURES, CHANGELOG