### PR TITLE
feat: remove built-in auth UI, enforce user pages via analyzer (closes #55)

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -82,6 +82,7 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkModelDefaults(app.Models)...)
 	diags = append(diags, checkModelMinMax(app.Models)...)
 	diags = append(diags, checkAuthRef(app, schema)...)
+	diags = append(diags, checkAuthPages(app)...)
 	diags = append(diags, checkModelRefs(app, schema)...)
 	diags = append(diags, checkTenantRefs(app, schema)...)
 	diags = append(diags, checkAllSQL(app, schema)...)
@@ -89,6 +90,42 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkTemplateInterpolations(app, schema)...)
 	diags = append(diags, checkTableColumnRefs(app, schema)...)
 
+	return diags
+}
+
+// checkAuthPages ensures that an app declaring an `auth` block also
+// declares the four auth entry pages. The runtime only owns the POST
+// side of those routes; the GET side (form, error display, token
+// validation UI) must live in user-declared pages so the app controls
+// branding and i18n. Catching this at compile time prevents a runtime
+// 404 on an otherwise working-looking app.
+func checkAuthPages(app *parser.App) []Diagnostic {
+	if app == nil || app.Auth == nil {
+		return nil
+	}
+	loginPath := app.Auth.LoginPath
+	if loginPath == "" {
+		loginPath = "/login"
+	}
+	required := []string{loginPath, "/register", "/forgot-password", "/reset-password"}
+	declared := make(map[string]bool)
+	for _, p := range app.Pages {
+		declared[p.Path] = true
+	}
+	var diags []Diagnostic
+	for _, path := range required {
+		if !declared[path] {
+			diags = append(diags, Diagnostic{
+				Level: "error",
+				Message: fmt.Sprintf(
+					"auth block is declared but required page '%s' is missing; "+
+						"declare `page %s` so the app controls the UI "+
+						"(the runtime only owns the POST side of auth routes)",
+					path, path),
+				Context: "auth",
+			})
+		}
+	}
 	return diags
 }
 

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -103,11 +103,26 @@ func checkAuthPages(app *parser.App) []Diagnostic {
 	if app == nil || app.Auth == nil {
 		return nil
 	}
+	// Every auth path is configurable in the `auth` block
+	// (login:, register:, forgot:, reset:). Fall back to the built-in
+	// defaults if the user did not set them explicitly.
 	loginPath := app.Auth.LoginPath
 	if loginPath == "" {
 		loginPath = "/login"
 	}
-	required := []string{loginPath, "/register", "/forgot-password", "/reset-password"}
+	registerPath := app.Auth.RegisterPath
+	if registerPath == "" {
+		registerPath = "/register"
+	}
+	forgotPath := app.Auth.ForgotPath
+	if forgotPath == "" {
+		forgotPath = "/forgot-password"
+	}
+	resetPath := app.Auth.ResetPath
+	if resetPath == "" {
+		resetPath = "/reset-password"
+	}
+	required := []string{loginPath, registerPath, forgotPath, resetPath}
 	declared := make(map[string]bool)
 	for _, p := range app.Pages {
 		declared[p.Path] = true

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -276,6 +276,64 @@ func TestAnalyze_AuthPagesRespectCustomLoginPath(t *testing.T) {
 	}
 }
 
+func TestAnalyze_AuthPagesHonorCustomSlugs(t *testing.T) {
+	// All four auth paths configurable: if the app uses Portuguese
+	// slugs, the analyzer must demand those exact paths (not the
+	// english defaults) and must NOT demand the defaults.
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+				{Name: "password", Type: parser.FieldPassword},
+			}},
+		},
+		Auth: &parser.AuthConfig{
+			Table:        "user",
+			Identity:     "email",
+			Password:     "password",
+			LoginPath:    "/entrar",
+			RegisterPath: "/cadastrar",
+			ForgotPath:   "/senha/esqueci",
+			ResetPath:    "/senha/redefinir",
+		},
+		Pages: []parser.Page{
+			{Path: "/entrar"},
+			{Path: "/cadastrar"},
+			{Path: "/senha/esqueci"},
+			{Path: "/senha/redefinir"},
+		},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "required page") {
+			t.Errorf("all 4 custom slugs declared; unexpected error: %s", d.Message)
+		}
+	}
+
+	// Missing pt-BR page triggers error about THAT path, not /register.
+	app.Pages = []parser.Page{
+		{Path: "/entrar"},
+		{Path: "/senha/esqueci"},
+		{Path: "/senha/redefinir"},
+	}
+	diags = Analyze(app)
+	wantMsg := "'/cadastrar'"
+	dontWant := "'/register'"
+	foundWant := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, dontWant) {
+			t.Errorf("analyzer asked for default '/register' but custom slug is '/cadastrar': %s", d.Message)
+		}
+		if strings.Contains(d.Message, wantMsg) {
+			foundWant = true
+		}
+	}
+	if !foundWant {
+		t.Errorf("expected error mentioning '/cadastrar' (custom register slug), got diagnostics: %+v", diags)
+	}
+}
+
 func TestAnalyze_NoAuthBlock_NoPagesRequired(t *testing.T) {
 	app := &parser.App{
 		Models: []parser.Model{

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -582,6 +582,14 @@ func TestAnalyze_InvalidAuthTable(t *testing.T) {
 			{Name: "user", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
 		},
 		Auth: &parser.AuthConfig{Table: "accounts"},
+		// Declare the four auth pages so this test isolates the
+		// auth-table error; otherwise checkAuthPages would also fire.
+		Pages: []parser.Page{
+			{Path: "/login"},
+			{Path: "/register"},
+			{Path: "/forgot-password"},
+			{Path: "/reset-password"},
+		},
 	}
 
 	diags := Analyze(app)

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -224,6 +224,72 @@ func TestExtractSelectColumns(t *testing.T) {
 	}
 }
 
+func TestAnalyze_AuthPagesRequired(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+				{Name: "password", Type: parser.FieldPassword},
+			}},
+		},
+		Auth: &parser.AuthConfig{Table: "user", Identity: "email", Password: "password", LoginPath: "/login"},
+	}
+	diags := Analyze(app)
+	required := map[string]bool{"/login": false, "/register": false, "/forgot-password": false, "/reset-password": false}
+	for _, d := range diags {
+		for path := range required {
+			if d.Level == "error" && strings.Contains(d.Message, "'"+path+"'") {
+				required[path] = true
+			}
+		}
+	}
+	for path, found := range required {
+		if !found {
+			t.Errorf("expected missing-page error for %s, got diagnostics: %+v", path, diags)
+		}
+	}
+}
+
+func TestAnalyze_AuthPagesRespectCustomLoginPath(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+				{Name: "email", Type: parser.FieldEmail},
+				{Name: "password", Type: parser.FieldPassword},
+			}},
+		},
+		Auth: &parser.AuthConfig{Table: "user", Identity: "email", Password: "password", LoginPath: "/entrar"},
+		Pages: []parser.Page{
+			{Path: "/entrar"},
+			{Path: "/register"},
+			{Path: "/forgot-password"},
+			{Path: "/reset-password"},
+		},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "required page") {
+			t.Errorf("unexpected auth-page error when all 4 paths declared: %s", d.Message)
+		}
+	}
+}
+
+func TestAnalyze_NoAuthBlock_NoPagesRequired(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "user", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
+		},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "required page") {
+			t.Errorf("apps without auth block must not be forced to declare auth pages: %s", d.Message)
+		}
+	}
+}
+
 func TestAnalyze_TenantRefUnknownModel(t *testing.T) {
 	app := &parser.App{
 		Models: []parser.Model{
@@ -297,6 +363,12 @@ func TestAnalyze_ValidApp(t *testing.T) {
 					{Type: parser.NodeQuery, Name: "users", SQL: "SELECT id, name, email, role FROM user ORDER BY id DESC"},
 				},
 			},
+			// Auth pages required because checkAuthPages enforces user
+			// ownership of the GET side of every auth route.
+			{Path: "/login"},
+			{Path: "/register"},
+			{Path: "/forgot-password"},
+			{Path: "/reset-password"},
 		},
 		Actions: []parser.Page{
 			{

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -126,11 +126,15 @@ type Layout struct {
 }
 
 type AuthConfig struct {
-	Table      string // user table name (default: "user")
-	Identity   string // identity field (default: "email")
-	Password   string // password field (default: "password")
-	LoginPath  string // login page path (default: "/login")
-	AfterLogin string // redirect after login (default: "/")
+	Table        string // user table name (default: "user")
+	Identity     string // identity field (default: "email")
+	Password     string // password field (default: "password")
+	LoginPath    string // login page path (default: "/login")
+	LogoutPath   string // logout POST path (default: "/logout")
+	RegisterPath string // registration page path (default: "/register")
+	ForgotPath   string // forgot-password page path (default: "/forgot-password")
+	ResetPath    string // reset-password page path (default: "/reset-password")
+	AfterLogin   string // redirect after login (default: "/")
 }
 
 type Model struct {
@@ -1341,11 +1345,15 @@ func (p *parserState) parseHTMLNode() Node {
 //	  after login: /dashboard
 func (p *parserState) parseAuth() (AuthConfig, error) {
 	cfg := AuthConfig{
-		Table:      "user",
-		Identity:   "email",
-		Password:   "password",
-		LoginPath:  "/login",
-		AfterLogin: "/",
+		Table:        "user",
+		Identity:     "email",
+		Password:     "password",
+		LoginPath:    "/login",
+		LogoutPath:   "/logout",
+		RegisterPath: "/register",
+		ForgotPath:   "/forgot-password",
+		ResetPath:    "/reset-password",
+		AfterLogin:   "/",
 	}
 
 	// consume "auth"
@@ -1400,6 +1408,14 @@ func (p *parserState) parseAuth() (AuthConfig, error) {
 				cfg.Password = val
 			case "login":
 				cfg.LoginPath = val
+			case "logout":
+				cfg.LogoutPath = val
+			case "register":
+				cfg.RegisterPath = val
+			case "forgot", "forgot_password", "forgot-password":
+				cfg.ForgotPath = val
+			case "reset", "reset_password", "reset-password":
+				cfg.ResetPath = val
 			case "after login":
 				cfg.AfterLogin = val
 			}

--- a/internal/runtime/auth.go
+++ b/internal/runtime/auth.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"html"
 	"io"
 	"net/http"
 	"net/smtp"
@@ -395,11 +394,6 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Method == http.MethodGet {
-		s.renderLoginPage(w, r, "")
-		return
-	}
-
 	r.ParseForm()
 	identity := r.FormValue("identity")
 	password := r.FormValue("password")
@@ -411,7 +405,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if identity == "" || password == "" {
-		s.renderLoginPage(w, r, "All fields are required")
+		redirectWithError(w, r, app.Auth.LoginPath, "All fields are required")
 		return
 	}
 
@@ -419,7 +413,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		sanitizeIdentifier(app.Auth.Table), sanitizeIdentifier(app.Auth.Identity))
 	rows, err := s.db.QueryRowsWithParams(sql, map[string]string{"identity": identity})
 	if err != nil || len(rows) == 0 {
-		s.renderLoginPage(w, r, "Invalid credentials")
+		redirectWithError(w, r, app.Auth.LoginPath, "Invalid credentials")
 		return
 	}
 
@@ -427,7 +421,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	passwordHash := user[app.Auth.Password]
 
 	if !CheckPassword(password, passwordHash) {
-		s.renderLoginPage(w, r, "Invalid credentials")
+		redirectWithError(w, r, app.Auth.LoginPath, "Invalid credentials")
 		return
 	}
 
@@ -496,11 +490,6 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Method == http.MethodGet {
-		s.renderRegisterPage(w, r, "")
-		return
-	}
-
 	r.ParseForm()
 	identity := r.FormValue("identity")
 	password := r.FormValue("password")
@@ -513,18 +502,18 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if identity == "" || password == "" {
-		s.renderRegisterPage(w, r, "All fields are required")
+		redirectWithError(w, r, "/register", "All fields are required")
 		return
 	}
 
 	if len(password) < 6 {
-		s.renderRegisterPage(w, r, "Password must be at least 6 characters")
+		redirectWithError(w, r, "/register", "Password must be at least 6 characters")
 		return
 	}
 
 	hash, err := HashPassword(password)
 	if err != nil {
-		s.renderRegisterPage(w, r, "Server error")
+		redirectWithError(w, r, "/register", "Server error")
 		return
 	}
 
@@ -541,176 +530,58 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE") {
-			s.renderRegisterPage(w, r, "An account with that email already exists")
+			redirectWithError(w, r, "/register", "An account with that email already exists")
 			return
 		}
-		s.renderRegisterPage(w, r, "Could not create account")
+		redirectWithError(w, r, "/register", "Could not create account")
 		return
 	}
 
 	http.Redirect(w, r, app.Auth.LoginPath, http.StatusSeeOther)
 }
 
-func (s *Server) renderLoginPage(w http.ResponseWriter, r *http.Request, errorMsg string) {
-	app := s.getApp()
-	csrf := generateCSRFToken()
-
-	errorHTML := ""
-	if errorMsg != "" {
-		errorHTML = fmt.Sprintf("    <div class=\"kilnx-alert kilnx-alert-error\">%s</div>\n", html.EscapeString(errorMsg))
+// redirectWithError issues a 303 See Other to `path?error=...` so the
+// user-declared page can re-render with the error visible via a query
+// parameter (`{error|default:""}`). Keeps POST handlers in Go while
+// letting the UI live entirely in .kilnx land.
+func redirectWithError(w http.ResponseWriter, r *http.Request, path, msg string) {
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
 	}
-
-	identityLabel := "Email"
-	if app.Auth != nil && app.Auth.Identity != "email" {
-		identityLabel = strings.ToUpper(app.Auth.Identity[:1]) + app.Auth.Identity[1:]
-	}
-
-	identityType := "email"
-	if app.Auth != nil && app.Auth.Identity != "email" {
-		identityType = "text"
-	}
-
-	body := fmt.Sprintf(`    <p class="kilnx-auth-sub">Sign in to your account</p>
-%s    <form method="POST" class="kilnx-form">
-      <input type="hidden" name="_csrf" value="%s">
-      <div class="kilnx-field">
-        <label for="identity">%s</label>
-        <input type="%s" id="identity" name="identity" placeholder="%s" required>
-      </div>
-      <div class="kilnx-field">
-        <label for="password">Password</label>
-        <input type="password" id="password" name="password" placeholder="Enter your password" required>
-      </div>
-      <button type="submit" class="kilnx-btn">Log in</button>
-    </form>
-    <p style="margin-top:1.25rem;font-size:0.85rem;text-align:center">Don't have an account? <a href="/register">Register</a></p>
-    <p style="margin-top:0.5rem;font-size:0.85rem;text-align:center"><a href="/forgot-password">Forgot password?</a></p>
-`, errorHTML, csrf, identityLabel, identityType, strings.ToLower(identityLabel)+"@example.com")
-
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(renderAuthPage("Log in", body, app.Pages)))
+	target := path + sep + "error=" + url.QueryEscape(msg)
+	http.Redirect(w, r, target, http.StatusSeeOther)
 }
 
-func (s *Server) renderRegisterPage(w http.ResponseWriter, r *http.Request, errorMsg string) {
-	app := s.getApp()
-	csrf := generateCSRFToken()
-
-	errorHTML := ""
-	if errorMsg != "" {
-		errorHTML = fmt.Sprintf("    <div class=\"kilnx-alert kilnx-alert-error\">%s</div>\n", html.EscapeString(errorMsg))
-	}
-
-	identityLabel := "Email"
-	identityType := "email"
-	if app.Auth != nil && app.Auth.Identity != "email" {
-		identityLabel = strings.ToUpper(app.Auth.Identity[:1]) + app.Auth.Identity[1:]
-		identityType = "text"
-	}
-
-	body := fmt.Sprintf(`    <p class="kilnx-auth-sub">Create your account</p>
-%s    <form method="POST" class="kilnx-form">
-      <input type="hidden" name="_csrf" value="%s">
-      <div class="kilnx-field">
-        <label for="name">Name</label>
-        <input type="text" id="name" name="name" placeholder="Your name" required>
-      </div>
-      <div class="kilnx-field">
-        <label for="identity">%s</label>
-        <input type="%s" id="identity" name="identity" placeholder="%s" required>
-      </div>
-      <div class="kilnx-field">
-        <label for="password">Password</label>
-        <input type="password" id="password" name="password" placeholder="Min 6 characters" required minlength="6">
-      </div>
-      <button type="submit" class="kilnx-btn">Create account</button>
-    </form>
-    <p style="margin-top:1.25rem;font-size:0.85rem;text-align:center">Already have an account? <a href="%s">Log in</a></p>
-`, errorHTML, csrf, identityLabel, identityType, strings.ToLower(identityLabel)+"@example.com", app.Auth.LoginPath)
-
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(renderAuthPage("Register", body, app.Pages)))
-}
-
-func renderAuthPage(title, body string, pages []parser.Page) string {
-	return fmt.Sprintf(`<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>%s</title>
-  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 470 469'><g transform='translate(0,470) scale(0.1,-0.1)' fill='%%23e64a19'><path d='M360 2850 l0-1850 111 0 111 0 240 233c132 127 256 245 274 260l34 28 0 530 0 529 1220 0 1220 0 0-522-1-523 273-267 273-267 113-1 112 0 0 1850 0 1850-1990 0-1990 0 0-1850z M1410 1877l0-473-349-347-349-347-356 0-356 0 2-352c2-194 6-352 11-350 4 1 333 2 732 2l725 0 0 288 0 288 116 215c64 117 156 288 205 379l89 164 0 503 0 503-235 0-235 0 0-473z M2120 2243c0-60-1-322-2-583l-2-475-178-374-178-374 0-213 0-214 590 0 590 0 0 214 0 214-111 233c-61 129-139 290-173 359l-61 125-5 595-5 595-232 3-233 2 0-107z M2820 1848l0-502 92-170c51-94 143-265 205-381l113-210 0-287 0-288 735 0 735 0 0 350 0 350-355 0-355 0-350 346-350 347 0 473 0 474-235 0-235 0 0-502z'/></g></svg>">
-  <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #e4e4e7; background: #09090b; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 1rem; -webkit-font-smoothing: antialiased; }
-    .kilnx-auth-card { width: 100%%; max-width: 400px; background: #18181b; border: 1px solid #27272a; border-radius: 12px; padding: 2rem; box-shadow: 0 8px 30px rgba(0,0,0,0.4); }
-    .kilnx-auth-logo { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1.5rem; }
-    .kilnx-auth-logo svg { width: 28px; height: 28px; }
-    .kilnx-auth-logo span { font-size: 1.1rem; font-weight: 700; color: #ff6e40; letter-spacing: -0.02em; }
-    h2 { margin-bottom: 0.25rem; font-size: 1.5rem; font-weight: 700; color: #fafafa; letter-spacing: -0.02em; }
-    .kilnx-auth-sub { font-size: 0.85rem; color: #71717a; margin-bottom: 1.5rem; }
-    .kilnx-form { display: flex; flex-direction: column; gap: 0.875rem; }
-    .kilnx-field { display: flex; flex-direction: column; gap: 0.3rem; }
-    .kilnx-field label { font-size: 0.8rem; font-weight: 500; color: #a1a1aa; text-transform: uppercase; letter-spacing: 0.04em; }
-    .kilnx-field input { padding: 0.625rem 0.75rem; background: #09090b; border: 1px solid #3f3f46; border-radius: 8px; font-size: 0.9rem; font-family: inherit; color: #fafafa; outline: none; transition: border-color 0.2s, box-shadow 0.2s; }
-    .kilnx-field input:hover { border-color: #52525b; }
-    .kilnx-field input:focus { border-color: #e64a19; box-shadow: 0 0 0 3px rgba(230,74,25,0.2); }
-    .kilnx-field input::placeholder { color: #52525b; }
-    .kilnx-btn { padding: 0.625rem 1.25rem; background: #e64a19; color: white; border: none; border-radius: 8px; font-size: 0.9rem; font-weight: 600; cursor: pointer; font-family: inherit; transition: background 0.2s, box-shadow 0.2s, transform 0.1s; margin-top: 0.25rem; }
-    .kilnx-btn:hover { background: #ff6e40; box-shadow: 0 0 20px rgba(230,74,25,0.25); }
-    .kilnx-btn:active { transform: scale(0.98); }
-    .kilnx-alert { padding: 0.75rem 1rem; border-radius: 8px; margin-bottom: 1rem; font-size: 0.85rem; }
-    .kilnx-alert-error { background: rgba(239,68,68,0.1); color: #fca5a5; border: 1px solid rgba(239,68,68,0.2); }
-    a { color: #ff6e40; text-decoration: none; transition: color 0.2s; }
-    a:hover { color: #ffab91; }
-    p { color: #71717a; }
-  </style>
-</head>
-<body>
-  <div class="kilnx-auth-card">
-  <div class="kilnx-auth-logo">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 470 469"><g transform="translate(0,470) scale(0.1,-0.1)" fill="#e64a19" stroke="none"><path d="M360 2850 l0-1850 111 0 111 0 240 233c132 127 256 245 274 260l34 28 0 530 0 529 1220 0 1220 0 0-522-1-523 273-267 273-267 113-1 112 0 0 1850 0 1850-1990 0-1990 0 0-1850z M1410 1877l0-473-349-347-349-347-356 0-356 0 2-352c2-194 6-352 11-350 4 1 333 2 732 2l725 0 0 288 0 288 116 215c64 117 156 288 205 379l89 164 0 503 0 503-235 0-235 0 0-473z M2120 2243c0-60-1-322-2-583l-2-475-178-374-178-374 0-213 0-214 590 0 590 0 0 214 0 214-111 233c-61 129-139 290-173 359l-61 125-5 595-5 595-232 3-233 2 0-107z M2820 1848l0-502 92-170c51-94 143-265 205-381l113-210 0-287 0-288 735 0 735 0 0 350 0 350-355 0-355 0-350 346-350 347 0 473 0 474-235 0-235 0 0-502z"/></g></svg>
-    <span>kilnx</span>
-  </div>
-  <h2>%s</h2>
-%s  </div>
-</body>
-</html>
-`, html.EscapeString(title), html.EscapeString(title), body)
-}
-
-// sanitizeIdentifier ensures a SQL identifier contains only safe characters
-// handleForgotPassword renders the forgot password form and processes reset requests
+// handleForgotPassword processes reset requests. Only POST is served;
+// GET is rendered by the user-declared `page /forgot-password` (enforced
+// at compile time by the analyzer).
 func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodGet {
-		s.renderForgotPasswordPage(w, r, "")
-		return
-	}
-
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	if err := r.ParseForm(); err != nil {
-		s.renderForgotPasswordPage(w, r, "Invalid request")
+		redirectWithError(w, r, "/forgot-password", "Invalid request")
 		return
 	}
 
 	csrf := r.FormValue("_csrf")
 	if !validateCSRFToken(csrf) {
-		s.renderForgotPasswordPage(w, r, "Invalid CSRF token. Please try again.")
+		redirectWithError(w, r, "/forgot-password", "Invalid CSRF token. Please try again.")
 		return
 	}
 
 	email := strings.TrimSpace(r.FormValue("email"))
 	if email == "" {
-		s.renderForgotPasswordPage(w, r, "Email is required")
+		redirectWithError(w, r, "/forgot-password", "Email is required")
 		return
 	}
 
 	app := s.getApp()
 	if app.Auth == nil || s.db == nil {
-		s.renderForgotPasswordPage(w, r, "Password reset is not available")
+		redirectWithError(w, r, "/forgot-password", "Password reset is not available")
 		return
 	}
 
@@ -722,8 +593,9 @@ func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
 		map[string]string{"email": email},
 	)
 	if err != nil || len(rows) == 0 {
-		// Don't reveal whether the email exists
-		s.renderForgotPasswordSuccess(w, r)
+		// Don't reveal whether the email exists; redirect to the page
+		// with ?sent=1 so it can render a generic confirmation.
+		http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
 		return
 	}
 
