### PR TITLE
feat: custom fields via versioned manifest (closes #58)

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -365,7 +365,36 @@ func loadApp(filename string) (*parser.App, error) {
 
 	source = lexer.StripComments(source)
 	tokens := lexer.Tokenize(source)
-	return parser.Parse(tokens, source)
+	app, err := parser.Parse(tokens, source)
+	if err != nil {
+		return nil, err
+	}
+
+	app.CustomManifests = make(map[string]*parser.CustomFieldManifest)
+	for _, model := range app.Models {
+		if model.CustomFieldsFile == "" {
+			continue
+		}
+		if !strings.HasSuffix(model.CustomFieldsFile, ".kilnx") {
+			return nil, fmt.Errorf("custom fields manifest must be a .kilnx file: %s", model.CustomFieldsFile)
+		}
+		manifestPath := filepath.Join(projectRoot, model.CustomFieldsFile)
+		rel, err := filepath.Rel(projectRoot, manifestPath)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return nil, fmt.Errorf("custom fields manifest escapes project directory: %s", model.CustomFieldsFile)
+		}
+		raw, err := os.ReadFile(manifestPath)
+		if err != nil {
+			return nil, fmt.Errorf("reading manifest %s: %w", model.CustomFieldsFile, err)
+		}
+		manifest, err := parser.ParseManifest(string(raw), model.Name)
+		if err != nil {
+			return nil, fmt.Errorf("parsing manifest %s: %w", model.CustomFieldsFile, err)
+		}
+		app.CustomManifests[model.Name] = manifest
+	}
+
+	return app, nil
 }
 
 const maxImportDepth = 64

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -67,6 +67,12 @@ func BuildSchema(models []parser.Model) *Schema {
 				mf.ColumnToField[f.Name] = f.Name
 			}
 		}
+		if m.CustomFieldsFile != "" {
+			info.Columns["custom"] = &ColumnInfo{FieldType: parser.FieldText}
+			mf.FormFields["custom"] = true
+			mf.FieldToColumn["custom"] = "custom"
+			mf.ColumnToField["custom"] = "custom"
+		}
 		s.Tables[m.Name] = info
 		s.ModelFields[m.Name] = mf
 	}
@@ -79,6 +85,8 @@ func Analyze(app *parser.App) []Diagnostic {
 	var diags []Diagnostic
 	schema := BuildSchema(app.Models)
 
+	populateSourceModels(app)
+
 	diags = append(diags, checkModelDefaults(app.Models)...)
 	diags = append(diags, checkModelMinMax(app.Models)...)
 	diags = append(diags, checkAuthRef(app, schema)...)
@@ -89,8 +97,57 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkSecurity(app, schema)...)
 	diags = append(diags, checkTemplateInterpolations(app, schema)...)
 	diags = append(diags, checkTableColumnRefs(app, schema)...)
+	diags = append(diags, checkCustomFieldRefs(app, schema)...)
 
 	return diags
+}
+
+// populateSourceModels sets Node.SourceModel on all query nodes by extracting
+// the primary table name from each query's SQL FROM clause.
+func populateSourceModels(app *parser.App) {
+	var populate func(nodes []parser.Node)
+	populate = func(nodes []parser.Node) {
+		for i := range nodes {
+			n := &nodes[i]
+			if n.Type == parser.NodeQuery && n.SQL != "" {
+				refs := extractTableRefs(tokenizeSQL(n.SQL))
+				if len(refs) > 0 {
+					n.SourceModel = refs[0].name
+				}
+			}
+			if len(n.Children) > 0 {
+				populate(n.Children)
+			}
+		}
+	}
+	for i := range app.Pages {
+		populate(app.Pages[i].Body)
+	}
+	for i := range app.Actions {
+		populate(app.Actions[i].Body)
+	}
+	for i := range app.Fragments {
+		populate(app.Fragments[i].Body)
+	}
+	for i := range app.APIs {
+		populate(app.APIs[i].Body)
+	}
+	for i := range app.Schedules {
+		populate(app.Schedules[i].Body)
+	}
+	for i := range app.Jobs {
+		populate(app.Jobs[i].Body)
+	}
+	for i := range app.Webhooks {
+		for j := range app.Webhooks[i].Events {
+			populate(app.Webhooks[i].Events[j].Body)
+		}
+	}
+	for i := range app.Sockets {
+		populate(app.Sockets[i].OnConnect)
+		populate(app.Sockets[i].OnMessage)
+		populate(app.Sockets[i].OnDisconnect)
+	}
 }
 
 // checkAuthPages ensures that an app declaring an `auth` block also

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -1728,3 +1728,65 @@ func TestQueryModelMap(t *testing.T) {
 		t.Errorf("expected posts -> post, got %s", m["posts"])
 	}
 }