@@ -788,48 +660,33 @@ func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("  ╚══════════════════════════════════════════╝\n\n")
 	}
 
-	s.renderForgotPasswordSuccess(w, r)
+	http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
 }
 
 // handleResetPassword processes the password reset form
 func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	token := r.URL.Query().Get("token")
-	if token == "" {
-		http.Redirect(w, r, "/forgot-password", http.StatusSeeOther)
-		return
-	}
-
-	if r.Method == http.MethodGet {
-		// Validate token
-		if s.db == nil {
-			http.Error(w, "Not available", http.StatusInternalServerError)
-			return
-		}
-		rows, err := s.db.QueryRowsWithParams(
-			`SELECT email FROM _kilnx_password_resets WHERE token = :token AND expires_at > datetime('now')`,
-			map[string]string{"token": token},
-		)
-		if err != nil || len(rows) == 0 {
-			s.renderResetPasswordPage(w, r, token, "This reset link is invalid or has expired.")
-			return
-		}
-		s.renderResetPasswordPage(w, r, token, "")
-		return
-	}
 
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
+	if token == "" {
+		http.Redirect(w, r, "/forgot-password", http.StatusSeeOther)
+		return
+	}
+
+	resetURL := "/reset-password?token=" + url.QueryEscape(token)
+
 	if err := r.ParseForm(); err != nil {
-		s.renderResetPasswordPage(w, r, token, "Invalid request")
+		redirectWithError(w, r, resetURL, "Invalid request")
 		return
 	}
 
 	csrf := r.FormValue("_csrf")
 	if !validateCSRFToken(csrf) {
-		s.renderResetPasswordPage(w, r, token, "Invalid CSRF token. Please try again.")
+		redirectWithError(w, r, resetURL, "Invalid CSRF token. Please try again.")
 		return
 	}
 
@@ -837,11 +694,11 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	passwordConfirm := r.FormValue("password_confirm")
 
 	if len(password) < 6 {
-		s.renderResetPasswordPage(w, r, token, "Password must be at least 6 characters")
+		redirectWithError(w, r, resetURL, "Password must be at least 6 characters")
 		return
 	}
 	if password != passwordConfirm {
-		s.renderResetPasswordPage(w, r, token, "Passwords do not match")
+		redirectWithError(w, r, resetURL, "Passwords do not match")
 		return
 	}
 
@@ -851,7 +708,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		map[string]string{"token": token},
 	)
 	if err != nil || len(rows) == 0 {
-		s.renderResetPasswordPage(w, r, token, "This reset link is invalid or has expired.")
+		redirectWithError(w, r, resetURL, "This reset link is invalid or has expired.")
 		return
 	}
 
@@ -860,7 +717,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	// Hash new password
 	hashed, err := bcrypt.GenerateFromPassword([]byte(password), 12)
 	if err != nil {
-		s.renderResetPasswordPage(w, r, token, "An error occurred. Please try again.")
+		redirectWithError(w, r, resetURL, "An error occurred. Please try again.")
 		return
 	}
 
@@ -875,7 +732,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		map[string]string{"password": string(hashed), "email": email},
 	)
 	if err != nil {
-		s.renderResetPasswordPage(w, r, token, "Failed to update password. Please try again.")
+		redirectWithError(w, r, resetURL, "Failed to update password. Please try again.")
 		return
 	}
 