+
+func TestBuildSchemaCustomFields(t *testing.T) {
+	models := []parser.Model{
+		{
+			Name:             "deal",
+			CustomFieldsFile: "deal_fields.kilnx",
+			Fields: []parser.Field{
+				{Name: "title", Type: parser.FieldText},
+			},
+		},
+		{
+			Name:   "contact",
+			Fields: []parser.Field{{Name: "name", Type: parser.FieldText}},
+		},
+	}
+	schema := BuildSchema(models)
+
+	deal := schema.Tables["deal"]
+	if deal == nil {
+		t.Fatal("deal table not found")
+	}
+	if _, ok := deal.Columns["custom"]; !ok {
+		t.Error("deal table should have 'custom' column")
+	}
+
+	contact := schema.Tables["contact"]
+	if _, ok := contact.Columns["custom"]; ok {
+		t.Error("contact table should NOT have 'custom' column")
+	}
+}
+
+func TestCheckCustomFieldRefs(t *testing.T) {
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Label: "Receita"},
+		},
+	}
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "deal", CustomFieldsFile: "deal_fields.kilnx"},
+		},
+		Pages: []parser.Page{{
+			Path: "/deals/:id",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "d", SQL: "SELECT * FROM deal WHERE id = :id"},
+				{Type: parser.NodeHTML, HTMLContent: "<span>{d.custom.revenue}</span><span>{d.custom.unknown}</span>"},
+			},
+		}},
+		CustomManifests: map[string]*parser.CustomFieldManifest{
+			"deal": manifest,
+		},
+	}
+	schema := BuildSchema(app.Models)
+	diags := checkCustomFieldRefs(app, schema)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic (unknown field), got %d", len(diags))
+	}
+	if !strings.Contains(diags[0].Message, "unknown") {
+		t.Errorf("expected 'unknown' in diagnostic, got %q", diags[0].Message)
+	}
+}

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -663,3 +663,76 @@ func extractSelectAliases(tokens []sqlToken) map[string]bool {
 func checkTableColumnRefs(app *parser.App, schema *Schema) []Diagnostic {
 	return nil
 }
+
+// customFieldRefRe matches {queryName.custom.fieldName} in HTML content.
+var customFieldRefRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\.custom\.([a-zA-Z_][a-zA-Z0-9_]*)\}`)
+
+// checkCustomFieldRefs validates {q.custom.fieldName} template references
+// against the corresponding model's custom field manifest.
+func checkCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
+	if len(app.CustomManifests) == 0 {
+		return nil
+	}
+
+	qMap := queryModelMap(app.Pages, app.Fragments, app.APIs)
+
+	var diags []Diagnostic
+
+	scanHTML := func(html, context string) {
+		matches := customFieldRefRe.FindAllStringSubmatch(html, -1)
+		for _, m := range matches {
+			queryName := m[1]
+			fieldName := m[2]
+
+			modelName, ok := qMap[queryName]
+			if !ok {
+				continue // unknown query already reported by checkTemplateInterpolations
+			}
+
+			manifest, ok := app.CustomManifests[modelName]
+			if !ok {
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("template reference '{%s.custom.%s}': model '%s' has no custom fields manifest", queryName, fieldName, modelName),
+					Context: context,
+				})
+				continue
+			}
+
+			found := false
+			for _, f := range manifest.Fields {
+				if f.Name == fieldName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("template reference '{%s.custom.%s}': field '%s' not defined in manifest for model '%s'", queryName, fieldName, fieldName, modelName),
+					Context: context,
+				})
+			}
+		}
+	}
+
+	scanNodes := func(nodes []parser.Node, context string) {
+		for _, n := range nodes {
+			if n.Type == parser.NodeHTML {
+				scanHTML(n.HTMLContent, context)
+			}
+		}
+	}
+
+	for _, p := range app.Pages {
+		scanNodes(p.Body, fmt.Sprintf("page %s", p.Path))
+	}
+	for _, f := range app.Fragments {
+		scanNodes(f.Body, fmt.Sprintf("fragment %s", f.Path))
+	}
+	for _, a := range app.APIs {
+		scanNodes(a.Body, fmt.Sprintf("api %s", a.Path))
+	}
+
+	return diags
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -255,6 +255,12 @@ func (db *DB) planExistingTable(model parser.Model) ([]string, error) {
 		stmts = append(stmts, stmt)
 	}
 
+	if model.CustomFieldsFile != "" {
+		if _, ok := existing["custom"]; !ok {
+			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" TEXT", model.Name))
+		}
+	}
+
 	return stmts, nil
 }
 
@@ -292,6 +298,10 @@ func (db *DB) generateCreateTable(model parser.Model) string {
 	for _, field := range model.Fields {
 		col := db.fieldToColumnDef(field)
 		cols = append(cols, col)
+	}
+
+	if model.CustomFieldsFile != "" {
+		cols = append(cols, `"custom" TEXT`)
 	}
 
 	return fmt.Sprintf("CREATE TABLE \"%s\" (\n  %s\n)", model.Name, strings.Join(cols, ",\n  "))

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -848,3 +848,43 @@ func TestMigrationStatus_Pending(t *testing.T) {
 		t.Errorf("expected ALTER TABLE, got %q", pending[0])
 	}
 }
+
+func TestCustomFieldsColumn(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{
+		{
+			Name:             "deal",
+			CustomFieldsFile: "deal_fields.kilnx",
+			Fields: []parser.Field{
+				{Name: "title", Type: parser.FieldText},
+			},
+		},
+	}
+
+	stmts, err := db.PlanMigration(models)
+	if err != nil {
+		t.Fatalf("PlanMigration: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 CREATE TABLE statement, got %d", len(stmts))
+	}
+	if !strings.Contains(stmts[0], `"custom" TEXT`) {
+		t.Errorf("expected 'custom' TEXT column in CREATE TABLE, got:\n%s", stmts[0])
+	}
+
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	// Removing CustomFieldsFile should not drop the column (ALTER TABLE ADD COLUMN only)
+	models[0].CustomFieldsFile = "deal_fields.kilnx"
+	pending, err := db.PlanMigration(models)
+	if err != nil {
+		t.Fatalf("PlanMigration second: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("expected 0 pending changes (custom column already exists), got %d: %v", len(pending), pending)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -27,8 +27,8 @@ type App struct {
 	Layouts         []Layout
 	Tests           []Test
 	LogConfig       *LogConfig
-	Translations    map[string]map[string]string   // lang -> key -> value
-	NamedQueries    map[string]string              // name -> SQL
+	Translations    map[string]map[string]string    // lang -> key -> value
+	NamedQueries    map[string]string               // name -> SQL
 	CustomManifests map[string]*CustomFieldManifest // model name -> custom field definitions
 }
 
@@ -145,8 +145,8 @@ type Model struct {
 	// field named after the tenant model (e.g. `tenant: org` adds an
 	// `org_id` column) and the runtime injects a WHERE filter on SELECT
 	// queries against this table.
-	Tenant          string
-	Fields          []Field
+	Tenant           string
+	Fields           []Field
 	CustomFieldsFile string // path to *_fields.kilnx manifest; empty if unused
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -10,25 +10,26 @@ import (
 )
 
 type App struct {
-	Models       []Model
-	Pages        []Page
-	Actions      []Page       // actions share the same structure as pages but handle POST/PUT/DELETE
-	Fragments    []Page       // fragments return partial HTML (no page wrapper)
-	APIs         []Page       // api endpoints return JSON instead of HTML
-	Streams      []Stream     // SSE stream endpoints
-	Schedules    []Schedule   // timed tasks
-	Jobs         []Job        // async background jobs
-	Webhooks     []Webhook    // external event receivers
-	Sockets      []Socket     // bidirectional websockets
-	RateLimits   []RateLimit  // rate limiting rules
-	Config       *AppConfig   // nil if no config block defined
-	Auth         *AuthConfig  // nil if no auth block defined
-	Permissions  []Permission // role-based access rules
-	Layouts      []Layout
-	Tests        []Test
-	LogConfig    *LogConfig
-	Translations map[string]map[string]string // lang -> key -> value
-	NamedQueries map[string]string            // name -> SQL
+	Models          []Model
+	Pages           []Page
+	Actions         []Page       // actions share the same structure as pages but handle POST/PUT/DELETE
+	Fragments       []Page       // fragments return partial HTML (no page wrapper)
+	APIs            []Page       // api endpoints return JSON instead of HTML
+	Streams         []Stream     // SSE stream endpoints
+	Schedules       []Schedule   // timed tasks
+	Jobs            []Job        // async background jobs
+	Webhooks        []Webhook    // external event receivers
+	Sockets         []Socket     // bidirectional websockets
+	RateLimits      []RateLimit  // rate limiting rules
+	Config          *AppConfig   // nil if no config block defined
+	Auth            *AuthConfig  // nil if no auth block defined
+	Permissions     []Permission // role-based access rules
+	Layouts         []Layout
+	Tests           []Test
+	LogConfig       *LogConfig
+	Translations    map[string]map[string]string   // lang -> key -> value
+	NamedQueries    map[string]string              // name -> SQL
+	CustomManifests map[string]*CustomFieldManifest // model name -> custom field definitions
 }
 
 type Test struct {
@@ -144,8 +145,34 @@ type Model struct {
 	// field named after the tenant model (e.g. `tenant: org` adds an
 	// `org_id` column) and the runtime injects a WHERE filter on SELECT
 	// queries against this table.
-	Tenant string
-	Fields []Field
+	Tenant          string
+	Fields          []Field
+	CustomFieldsFile string // path to *_fields.kilnx manifest; empty if unused
+}
+
+// CustomFieldKind is the type of a runtime-extensible custom field.
+type CustomFieldKind string
+
+const (
+	CustomFieldKindText   CustomFieldKind = "text"
+	CustomFieldKindNumber CustomFieldKind = "number"
+	CustomFieldKindDate   CustomFieldKind = "date"
+	CustomFieldKindOption CustomFieldKind = "option"
+)
+
+// CustomFieldDef describes a single custom field from a manifest file.
+type CustomFieldDef struct {
+	Name     string
+	Kind     CustomFieldKind
+	Label    string
+	Required bool
+	Options  []string
+}
+
+// CustomFieldManifest holds all custom field definitions for a model.
+type CustomFieldManifest struct {
+	ModelName string
+	Fields    []CustomFieldDef
 }
 
 type FieldType string
@@ -210,6 +237,7 @@ type Node struct {
 	Value         string
 	Name          string            // for query: result var name
 	SQL           string            // for query: the raw SQL
+	SourceModel   string            // primary model this query targets (set by analyzer)
 	Props         map[string]string // for on: condition; for send email: body
 	Paginate      int               // for query: items per page (0 = no pagination)
 	ModelName     string            // for validate: which model to validate against
@@ -543,6 +571,20 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 			continue
 		}
 
+		// custom fields from "<file>" is a model-level meta directive.
+		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) &&
+			tok.Value == "custom" && p.peekIsCustomFieldsDirective() {
+			path, err := p.parseCustomFieldsDirective()
+			if err != nil {
+				return model, err
+			}
+			if model.CustomFieldsFile != "" {
+				return model, fmt.Errorf("line %d: model '%s' already has a custom fields directive", tok.Line, model.Name)
+			}
+			model.CustomFieldsFile = path
+			continue
+		}
+
 		// tenant: <model> is a model-level meta directive, not a field.
 		// Must appear before any field declaration.
 		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) &&
@@ -616,6 +658,36 @@ func (p *parserState) parseTenantDirective() (string, error) {
 		p.advance()
 	}
 	return name, nil
+}
+
+// peekIsCustomFieldsDirective returns true when the next tokens form
+// `custom fields from "<path>"` rather than a regular field declaration.
+func (p *parserState) peekIsCustomFieldsDirective() bool {
+	if p.pos+3 >= len(p.tokens) {
+		return false
+	}
+	t1 := p.tokens[p.pos+1]
+	t2 := p.tokens[p.pos+2]
+	t3 := p.tokens[p.pos+3]
+	return (t1.Type == lexer.TokenIdentifier && t1.Value == "fields") &&
+		(t2.Type == lexer.TokenIdentifier && t2.Value == "from") &&
+		t3.Type == lexer.TokenString
+}
+
+// parseCustomFieldsDirective parses `custom fields from "<path>"` and
+// returns the manifest file path. Caller verified with peekIsCustomFieldsDirective.
+func (p *parserState) parseCustomFieldsDirective() (string, error) {
+	p.advance() // consume "custom"
+	p.advance() // consume "fields"
+	p.advance() // consume "from"
+	pathTok := p.advance()
+	if pathTok.Type != lexer.TokenString {
+		return "", fmt.Errorf("line %d: expected file path string after 'custom fields from'", pathTok.Line)
+	}
+	for !p.isEOF() && p.current().Type != lexer.TokenNewline && p.current().Type != lexer.TokenDedent {
+		p.advance()
+	}
+	return pathTok.Value, nil
 }
 
 func (p *parserState) parseField(app *App) (Field, error) {
@@ -2979,4 +3051,115 @@ func (p *parserState) peek() lexer.Token {
 		return p.tokens[p.pos+1]
 	}
 	return lexer.Token{Type: lexer.TokenEOF}
+}
+
+// ParseManifest parses a custom fields manifest file (`*_fields.kilnx`).
+// The manifest contains top-level `field <name>` blocks with kind, label,
+// required, and option properties.
+func ParseManifest(source, modelName string) (*CustomFieldManifest, error) {
+	stripped := lexer.StripComments(source)
+	tokens := lexer.Tokenize(stripped)
+	manifest := &CustomFieldManifest{ModelName: modelName}
+
+	p := &parserState{tokens: tokens, pos: 0, lines: strings.Split(source, "\n")}
+
+	for !p.isEOF() {
+		p.skipNewlines()
+		if p.isEOF() {
+			break
+		}
+		tok := p.current()
+		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) && tok.Value == "field" {
+			fieldDef, err := p.parseManifestField()
+			if err != nil {
+				return nil, err
+			}
+			manifest.Fields = append(manifest.Fields, fieldDef)
+		} else {
+			p.advance()
+		}
+	}
+
+	return manifest, nil
+}
+
+func (p *parserState) parseManifestField() (CustomFieldDef, error) {
+	def := CustomFieldDef{}
+	p.advance() // consume "field"
+
+	if p.current().Type != lexer.TokenIdentifier && p.current().Type != lexer.TokenKeyword {
+		return def, fmt.Errorf("line %d: expected field name after 'field'", p.current().Line)
+	}
+	def.Name = p.advance().Value
+
+	p.skipNewlines()
+
+	if p.current().Type != lexer.TokenIndent {
+		return def, nil
+	}
+	p.advance() // consume indent
+
+	for !p.isEOF() {
+		tok := p.current()
+
+		if tok.Type == lexer.TokenDedent {
+			p.advance()
+			break
+		}
+		if tok.Type == lexer.TokenNewline {
+			p.advance()
+			continue
+		}
+
+		if tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword {
+			propName := p.advance().Value
+			if p.current().Type == lexer.TokenColon {
+				p.advance()
+			}
+
+			switch propName {
+			case "kind":
+				if p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword {
+					def.Kind = CustomFieldKind(p.advance().Value)
+				}
+				// kind: option [A, B, C] — options may follow on the same line
+				if def.Kind == CustomFieldKindOption && p.current().Type == lexer.TokenBracketOpen {
+					p.advance() // consume '['
+					for !p.isEOF() && p.current().Type != lexer.TokenBracketClose {
+						if p.current().Type == lexer.TokenComma {
+							p.advance()
+							continue
+						}
+						if p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword {
+							def.Options = append(def.Options, p.advance().Value)
+						} else {
+							p.advance()
+						}
+					}
+					if p.current().Type == lexer.TokenBracketClose {
+						p.advance()
+					}
+				}
+			case "label":
+				if p.current().Type == lexer.TokenString {
+					def.Label = p.advance().Value
+				} else if p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword {
+					def.Label = p.advance().Value
+				}
+			case "required":
+				if p.current().Type == lexer.TokenIdentifier {
+					def.Required = p.current().Value != "false"
+					p.advance()
+				} else {
+					def.Required = true // bare keyword, no value
+				}
+			}
+		}
+
+		for !p.isEOF() && p.current().Type != lexer.TokenNewline && p.current().Type != lexer.TokenDedent {
+			p.advance()
+		}
+	}
+
+	return def, nil
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1066,3 +1066,63 @@ func TestPageWithStaticTitleStillWorks(t *testing.T) {
 		t.Errorf("expected layout 'main', got %q", app.Pages[0].Layout)
 	}
 }
+
+func TestModelCustomFieldsDirective(t *testing.T) {
+	src := "model deal\n  title: text required\n  custom fields from \"deal_fields.kilnx\"\n  value: float"
+	app := parse(t, src)
+	if len(app.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(app.Models))
+	}
+	m := app.Models[0]
+	if m.CustomFieldsFile != "deal_fields.kilnx" {
+		t.Errorf("expected CustomFieldsFile 'deal_fields.kilnx', got %q", m.CustomFieldsFile)
+	}
+	if len(m.Fields) != 2 {
+		t.Errorf("expected 2 fields (title, value), got %d", len(m.Fields))
+	}
+}
+
+func TestParseManifest(t *testing.T) {
+	src := `field revenue
+  kind: number
+  label: "Receita"
+  required: false
+
+field region
+  kind: option [N, S, L, O]
+  label: "Região"
+  required: true`
+	manifest, err := ParseManifest(src, "deal")
+	if err != nil {
+		t.Fatalf("ParseManifest error: %v", err)
+	}
+	if manifest.ModelName != "deal" {
+		t.Errorf("expected model name 'deal', got %q", manifest.ModelName)
+	}
+	if len(manifest.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(manifest.Fields))
+	}
+	rev := manifest.Fields[0]
+	if rev.Name != "revenue" {
+		t.Errorf("expected field name 'revenue', got %q", rev.Name)
+	}
+	if rev.Kind != CustomFieldKindNumber {
+		t.Errorf("expected kind 'number', got %q", rev.Kind)
+	}
+	if rev.Label != "Receita" {
+		t.Errorf("expected label 'Receita', got %q", rev.Label)
+	}
+	if rev.Required {
+		t.Error("expected required=false")
+	}
+	reg := manifest.Fields[1]
+	if reg.Name != "region" {
+		t.Errorf("expected field name 'region', got %q", reg.Name)
+	}
+	if len(reg.Options) != 4 {
+		t.Errorf("expected 4 options, got %d", len(reg.Options))
+	}
+	if !reg.Required {
+		t.Error("expected required=true for region")
+	}
+}

--- a/internal/runtime/forms.go
+++ b/internal/runtime/forms.go
@@ -3,11 +3,13 @@ package runtime
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,6 +17,8 @@ import (
 
 	"github.com/kilnx-org/kilnx/internal/parser"
 )
+
+var customBracketRe = regexp.MustCompile(`^custom\[(\w+)\]$`)
 
 // CSRF token store with expiry (#6 fix: bounded store with TTL cleanup)
 type csrfEntry struct {
@@ -138,6 +142,70 @@ func validateFormData(modelName string, app *parser.App, formData map[string]str
 				}
 			} else if max > 0 && len(val) > max {
 				errors = append(errors, fmt.Sprintf("%s must be at most %d characters", label, max))
+			}
+		}
+	}
+
+	if model.CustomFieldsFile != "" {
+		if manifest, ok := app.CustomManifests[modelName]; ok {
+			customVals := make(map[string]string)
+			if raw := formData["custom"]; raw != "" {
+				var m map[string]interface{}
+				if err := json.Unmarshal([]byte(raw), &m); err != nil {
+					errors = append(errors, "Invalid custom field data")
+				} else {
+					for k, v := range m {
+						customVals[k] = fmt.Sprintf("%v", v)
+					}
+				}
+			}
+			allowedKeys := make(map[string]bool, len(manifest.Fields))
+			for _, f := range manifest.Fields {
+				allowedKeys[f.Name] = true
+			}
+			for k := range customVals {
+				if !allowedKeys[k] {
+					errors = append(errors, fmt.Sprintf("Unknown custom field: %s", k))
+				}
+			}
+			for _, f := range manifest.Fields {
+				val := customVals[f.Name]
+				label := f.Label
+				if label == "" {
+					label = f.Name
+				}
+				if f.Required && strings.TrimSpace(val) == "" {
+					errors = append(errors, label+" is required")
+				}
+				if f.Kind == parser.CustomFieldKindNumber && val != "" {
+					if _, err := strconv.ParseFloat(val, 64); err != nil {
+						errors = append(errors, fmt.Sprintf("%s must be a number", label))
+					}
+				}
+				if f.Kind == parser.CustomFieldKindDate && val != "" {
+					valid := false
+					for _, layout := range []string{"2006-01-02", "01/02/2006", "02-01-2006", "2006/01/02"} {
+						if _, err := time.Parse(layout, val); err == nil {
+							valid = true
+							break
+						}
+					}
+					if !valid {
+						errors = append(errors, fmt.Sprintf("%s must be a valid date", label))
+					}
+				}
+				if f.Kind == parser.CustomFieldKindOption && len(f.Options) > 0 && val != "" {
+					valid := false
+					for _, opt := range f.Options {
+						if val == opt {
+							valid = true
+							break
+						}
+					}
+					if !valid {
+						errors = append(errors, fmt.Sprintf("%s must be one of: %s", label, strings.Join(f.Options, ", ")))
+					}
+				}
 			}
 		}
 	}
@@ -277,5 +345,40 @@ func extractFormData(r *http.Request, config *parser.AppConfig) map[string]strin
 		}
 	}
 
+	serializeCustomBrackets(data)
 	return data
+}
+
+// serializeCustomBrackets collects custom[field]=value entries from form data,
+// JSON-encodes them, and stores the result as data["custom"].
+func serializeCustomBrackets(data map[string]string) {
+	customMap := make(map[string]string)
+	for k, v := range data {
+		if m := customBracketRe.FindStringSubmatch(k); m != nil {
+			customMap[m[1]] = v
+		}
+	}
+	if len(customMap) == 0 {
+		return
+	}
+	for k := range customMap {
+		delete(data, "custom["+k+"]")
+	}
+	if existing, ok := data["custom"]; ok && existing != "" {
+		var prev map[string]interface{}
+		if json.Unmarshal([]byte(existing), &prev) == nil {
+			for k, v := range customMap {
+				prev[k] = v
+			}
+			merged := make(map[string]string, len(prev))
+			for k, v := range prev {
+				merged[k] = fmt.Sprintf("%v", v)
+			}
+			customMap = merged
+		}
+	}
+	b, err := json.Marshal(customMap)
+	if err == nil {
+		data["custom"] = string(b)
+	}
 }

--- a/internal/runtime/render_test.go
+++ b/internal/runtime/render_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kilnx-org/kilnx/internal/database"
+	"github.com/kilnx-org/kilnx/internal/parser"
 )
 
 func newTestContext() *renderContext {
@@ -543,5 +544,118 @@ func TestRenderHTML_IfAndQuotedString(t *testing.T) {
 	result := renderHTML(`{{if item.name == "foo and bar"}}<p>Match</p>{{end}}`, ctx)
 	if !strings.Contains(result, "Match") {
 		t.Errorf("'and' inside quotes should not split condition, got %s", result)
+	}
+}
+
+func TestExpandCustomFields_DirectAccess(t *testing.T) {
+	rows := []database.Row{
+		{"title": "Deal A", "custom": `{"revenue":"500","region":"S"}`},
+	}
+	rows = expandCustomFields(rows)
+	if rows[0]["custom.revenue"] != "500" {
+		t.Errorf("expected custom.revenue='500', got %q", rows[0]["custom.revenue"])
+	}
+	if rows[0]["custom.region"] != "S" {
+		t.Errorf("expected custom.region='S', got %q", rows[0]["custom.region"])
+	}
+}
+
+func TestExpandCustomFields_NoCustomColumn(t *testing.T) {
+	rows := []database.Row{{"title": "Deal B"}}
+	rows = expandCustomFields(rows)
+	if _, ok := rows[0]["custom.anything"]; ok {
+		t.Error("should not expand if no custom column")
+	}
+}
+
+func TestExpandCustomFields_TemplateResolution(t *testing.T) {
+	ctx := newTestContext()
+	ctx.queries["d"] = expandCustomFields([]database.Row{
+		{"title": "Deal A", "custom": `{"revenue":"500"}`},
+	})
+	result := renderHTML("<span>{d.custom.revenue}</span>", ctx)
+	if !strings.Contains(result, "500") {
+		t.Errorf("expected 500 in output, got %s", result)
+	}
+}
+
+func TestSerializeCustomBrackets_Basic(t *testing.T) {
+	data := map[string]string{
+		"title":          "Deal A",
+		"custom[revenue]": "500",
+		"custom[region]": "S",
+	}
+	serializeCustomBrackets(data)
+	if _, ok := data["custom[revenue]"]; ok {
+		t.Error("bracket key should be removed")
+	}
+	customJSON := data["custom"]
+	if !strings.Contains(customJSON, `"revenue"`) || !strings.Contains(customJSON, `"500"`) {
+		t.Errorf("expected revenue in custom JSON, got %q", customJSON)
+	}
+	if !strings.Contains(customJSON, `"region"`) || !strings.Contains(customJSON, `"S"`) {
+		t.Errorf("expected region in custom JSON, got %q", customJSON)
+	}
+	if data["title"] != "Deal A" {
+		t.Error("non-custom keys must not be removed")
+	}
+}
+
+func TestSerializeCustomBrackets_MergeExisting(t *testing.T) {
+	data := map[string]string{
+		"custom":          `{"notes":"abc"}`,
+		"custom[revenue]": "999",
+	}
+	serializeCustomBrackets(data)
+	customJSON := data["custom"]
+	if !strings.Contains(customJSON, `"notes"`) {
+		t.Errorf("existing custom key must be preserved, got %q", customJSON)
+	}
+	if !strings.Contains(customJSON, `"revenue"`) {
+		t.Errorf("new key must be merged, got %q", customJSON)
+	}
+}
+
+func TestSerializeCustomBrackets_NoBrackets(t *testing.T) {
+	data := map[string]string{"title": "X", "value": "1"}
+	serializeCustomBrackets(data)
+	if _, ok := data["custom"]; ok {
+		t.Error("custom key must not be created when no bracket keys exist")
+	}
+}
+
+func TestBuildCustomIterRows_WithManifest(t *testing.T) {
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Label: "Receita"},
+			{Name: "region", Kind: parser.CustomFieldKindOption, Label: "Região"},
+		},
+	}
+	row := database.Row{"custom": `{"revenue":"500","region":"S"}`}
+	result := buildCustomIterRows(row, manifest)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 synthetic rows, got %d", len(result))
+	}
+	if result[0]["name"] != "revenue" || result[0]["value"] != "500" || result[0]["label"] != "Receita" {
+		t.Errorf("first row wrong: %v", result[0])
+	}
+	if result[1]["name"] != "region" || result[1]["value"] != "S" || result[1]["label"] != "Região" {
+		t.Errorf("second row wrong: %v", result[1])
+	}
+}
+
+func TestBuildCustomIterRows_EmptyCustomColumn(t *testing.T) {
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields:    []parser.CustomFieldDef{{Name: "revenue", Kind: parser.CustomFieldKindNumber, Label: "Revenue"}},
+	}
+	row := database.Row{"title": "No custom data"}
+	result := buildCustomIterRows(row, manifest)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 row (empty value), got %d", len(result))
+	}
+	if result[0]["value"] != "" {
+		t.Errorf("expected empty value, got %q", result[0]["value"])
 	}
 }

--- a/internal/runtime/render_test.go
+++ b/internal/runtime/render_test.go
@@ -581,9 +581,9 @@ func TestExpandCustomFields_TemplateResolution(t *testing.T) {
 
 func TestSerializeCustomBrackets_Basic(t *testing.T) {
 	data := map[string]string{
-		"title":          "Deal A",
+		"title":           "Deal A",
 		"custom[revenue]": "500",
-		"custom[region]": "S",
+		"custom[region]":  "S",
 	}
 	serializeCustomBrackets(data)
 	if _, ok := data["custom[revenue]"]; ok {

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
 	"html"
 	"net/http"
@@ -311,18 +312,21 @@ type PaginateInfo struct {
 
 // renderContext holds query results available during template rendering
 type renderContext struct {
-	queries     map[string][]database.Row
-	paginate    map[string]PaginateInfo
-	currentUser *Session
-	queryParams map[string]string // URL query parameters (?key=value)
+	queries          map[string][]database.Row
+	paginate         map[string]PaginateInfo
+	currentUser      *Session
+	queryParams      map[string]string // URL query parameters (?key=value)
+	querySourceModels map[string]string // query name -> primary model name (set by analyzer)
 }
 
 func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Request) string {
+	app := s.getApp()
 	ctx := &renderContext{
-		queries:     make(map[string][]database.Row),
-		paginate:    make(map[string]PaginateInfo),
-		currentUser: s.getSession(r),
-		queryParams: make(map[string]string),
+		queries:           make(map[string][]database.Row),
+		paginate:          make(map[string]PaginateInfo),
+		currentUser:       s.getSession(r),
+		queryParams:       make(map[string]string),
+		querySourceModels: make(map[string]string),
 	}
 
 	pathParams := matchPathParams(p.Path, r.URL.Path)
@@ -415,7 +419,14 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 			s.logger.LogError("page query failed", err)
 			continue
 		}
+		rows = expandCustomFields(rows)
 		ctx.queries[queryName] = rows
+		if node.SourceModel != "" {
+			ctx.querySourceModels[queryName] = node.SourceModel
+			if manifest, ok := app.CustomManifests[node.SourceModel]; ok && len(rows) > 0 {
+				ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
+			}
+		}
 	}
 
 	// Execute fetch nodes
@@ -461,7 +472,6 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 	bodyContent := body.String()
 
 	appName := ""
-	app := s.getApp()
 	if app.Config != nil {
 		appName = app.Config.Name
 	}
@@ -663,11 +673,13 @@ func render404(path string, pages []parser.Page) string {
 
 // renderFragment renders a fragment (partial HTML, no page wrapper)
 func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
+	app := s.getApp()
 	ctx := &renderContext{
-		queries:     make(map[string][]database.Row),
-		paginate:    make(map[string]PaginateInfo),
-		currentUser: s.getSession(r),
-		queryParams: make(map[string]string),
+		queries:           make(map[string][]database.Row),
+		paginate:          make(map[string]PaginateInfo),
+		currentUser:       s.getSession(r),
+		queryParams:       make(map[string]string),
+		querySourceModels: make(map[string]string),
 	}
 
 	// Make current_user available in fragments
@@ -732,7 +744,14 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 					body.WriteString("<p style=\"color:red\">Query error</p>")
 					continue
 				}
+				rows = expandCustomFields(rows)
 				ctx.queries[queryName] = rows
+				if node.SourceModel != "" {
+					ctx.querySourceModels[queryName] = node.SourceModel
+					if manifest, ok := app.CustomManifests[node.SourceModel]; ok && len(rows) > 0 {
+						ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
+					}
+				}
 			}
 
 		case parser.NodeText:
@@ -752,9 +771,11 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 
 // renderFragmentWithParams renders a fragment using provided params (for WebSocket broadcast)
 func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]string) string {
+	app := s.getApp()
 	ctx := &renderContext{
-		queries:  make(map[string][]database.Row),
-		paginate: make(map[string]PaginateInfo),
+		queries:           make(map[string][]database.Row),
+		paginate:          make(map[string]PaginateInfo),
+		querySourceModels: make(map[string]string),
 	}
 
 	var body strings.Builder
@@ -779,7 +800,14 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 				if name == "" {
 					name = "_last"
 				}
+				rows = expandCustomFields(rows)
 				ctx.queries[name] = rows
+				if node.SourceModel != "" {
+					ctx.querySourceModels[name] = node.SourceModel
+					if manifest, ok := app.CustomManifests[node.SourceModel]; ok && len(rows) > 0 {
+						ctx.queries[name+".custom"] = buildCustomIterRows(rows[0], manifest)
+					}
+				}
 			}
 
 		case parser.NodeText:
@@ -1158,8 +1186,10 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 					return
 				}
 				tx.Commit()
+				rows = expandCustomFields(rows)
 				ctx := &renderContext{
-					queries: map[string][]database.Row{"_result": rows},
+					queries:           map[string][]database.Row{"_result": rows},
+					querySourceModels: make(map[string]string),
 				}
 				if node.RespondTarget != "" {
 					w.Header().Set("HX-Retarget", node.RespondTarget)
@@ -1407,4 +1437,54 @@ func matchPathParams(pattern, urlPath string) map[string]string {
 	}
 
 	return params
+}
+
+// expandCustomFields parses the "custom" JSON column in each row and adds
+// flattened "custom.<field>" keys so templates can access {q.custom.revenue}.
+func expandCustomFields(rows []database.Row) []database.Row {
+	for i, row := range rows {
+		jsonStr, ok := row["custom"]
+		if !ok || jsonStr == "" {
+			continue
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+			continue
+		}
+		for k, v := range m {
+			row["custom."+k] = fmt.Sprintf("%v", v)
+		}
+		rows[i] = row
+	}
+	return rows
+}
+
+// buildCustomIterRows creates synthetic rows for {{each q.custom}} iteration.
+// Each row has name, value, label, and kind fields. Designed for detail pages
+// where the query returns a single row; on list pages use {q.custom.field} dot-access.
+func buildCustomIterRows(row database.Row, manifest *parser.CustomFieldManifest) []database.Row {
+	jsonStr := row["custom"]
+	values := make(map[string]string)
+	if jsonStr != "" {
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(jsonStr), &m); err == nil {
+			for k, v := range m {
+				values[k] = fmt.Sprintf("%v", v)
+			}
+		}
+	}
+	var result []database.Row
+	for _, f := range manifest.Fields {
+		label := f.Label
+		if label == "" {
+			label = f.Name
+		}
+		result = append(result, database.Row{
+			"name":  f.Name,
+			"value": values[f.Name],
+			"label": label,
+			"kind":  string(f.Kind),
+		})
+	}
+	return result
 }

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -312,10 +312,10 @@ type PaginateInfo struct {
 
 // renderContext holds query results available during template rendering
 type renderContext struct {
-	queries          map[string][]database.Row
-	paginate         map[string]PaginateInfo
-	currentUser      *Session
-	queryParams      map[string]string // URL query parameters (?key=value)
+	queries           map[string][]database.Row
+	paginate          map[string]PaginateInfo
+	currentUser       *Session
+	queryParams       map[string]string // URL query parameters (?key=value)
 	querySourceModels map[string]string // query name -> primary model name (set by analyzer)
 }
 


### PR DESCRIPTION
## Summary

- Adds `custom fields from "<file>"` syntax on models for per-tenant extensible fields stored as `custom TEXT` (JSON) in SQLite
- Template access: `{d.custom.revenue}` (direct) and `{{each d.custom}}{label}: {value}{{end}}` (iteration with manifest labels)
- `kilnx check` validates `{q.custom.nonexistent}` at analysis time across pages, fragments, and APIs
- POST via bracket notation: `custom[revenue]=500&custom[region]=S` serialized to JSON; validated against manifest on `validate <model>`

## How it works

```kilnx
# app.kilnx
model deal
  title: text required
  value: float
  custom fields from "deal_fields.kilnx"
```

```kilnx
# deal_fields.kilnx
field revenue
  kind: number
  label: "Receita"
  required: false

field region
  kind: option [N, S, L, O]
  label: "Região"
  required: true
```

```kilnx
page /deals/:id requires auth
  query d: SELECT * FROM deal WHERE id = :id
  html
    <h1>{d.title}</h1>
    <span>{d.custom.revenue}</span>
    {{each d.custom}}
      <div><strong>{label}:</strong> {value}</div>
    {{end}}
```

## Test plan

- [ ] `go test -race ./...` passes (416 tests)
- [ ] Model with `custom fields from "..."` creates `custom TEXT` column on `kilnx run`
- [ ] `kilnx migrate --dry-run` emits `ALTER TABLE ... ADD COLUMN "custom" TEXT` for existing tables
- [ ] POST `custom[revenue]=500` stores `{"revenue":"500"}` in DB
- [ ] `{d.custom.revenue}` renders `500` on detail page
- [ ] `{{each d.custom}}` renders all manifest fields with labels
- [ ] `kilnx check` reports error for `{d.custom.typo}` when `typo` not in manifest
- [ ] `validate deal` in action rejects unknown keys, enforces `required`, validates `kind: option` options