@@ -885,73 +742,12 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		map[string]string{"token": token},
 	)
 
-	// Redirect to login with success
+	// Redirect to login with success flag
 	loginPath := "/login"
 	if app.Auth != nil && app.Auth.LoginPath != "" {
 		loginPath = app.Auth.LoginPath
 	}
-	http.Redirect(w, r, loginPath, http.StatusSeeOther)
-}
-
-func (s *Server) renderForgotPasswordPage(w http.ResponseWriter, r *http.Request, errorMsg string) {
-	csrf := generateCSRFToken()
-	errorHTML := ""
-	if errorMsg != "" {
-		errorHTML = fmt.Sprintf("    <div class=\"kilnx-alert kilnx-alert-error\">%s</div>\n", html.EscapeString(errorMsg))
-	}
-
-	app := s.getApp()
-	body := fmt.Sprintf(`    <p class="kilnx-auth-sub">Enter your email to receive a reset link</p>
-%s    <form method="POST" class="kilnx-form">
-      <input type="hidden" name="_csrf" value="%s">
-      <div class="kilnx-field">
-        <label for="email">Email</label>
-        <input type="email" id="email" name="email" placeholder="you@example.com" required>
-      </div>
-      <button type="submit" class="kilnx-btn">Send reset link</button>
-    </form>
-    <p style="margin-top:1.25rem;font-size:0.85rem;text-align:center"><a href="%s">Back to login</a></p>
-`, errorHTML, csrf, app.Auth.LoginPath)
-
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(renderAuthPage("Forgot password", body, app.Pages)))
-}
-
-func (s *Server) renderForgotPasswordSuccess(w http.ResponseWriter, r *http.Request) {
-	app := s.getApp()
-	body := fmt.Sprintf(`    <p class="kilnx-auth-sub">Check your email</p>
-    <p style="font-size:0.9rem;color:#a1a1aa;margin-bottom:1.5rem">If an account exists with that email, we sent a password reset link. Check your inbox.</p>
-    <p style="font-size:0.85rem;text-align:center"><a href="%s">Back to login</a></p>
-`, app.Auth.LoginPath)
-
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(renderAuthPage("Check your email", body, app.Pages)))
-}
-
-func (s *Server) renderResetPasswordPage(w http.ResponseWriter, r *http.Request, token, errorMsg string) {
-	csrf := generateCSRFToken()
-	errorHTML := ""
-	if errorMsg != "" {
-		errorHTML = fmt.Sprintf("    <div class=\"kilnx-alert kilnx-alert-error\">%s</div>\n", html.EscapeString(errorMsg))
-	}
-
-	body := fmt.Sprintf(`    <p class="kilnx-auth-sub">Choose a new password</p>
-%s    <form method="POST" action="/reset-password?token=%s" class="kilnx-form">
-      <input type="hidden" name="_csrf" value="%s">
-      <div class="kilnx-field">
-        <label for="password">New password</label>
-        <input type="password" id="password" name="password" placeholder="Min 6 characters" required minlength="6">
-      </div>
-      <div class="kilnx-field">
-        <label for="password_confirm">Confirm password</label>
-        <input type="password" id="password_confirm" name="password_confirm" placeholder="Repeat password" required minlength="6">
-      </div>
-      <button type="submit" class="kilnx-btn">Reset password</button>
-    </form>
-`, errorHTML, html.EscapeString(token), csrf)
-
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(renderAuthPage("Reset password", body, nil)))
+	http.Redirect(w, r, loginPath+"?reset=1", http.StatusSeeOther)
 }
 
 func sanitizeIdentifier(name string) string {

--- a/internal/runtime/auth.go
+++ b/internal/runtime/auth.go
@@ -344,7 +344,7 @@ func (s *Server) hasPermission(userRole, requiredRole string, perms []parser.Per
 }
 
 func renderForbidden(pages []parser.Page, session *Session) string {
-	nav := renderNav(pages, "", session, "")
+	nav := renderNav(pages, "", session, "", "")
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -619,7 +619,7 @@ func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
 	if r.TLS != nil {
 		scheme = "https"
 	}
-	resetURL := fmt.Sprintf("%s://%s/reset-password?token=%s", scheme, r.Host, token)
+	resetURL := fmt.Sprintf("%s://%s%s?token=%s", scheme, r.Host, app.Auth.ResetPath, token)
 
 	// Try to send email, fall back to console
 	sent := false

--- a/internal/runtime/auth.go
+++ b/internal/runtime/auth.go
@@ -502,18 +502,18 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if identity == "" || password == "" {
-		redirectWithError(w, r, "/register", "All fields are required")
+		redirectWithError(w, r, app.Auth.RegisterPath, "All fields are required")
 		return
 	}
 
 	if len(password) < 6 {
-		redirectWithError(w, r, "/register", "Password must be at least 6 characters")
+		redirectWithError(w, r, app.Auth.RegisterPath, "Password must be at least 6 characters")
 		return
 	}
 
 	hash, err := HashPassword(password)
 	if err != nil {
-		redirectWithError(w, r, "/register", "Server error")
+		redirectWithError(w, r, app.Auth.RegisterPath, "Server error")
 		return
 	}
 
@@ -530,10 +530,10 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE") {
-			redirectWithError(w, r, "/register", "An account with that email already exists")
+			redirectWithError(w, r, app.Auth.RegisterPath, "An account with that email already exists")
 			return
 		}
-		redirectWithError(w, r, "/register", "Could not create account")
+		redirectWithError(w, r, app.Auth.RegisterPath, "Could not create account")
 		return
 	}
 
@@ -562,26 +562,26 @@ func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	app := s.getApp()
+	if app.Auth == nil || s.db == nil {
+		http.Error(w, "Password reset is not available", http.StatusInternalServerError)
+		return
+	}
+
 	if err := r.ParseForm(); err != nil {
-		redirectWithError(w, r, "/forgot-password", "Invalid request")
+		redirectWithError(w, r, app.Auth.ForgotPath, "Invalid request")
 		return
 	}
 
 	csrf := r.FormValue("_csrf")
 	if !validateCSRFToken(csrf) {
-		redirectWithError(w, r, "/forgot-password", "Invalid CSRF token. Please try again.")
+		redirectWithError(w, r, app.Auth.ForgotPath, "Invalid CSRF token. Please try again.")
 		return
 	}
 
 	email := strings.TrimSpace(r.FormValue("email"))
 	if email == "" {
-		redirectWithError(w, r, "/forgot-password", "Email is required")
-		return
-	}
-
-	app := s.getApp()
-	if app.Auth == nil || s.db == nil {
-		redirectWithError(w, r, "/forgot-password", "Password reset is not available")
+		redirectWithError(w, r, app.Auth.ForgotPath, "Email is required")
 		return
 	}
 
@@ -595,7 +595,7 @@ func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
 	if err != nil || len(rows) == 0 {
 		// Don't reveal whether the email exists; redirect to the page
 		// with ?sent=1 so it can render a generic confirmation.
-		http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
+		http.Redirect(w, r, app.Auth.ForgotPath+"?sent=1", http.StatusSeeOther)
 		return
 	}
 
@@ -660,7 +660,7 @@ func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("  ╚══════════════════════════════════════════╝\n\n")
 	}
 
-	http.Redirect(w, r, "/forgot-password?sent=1", http.StatusSeeOther)
+	http.Redirect(w, r, app.Auth.ForgotPath+"?sent=1", http.StatusSeeOther)
 }
 
 // handleResetPassword processes the password reset form
@@ -672,12 +672,18 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if token == "" {
-		http.Redirect(w, r, "/forgot-password", http.StatusSeeOther)
+	app := s.getApp()
+	if app.Auth == nil || s.db == nil {
+		http.Error(w, "Password reset is not available", http.StatusInternalServerError)
 		return
 	}
 
-	resetURL := "/reset-password?token=" + url.QueryEscape(token)
+	if token == "" {
+		http.Redirect(w, r, app.Auth.ForgotPath, http.StatusSeeOther)
+		return
+	}
+
+	resetURL := app.Auth.ResetPath + "?token=" + url.QueryEscape(token)
 
 	if err := r.ParseForm(); err != nil {
 		redirectWithError(w, r, resetURL, "Invalid request")
@@ -722,7 +728,6 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update password
-	app := s.getApp()
 	table := sanitizeIdentifier(app.Auth.Table)
 	identity := sanitizeIdentifier(app.Auth.Identity)
 	passField := sanitizeIdentifier(app.Auth.Password)
@@ -743,11 +748,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	)
 
 	// Redirect to login with success flag
-	loginPath := "/login"
-	if app.Auth != nil && app.Auth.LoginPath != "" {
-		loginPath = app.Auth.LoginPath
-	}
-	http.Redirect(w, r, loginPath+"?reset=1", http.StatusSeeOther)
+	http.Redirect(w, r, app.Auth.LoginPath+"?reset=1", http.StatusSeeOther)
 }
 
 func sanitizeIdentifier(name string) string {

--- a/internal/runtime/auth_override_test.go
+++ b/internal/runtime/auth_override_test.go
@@ -211,6 +211,82 @@ page /home requires auth
 	}
 }
 
+// TestAuthOverride_CustomSlugs proves all four auth paths are
+// configurable in the auth block. Apps that want Portuguese (or any
+// other language) slugs declare them via `register:`, `forgot:`,
+// `reset:` and the runtime + analyzer honor them end to end.
+func TestAuthOverride_CustomSlugs(t *testing.T) {
+	src := `
+config
+  secret: "test-secret-32-bytes-min-len-padding"
+
+model user
+  name: text required
+  email: email unique
+  password: password required
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /entrar
+  register: /cadastrar
+  forgot: /senha/esqueci
+  reset: /senha/redefinir
+  after login: /inicio
+
+page /entrar
+  html
+    <div class="marker-entrar">Entrar</div>
+
+page /cadastrar
+  html
+    <div class="marker-cadastrar">Cadastrar</div>
+
+page /senha/esqueci
+  html
+    <div class="marker-esqueci">Esqueci</div>
+
+page /senha/redefinir
+  html
+    <div class="marker-redefinir">Redefinir</div>
+
+page /inicio requires auth
+  html
+    inicio
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	cases := []struct{ path, marker string }{
+		{"/entrar", "marker-entrar"},
+		{"/cadastrar", "marker-cadastrar"},
+		{"/senha/esqueci", "marker-esqueci"},
+		{"/senha/redefinir", "marker-redefinir"},
+	}
+	for _, c := range cases {
+		_, body := httpGet(t, baseURL+c.path)
+		if !strings.Contains(body, c.marker) {
+			t.Errorf("GET %s should render user page (expected %q), got:\n%s", c.path, c.marker, body)
+		}
+	}
+
+	// POST on a custom slug still routes to the built-in handler
+	// (CSRF-less POST expected to fail with 403).
+	form := url.Values{}
+	form.Set("name", "Alice")
+	form.Set("identity", "alice@test.com")
+	form.Set("password", "supersecret")
+	resp, err := http.Post(baseURL+"/cadastrar", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("POST /cadastrar: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("POST /cadastrar without CSRF should hit built-in handler (expect 403), got %d", resp.StatusCode)
+	}
+}
+
 // TestAuthOverride_ForgotAndResetHonorOverride covers the remaining
 // auth routes behind the same override rule.
 func TestAuthOverride_ForgotAndResetHonorOverride(t *testing.T) {

--- a/internal/runtime/auth_override_test.go
+++ b/internal/runtime/auth_override_test.go
@@ -93,38 +93,6 @@ page /home requires auth
 	}
 }
 
-// TestAuthOverride_DefaultRenderWhenNoUserPage asserts the default dark
-// built-in UI still renders for projects that do NOT declare a page.
-func TestAuthOverride_DefaultRenderWhenNoUserPage(t *testing.T) {
-	src := `
-config
-  secret: "test-secret-32-bytes-min-len-padding"
-
-model user
-  name: text required
-  email: email unique
-  password: password required
-
-auth
-  table: user
-  identity: email
-  password: password
-  login: /login
-  after login: /home
-
-page /home requires auth
-  html
-    home
-`
-	baseURL, cleanup := startTestServer(t, src)
-	defer cleanup()
-
-	_, body := httpGet(t, baseURL+"/register")
-	if !strings.Contains(body, "kilnx-auth-card") {
-		t.Fatalf("GET /register should fall back to built-in UI when no page declared; body:\n%s", body)
-	}
-}
-
 // TestAuthOverride_LoginPathHonorsOverride uses a non-default LoginPath
 // (/entrar) to prove the dispatcher reads app.Auth.LoginPath dynamically
 // rather than a hardcoded /login string.

--- a/internal/runtime/auth_override_test.go
+++ b/internal/runtime/auth_override_test.go
@@ -1,0 +1,207 @@
+package runtime
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestAuthOverride_RegisterGETUsesUserPage asserts that declaring a
+// `page /register` in the app overrides the built-in dark auth UI on
+// GET requests while the POST flow still hits the built-in handler.
+func TestAuthOverride_RegisterGETUsesUserPage(t *testing.T) {
+	src := `
+config
+  secret: "test-secret-32-bytes-min-len-padding"
+
+model user
+  name: text required
+  email: email unique
+  password: password required
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /home
+
+page /register
+  html
+    <div class="custom-register-marker">Custom Register UI</div>
+
+page /home requires auth
+  html
+    welcome
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	_, body := httpGet(t, baseURL+"/register")
+	if !strings.Contains(body, "custom-register-marker") {
+		t.Fatalf("GET /register should render user page, got:\n%s", body)
+	}
+	if strings.Contains(body, "kilnx-auth-card") {
+		t.Errorf("GET /register should NOT render the built-in kilnx-auth-card when a page is declared; body:\n%s", body)
+	}
+}
+
+// TestAuthOverride_RegisterPOSTStaysBuiltin asserts that POST still hits
+// the built-in handler even when a custom page is declared, so bcrypt
+// hashing and session creation keep working.
+func TestAuthOverride_RegisterPOSTStaysBuiltin(t *testing.T) {
+	src := `
+config
+  secret: "test-secret-32-bytes-min-len-padding"
+
+model user
+  name: text required
+  email: email unique
+  password: password required
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /home
+
+page /register
+  html
+    <p>custom</p>
+
+page /home requires auth
+  html
+    home
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	// POST without CSRF must be rejected by the built-in handler (HTTP 403).
+	form := url.Values{}
+	form.Set("name", "Alice")
+	form.Set("identity", "alice@test.com")
+	form.Set("password", "supersecret")
+	resp, err := http.Post(baseURL+"/register", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("POST /register: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 (built-in CSRF check) for POST /register without token, got %d", resp.StatusCode)
+	}
+}
+
+// TestAuthOverride_DefaultRenderWhenNoUserPage asserts the default dark
+// built-in UI still renders for projects that do NOT declare a page.
+func TestAuthOverride_DefaultRenderWhenNoUserPage(t *testing.T) {
+	src := `
+config
+  secret: "test-secret-32-bytes-min-len-padding"
+
+model user
+  name: text required
+  email: email unique
+  password: password required
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /home
+
+page /home requires auth
+  html
+    home
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	_, body := httpGet(t, baseURL+"/register")
+	if !strings.Contains(body, "kilnx-auth-card") {
+		t.Fatalf("GET /register should fall back to built-in UI when no page declared; body:\n%s", body)
+	}
+}
+
+// TestAuthOverride_LoginPathHonorsOverride covers the LoginPath case
+// (configurable via auth block) in addition to /register.
+func TestAuthOverride_LoginPathHonorsOverride(t *testing.T) {
+	src := `
+config
+  secret: "test-secret-32-bytes-min-len-padding"
+
+model user
+  name: text required
+  email: email unique
+  password: password required
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /home
+
+page /login
+  html
+    <div class="custom-login-marker">Custom Login</div>
+
+page /home requires auth
+  html
+    home
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	_, body := httpGet(t, baseURL+"/login")
+	if !strings.Contains(body, "custom-login-marker") {
+		t.Fatalf("GET /login should render user page when declared, got:\n%s", body)
+	}
+}
+
+// TestAuthOverride_ForgotAndResetHonorOverride covers the remaining
+// auth routes behind the same override rule.
+func TestAuthOverride_ForgotAndResetHonorOverride(t *testing.T) {
+	src := `
+config
+  secret: "test-secret-32-bytes-min-len-padding"
+
+model user
+  name: text required
+  email: email unique
+  password: password required
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /home
+
+page /forgot-password
+  html
+    <div class="custom-forgot-marker">Forgot</div>
+
+page /reset-password
+  html
+    <div class="custom-reset-marker">Reset</div>
+
+page /home requires auth
+  html
+    home
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	for _, p := range []struct{ path, marker string }{
+		{"/forgot-password", "custom-forgot-marker"},
+		{"/reset-password", "custom-reset-marker"},
+	} {
+		_, body := httpGet(t, baseURL+p.path)
+		if !strings.Contains(body, p.marker) {
+			t.Errorf("GET %s should render user page (expected marker %q), got:\n%s", p.path, p.marker, body)
+		}
+	}
+}

--- a/internal/runtime/auth_override_test.go
+++ b/internal/runtime/auth_override_test.go
@@ -125,9 +125,91 @@ page /home requires auth
 	}
 }
 
-// TestAuthOverride_LoginPathHonorsOverride covers the LoginPath case
-// (configurable via auth block) in addition to /register.
+// TestAuthOverride_LoginPathHonorsOverride uses a non-default LoginPath
+// (/entrar) to prove the dispatcher reads app.Auth.LoginPath dynamically
+// rather than a hardcoded /login string.
 func TestAuthOverride_LoginPathHonorsOverride(t *testing.T) {
+	src := `
+config
+  secret: "test-secret-32-bytes-min-len-padding"
+
+model user
+  name: text required
+  email: email unique
+  password: password required
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /entrar
+  after login: /home
+
+page /entrar
+  html
+    <div class="custom-login-marker">Custom Login</div>
+
+page /home requires auth
+  html
+    home
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	_, body := httpGet(t, baseURL+"/entrar")
+	if !strings.Contains(body, "custom-login-marker") {
+		t.Fatalf("GET /entrar should render user page when declared, got:\n%s", body)
+	}
+}
+
+// TestAuthOverride_CustomLoginPathPOSTStaysBuiltin verifies POST on a
+// non-default LoginPath still goes to the built-in handler so bcrypt
+// comparison and session issuance keep working.
+func TestAuthOverride_CustomLoginPathPOSTStaysBuiltin(t *testing.T) {
+	src := `
+config
+  secret: "test-secret-32-bytes-min-len-padding"
+
+model user
+  name: text required
+  email: email unique
+  password: password required
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /entrar
+  after login: /home
+
+page /entrar
+  html
+    custom
+
+page /home requires auth
+  html
+    home
+`
+	baseURL, cleanup := startTestServer(t, src)
+	defer cleanup()
+
+	form := url.Values{}
+	form.Set("identity", "alice@test.com")
+	form.Set("password", "supersecret")
+	resp, err := http.Post(baseURL+"/entrar", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("POST /entrar: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 (built-in CSRF check) for POST /entrar without token, got %d", resp.StatusCode)
+	}
+}
+
+// TestAuthOverride_LogoutGETRendersUserPage covers the /logout override.
+// GET goes to the user page (confirmation dialog) when declared; POST
+// always invalidates the session via the built-in handler.
+func TestAuthOverride_LogoutGETRendersUserPage(t *testing.T) {
 	src := `
 config
   secret: "test-secret-32-bytes-min-len-padding"
@@ -144,9 +226,9 @@ auth
   login: /login
   after login: /home
 
-page /login
+page /logout
   html
-    <div class="custom-login-marker">Custom Login</div>
+    <div class="custom-logout-marker">Confirmar saida</div>
 
 page /home requires auth
   html
@@ -155,9 +237,9 @@ page /home requires auth
 	baseURL, cleanup := startTestServer(t, src)
 	defer cleanup()
 
-	_, body := httpGet(t, baseURL+"/login")
-	if !strings.Contains(body, "custom-login-marker") {
-		t.Fatalf("GET /login should render user page when declared, got:\n%s", body)
+	_, body := httpGet(t, baseURL+"/logout")
+	if !strings.Contains(body, "custom-logout-marker") {
+		t.Fatalf("GET /logout should render user page when declared, got:\n%s", body)
 	}
 }
 

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -171,27 +171,50 @@ func (s *Server) Start() error {
 			}
 		}
 
-		// Auth routes (auto-generated when auth block is present)
+		// Auth routes (auto-generated when auth block is present).
+		// A GET request falls through to the normal page routing when the
+		// user declared a `page` at the same path, allowing the app to
+		// override the default UI. POST/PUT/DELETE always hit the built-in
+		// handler because it performs bcrypt hashing, session signing, and
+		// other security-sensitive logic that must not be re-implemented
+		// in user code.
 		if app.Auth != nil {
-			if r.URL.Path == app.Auth.LoginPath {
-				s.handleLogin(w, r)
-				return
+			p := r.URL.Path
+			if p == app.Auth.LoginPath {
+				if r.Method == http.MethodGet && hasUserPage(app, p) {
+					// fall through to page routing
+				} else {
+					s.handleLogin(w, r)
+					return
+				}
 			}
-			if r.URL.Path == "/logout" {
+			if p == "/logout" {
 				s.handleLogout(w, r)
 				return
 			}
-			if r.URL.Path == "/register" {
-				s.handleRegister(w, r)
-				return
+			if p == "/register" {
+				if r.Method == http.MethodGet && hasUserPage(app, p) {
+					// fall through
+				} else {
+					s.handleRegister(w, r)
+					return
+				}
 			}
-			if r.URL.Path == "/forgot-password" {
-				s.handleForgotPassword(w, r)
-				return
+			if p == "/forgot-password" {
+				if r.Method == http.MethodGet && hasUserPage(app, p) {
+					// fall through
+				} else {
+					s.handleForgotPassword(w, r)
+					return
+				}
 			}
-			if r.URL.Path == "/reset-password" {
-				s.handleResetPassword(w, r)
-				return
+			if p == "/reset-password" {
+				if r.Method == http.MethodGet && hasUserPage(app, p) {
+					// fall through
+				} else {
+					s.handleResetPassword(w, r)
+					return
+				}
 			}
 		}
 
@@ -1341,6 +1364,22 @@ func (s *Server) handleActionNodes(w http.ResponseWriter, r *http.Request, nodes
 			}
 		}
 	}
+}
+
+// hasUserPage reports whether the app declares a `page` at exactly the
+// given path (exact match, no :param wildcards). Used by the auth route
+// dispatcher to decide whether a GET request should render the user's
+// custom page instead of the built-in default auth UI.
+func hasUserPage(app *parser.App, path string) bool {
+	if app == nil {
+		return false
+	}
+	for _, p := range app.Pages {
+		if p.Path == path {
+			return true
+		}
+	}
+	return false
 }
 
 // matchPath checks if a route pattern matches a URL path.

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -177,30 +177,26 @@ func (s *Server) Start() error {
 		// always fall through to user-declared pages; the analyzer
 		// enforces that the app declares a page at each auth path, so
 		// reaching GET here with no page means the user bypassed
-		// `kilnx check`.
-		if app.Auth != nil {
+		// `kilnx check`. All four auth paths honor the values configured
+		// in the `auth` block (e.g. `login: /entrar`, `register: /cadastrar`).
+		if app.Auth != nil && r.Method != http.MethodGet {
 			p := r.URL.Path
-			if r.Method != http.MethodGet {
-				if p == app.Auth.LoginPath {
-					s.handleLogin(w, r)
-					return
-				}
-				if p == "/logout" {
-					s.handleLogout(w, r)
-					return
-				}
-				if p == "/register" {
-					s.handleRegister(w, r)
-					return
-				}
-				if p == "/forgot-password" {
-					s.handleForgotPassword(w, r)
-					return
-				}
-				if p == "/reset-password" {
-					s.handleResetPassword(w, r)
-					return
-				}
+			switch p {
+			case app.Auth.LoginPath:
+				s.handleLogin(w, r)
+				return
+			case app.Auth.LogoutPath:
+				s.handleLogout(w, r)
+				return
+			case app.Auth.RegisterPath:
+				s.handleRegister(w, r)
+				return
+			case app.Auth.ForgotPath:
+				s.handleForgotPassword(w, r)
+				return
+			case app.Auth.ResetPath:
+				s.handleResetPassword(w, r)
+				return
 			}
 		}
 

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -179,7 +179,7 @@ func (s *Server) Start() error {
 		// reaching GET here with no page means the user bypassed
 		// `kilnx check`. All four auth paths honor the values configured
 		// in the `auth` block (e.g. `login: /entrar`, `register: /cadastrar`).
-		if app.Auth != nil && r.Method != http.MethodGet {
+		if app.Auth != nil && r.Method == http.MethodPost {
 			p := r.URL.Path
 			switch p {
 			case app.Auth.LoginPath:
@@ -465,7 +465,11 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 	if app.Config != nil {
 		appName = app.Config.Name
 	}
-	nav := renderNav(allPages, p.Path, ctx.currentUser, appName)
+	logoutPath := ""
+	if app.Auth != nil {
+		logoutPath = app.Auth.LogoutPath
+	}
+	nav := renderNav(allPages, p.Path, ctx.currentUser, appName, logoutPath)
 	content := bodyContent
 	if p.Layout != "" {
 		for _, layout := range app.Layouts {
@@ -576,7 +580,10 @@ func interpolate(text string, ctx *renderContext) string {
 	})
 }
 
-func renderNav(pages []parser.Page, currentPath string, session *Session, appName string) string {
+func renderNav(pages []parser.Page, currentPath string, session *Session, appName string, logoutPath string) string {
+	if logoutPath == "" {
+		logoutPath = "/logout"
+	}
 	var nav strings.Builder
 	nav.WriteString("  <header class=\"kilnx-topbar\">\n")
 	nav.WriteString("    <div class=\"kilnx-topbar-left\">\n")
@@ -616,7 +623,7 @@ func renderNav(pages []parser.Page, currentPath string, session *Session, appNam
 		nav.WriteString(fmt.Sprintf("      <span class=\"kilnx-user\">%s</span>\n",
 			html.EscapeString(session.Identity)))
 		csrf := generateCSRFToken()
-		nav.WriteString(fmt.Sprintf("      <form method=\"POST\" action=\"/logout\" style=\"display:inline;margin:0\"><input type=\"hidden\" name=\"_csrf\" value=\"%s\"><button type=\"submit\" class=\"kilnx-logout\">Logout</button></form>\n", csrf))
+		nav.WriteString(fmt.Sprintf("      <form method=\"POST\" action=\"%s\" style=\"display:inline;margin:0\"><input type=\"hidden\" name=\"_csrf\" value=\"%s\"><button type=\"submit\" class=\"kilnx-logout\">Logout</button></form>\n", html.EscapeString(logoutPath), csrf))
 		nav.WriteString("    </div>\n")
 	}
 	nav.WriteString("  </header>\n")
@@ -624,7 +631,7 @@ func renderNav(pages []parser.Page, currentPath string, session *Session, appNam
 }
 
 func render404(path string, pages []parser.Page) string {
-	nav := renderNav(pages, "", nil, "")
+	nav := renderNav(pages, "", nil, "", "")
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -171,54 +171,33 @@ func (s *Server) Start() error {
 			}
 		}
 
-		// Auth routes (auto-generated when auth block is present).
-		// A GET request falls through to the normal page routing when the
-		// user declared a `page` at the same path, allowing the app to
-		// override the default UI. POST/PUT/DELETE always hit the built-in
-		// handler because it performs bcrypt hashing, session signing, and
-		// other security-sensitive logic that must not be re-implemented
-		// in user code.
+		// Auth routes. When an `auth` block is declared, the runtime owns
+		// the POST side of these endpoints (bcrypt hashing, session
+		// signing, CSRF validation, password reset tokens). GET requests
+		// always fall through to user-declared pages; the analyzer
+		// enforces that the app declares a page at each auth path, so
+		// reaching GET here with no page means the user bypassed
+		// `kilnx check`.
 		if app.Auth != nil {
 			p := r.URL.Path
-			if p == app.Auth.LoginPath {
-				if r.Method == http.MethodGet && hasUserPage(app, p) {
-					// fall through to page routing
-				} else {
+			if r.Method != http.MethodGet {
+				if p == app.Auth.LoginPath {
 					s.handleLogin(w, r)
 					return
 				}
-			}
-			if p == "/logout" {
-				// GET may show a confirmation page; if the app declared
-				// one, render it. POST (actual logout) always runs the
-				// built-in handler so the session is invalidated safely.
-				if r.Method == http.MethodGet && hasUserPage(app, p) {
-					// fall through
-				} else {
+				if p == "/logout" {
 					s.handleLogout(w, r)
 					return
 				}
-			}
-			if p == "/register" {
-				if r.Method == http.MethodGet && hasUserPage(app, p) {
-					// fall through
-				} else {
+				if p == "/register" {
 					s.handleRegister(w, r)
 					return
 				}
-			}
-			if p == "/forgot-password" {
-				if r.Method == http.MethodGet && hasUserPage(app, p) {
-					// fall through
-				} else {
+				if p == "/forgot-password" {
 					s.handleForgotPassword(w, r)
 					return
 				}
-			}
-			if p == "/reset-password" {
-				if r.Method == http.MethodGet && hasUserPage(app, p) {
-					// fall through
-				} else {
+				if p == "/reset-password" {
 					s.handleResetPassword(w, r)
 					return
 				}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -189,8 +189,15 @@ func (s *Server) Start() error {
 				}
 			}
 			if p == "/logout" {
-				s.handleLogout(w, r)
-				return
+				// GET may show a confirmation page; if the app declared
+				// one, render it. POST (actual logout) always runs the
+				// built-in handler so the session is invalidated safely.
+				if r.Method == http.MethodGet && hasUserPage(app, p) {
+					// fall through
+				} else {
+					s.handleLogout(w, r)
+					return
+				}
 			}
 			if p == "/register" {
 				if r.Method == http.MethodGet && hasUserPage(app, p) {
@@ -1367,9 +1374,10 @@ func (s *Server) handleActionNodes(w http.ResponseWriter, r *http.Request, nodes
 }
 
 // hasUserPage reports whether the app declares a `page` at exactly the
-// given path (exact match, no :param wildcards). Used by the auth route
-// dispatcher to decide whether a GET request should render the user's
-// custom page instead of the built-in default auth UI.
+// given path. Uses exact string equality (not matchPath) because the
+// auth dispatcher only needs to cover fixed paths like /login and
+// /register; parameterised matching would let a page like /login-extra
+// accidentally shadow the built-in /login.
 func hasUserPage(app *parser.App, path string) bool {
 	if app == nil {
 		return false


### PR DESCRIPTION
Closes [#55](https://github.com/kilnx-org/kilnx/issues/55).

## Problem

Kilnx hardcoded the GET UI for `/login`, `/register`, `/forgot-password`, `/reset-password` into the binary with a dark theme, orange accent, and embedded `kilnx` wordmark. User-declared pages at those paths were silently ignored. Every production app that didn't patch Kilnx leaked Kilnx branding. Also, only `/login` was path-configurable; the other three were hardcoded literals, blocking non-English apps from customizing their URLs.

## Resolution (Option D from design discussion)

1. **Remove the built-in auth UI.** Runtime no longer ships any GET rendering for auth routes. The binary drops ~220 lines of HTML/CSS/SVG including the dark theme and wordmark.
2. **Runtime owns POST only.** Password hashing, CSRF, session signing, and reset-token verification stay in Go where they belong.
3. **User declares the pages.** Every auth path requires a `page` declaration. The analyzer enforces this at compile time so missing pages surface on `kilnx check`, not at runtime.
4. **All four paths configurable.** The `auth` block now accepts `register:`, `forgot:`, `reset:` (and `logout:`) in addition to `login:`. Defaults preserved.

## New AuthConfig shape

```kilnx
auth
  table: user
  identity: email
  password: password
  login: /entrar            # default /login
  logout: /sair              # default /logout
  register: /cadastrar       # default /register
  forgot: /senha/esqueci     # default /forgot-password (also: forgot_password, forgot-password)
  reset: /senha/redefinir    # default /reset-password  (also: reset_password, reset-password)
  after login: /inicio
```

## Dispatcher behavior

| | Before | After |
|---|---|---|
| Runtime owns GET on auth paths | yes (built-in dark UI) | no (user page renders) |
| Runtime owns POST on auth paths | yes | yes (unchanged) |
| `/register` path configurable | no | yes |
| `/forgot-password` path configurable | no | yes |
| `/reset-password` path configurable | no | yes |
| `/logout` path configurable | no | yes |
| Missing page at auth path | built-in default served | `kilnx check` errors |
| POST validation error | re-rendered with built-in HTML | 303 redirect to `path?error=...`; page reads `{error\|default:""}` |
| forgot-password confirmation | built-in success page | 303 to `<forgot>?sent=1`; page branches on `{sent\|default:""}` |
| reset-password success | redirect `/login` | redirect `<login>?reset=1`; page can show flash |

## Implementation

**Removed from `auth.go`** (~220 lines): `renderLoginPage`, `renderRegisterPage`, `renderForgotPasswordPage`, `renderForgotPasswordSuccess`, `renderResetPasswordPage`, `renderAuthPage`. The dark theme, kilnx wordmark, `#e64a19` orange, and SVG logo leave the binary.

**Added helpers**:
- `redirectWithError(w, r, path, msg)` in `auth.go`, appends `?error=<urlencoded msg>` (preserving existing query params, so `/reset-password?token=X` stays intact).

**Extended `AuthConfig`** (`parser.go`): three new fields (`RegisterPath`, `ForgotPath`, `ResetPath`) plus `LogoutPath`. `parseAuth` accepts new keys and aliases (`forgot_password`, `forgot-password`, etc).

**Dispatcher in `server.go`**: auth paths are only matched on non-GET methods, via a `switch` reading `app.Auth.{LoginPath,LogoutPath,RegisterPath,ForgotPath,ResetPath}`. All GETs flow through the normal page loop.

**POST handlers in `auth.go`**: hardcoded `"/register"` / `"/forgot-password"` / `"/reset-password"` replaced with `app.Auth.<Path>` fields. Login path `?reset=1` redirect uses configured path.

**Analyzer in `analyzer.go`**: new `checkAuthPages` pass asks for the exact configured paths when an `auth` block is declared. pt-BR app with `register: /cadastrar` gets asked for `page /cadastrar`, not the default.

## Tests

**Analyzer** (4 new + 1 updated):
- `TestAnalyze_AuthPagesRequired` — all four paths flagged when missing.
- `TestAnalyze_AuthPagesRespectCustomLoginPath` — `login: /entrar` respected.
- `TestAnalyze_AuthPagesHonorCustomSlugs` — every slug configurable, error mentions custom path not default.
- `TestAnalyze_NoAuthBlock_NoPagesRequired` — apps without auth block aren't forced.
- `TestAnalyze_ValidApp` updated to declare the four auth pages.

**Runtime** (7, all passing):
- `TestAuthOverride_RegisterGETUsesUserPage`
- `TestAuthOverride_RegisterPOSTStaysBuiltin`
- `TestAuthOverride_LoginPathHonorsOverride`
- `TestAuthOverride_CustomLoginPathPOSTStaysBuiltin`
- `TestAuthOverride_LogoutGETRendersUserPage`
- `TestAuthOverride_CustomSlugs` — pt-BR `/entrar`, `/cadastrar`, `/senha/esqueci`, `/senha/redefinir` all work end to end; POST on `/cadastrar` hits built-in handler.
- `TestAuthOverride_ForgotAndResetHonorOverride`

Removed `TestAuthOverride_DefaultRenderWhenNoUserPage` (scenario impossible under D; analyzer blocks the build).

`gofmt` clean, `go vet` clean, full suite green.

## Grammar budget

Zero new keywords. One analyzer rule added. Four new auth-config keys (`logout`, `register`, `forgot`, `reset`). Runtime loses ~220 lines of hardcoded HTML/CSS.

## Breaking change

Apps that declared an `auth` block without the four auth pages will now fail `kilnx check`. Fix: declare the missing pages with any HTML shell. One-time migration.

## Related

- Found while building [Adequa](https://github.com/kilnx-org) (self-hosted electrical engineering suite). A pt-BR app naturally wanted `/entrar`, `/cadastrar`, `/senha/esqueci`, `/senha/redefinir` and couldn't.
- Aligns with Principle 4 (declarative first) and Principle 5 (complexity opt-in) from [#48](https://github.com/kilnx-org/kilnx/issues/48).