### PR TITLE
feat(custom-fields): v2 PR A — JSONB, new kinds, SQL validation, list-page fix

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -98,6 +98,7 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkTemplateInterpolations(app, schema)...)
 	diags = append(diags, checkTableColumnRefs(app, schema)...)
 	diags = append(diags, checkCustomFieldRefs(app, schema)...)
+	diags = append(diags, checkSQLCustomFieldRefs(app, schema)...)
 
 	return diags
 }

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -736,3 +736,63 @@ func checkCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
 
 	return diags
 }
+
+// jsonExtractSQLiteRe matches json_extract(custom, '$.fieldName') in SQL.
+var jsonExtractSQLiteRe = regexp.MustCompile(`(?i)json_extract\s*\(\s*custom\s*,\s*'\$\.([a-zA-Z_][a-zA-Z0-9_]*)'\s*\)`)
+
+// jsonExtractPGRe matches custom->>'fieldName' and custom->'fieldName' in SQL.
+var jsonExtractPGRe = regexp.MustCompile(`\bcustom\s*->>?\s*'([a-zA-Z_][a-zA-Z0-9_]*)'`)
+
+// checkSQLCustomFieldRefs validates json_extract(custom, '$.field') and
+// custom->>'field' patterns in SQL query nodes against the custom field manifest.
+func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
+	if len(app.CustomManifests) == 0 {
+		return nil
+	}
+
+	var diags []Diagnostic
+
+	scanSQL := func(nodes []parser.Node, context string) {
+		for _, n := range nodes {
+			if n.Type != parser.NodeQuery || n.SQL == "" || n.SourceModel == "" {
+				continue
+			}
+			manifest, ok := app.CustomManifests[n.SourceModel]
+			if !ok {
+				continue
+			}
+			known := make(map[string]bool, len(manifest.Fields))
+			for _, f := range manifest.Fields {
+				known[f.Name] = true
+			}
+			check := func(fieldName string) {
+				if !known[fieldName] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("SQL references unknown custom field '%s' (model '%s')", fieldName, n.SourceModel),
+						Context: context,
+					})
+				}
+			}
+			for _, m := range jsonExtractSQLiteRe.FindAllStringSubmatch(n.SQL, -1) {
+				check(m[1])
+			}
+			for _, m := range jsonExtractPGRe.FindAllStringSubmatch(n.SQL, -1) {
+				check(m[1])
+			}
+		}
+	}
+
+	scanPage := func(p parser.Page, context string) { scanSQL(p.Body, context) }
+	for _, p := range app.Pages {
+		scanPage(p, fmt.Sprintf("page %s", p.Path))
+	}
+	for _, f := range app.Fragments {
+		scanPage(f, fmt.Sprintf("fragment %s", f.Path))
+	}
+	for _, a := range app.APIs {
+		scanPage(a, fmt.Sprintf("api %s", a.Path))
+	}
+
+	return diags
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -257,7 +257,11 @@ func (db *DB) planExistingTable(model parser.Model) ([]string, error) {
 
 	if model.CustomFieldsFile != "" {
 		if _, ok := existing["custom"]; !ok {
-			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" TEXT", model.Name))
+			colType := "TEXT"
+			if db.dialect.DriverName() == "pgx" {
+				colType = "JSONB"
+			}
+			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" %s", model.Name, colType))
 		}
 	}
 
@@ -301,7 +305,11 @@ func (db *DB) generateCreateTable(model parser.Model) string {
 	}
 
 	if model.CustomFieldsFile != "" {
-		cols = append(cols, `"custom" TEXT`)
+		if db.dialect.DriverName() == "pgx" {
+			cols = append(cols, `"custom" JSONB`)
+		} else {
+			cols = append(cols, `"custom" TEXT`)
+		}
 	}
 
 	return fmt.Sprintf("CREATE TABLE \"%s\" (\n  %s\n)", model.Name, strings.Join(cols, ",\n  "))

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -154,10 +154,14 @@ type Model struct {
 type CustomFieldKind string
 
 const (
-	CustomFieldKindText   CustomFieldKind = "text"
-	CustomFieldKindNumber CustomFieldKind = "number"
-	CustomFieldKindDate   CustomFieldKind = "date"
-	CustomFieldKindOption CustomFieldKind = "option"
+	CustomFieldKindText     CustomFieldKind = "text"
+	CustomFieldKindNumber   CustomFieldKind = "number"
+	CustomFieldKindDate     CustomFieldKind = "date"
+	CustomFieldKindOption   CustomFieldKind = "option"
+	CustomFieldKindEmail    CustomFieldKind = "email"
+	CustomFieldKindPhone    CustomFieldKind = "phone"
+	CustomFieldKindBool     CustomFieldKind = "bool"
+	CustomFieldKindRichtext CustomFieldKind = "richtext"
 )
 
 // CustomFieldDef describes a single custom field from a manifest file.

--- a/internal/runtime/forms.go
+++ b/internal/runtime/forms.go
@@ -194,6 +194,29 @@ func validateFormData(modelName string, app *parser.App, formData map[string]str
 						errors = append(errors, fmt.Sprintf("%s must be a valid date", label))
 					}
 				}
+				if f.Kind == parser.CustomFieldKindEmail && val != "" {
+					if !strings.Contains(val, "@") || !strings.Contains(val, ".") {
+						errors = append(errors, fmt.Sprintf("%s must be a valid email address", label))
+					}
+				}
+				if f.Kind == parser.CustomFieldKindPhone && val != "" {
+					stripped := strings.Map(func(r rune) rune {
+						if r >= '0' && r <= '9' {
+							return r
+						}
+						return -1
+					}, val)
+					if len(stripped) < 7 {
+						errors = append(errors, fmt.Sprintf("%s must be a valid phone number", label))
+					}
+				}
+				if f.Kind == parser.CustomFieldKindBool && val != "" {
+					switch strings.ToLower(val) {
+					case "true", "false", "1", "0", "on", "off", "yes", "no":
+					default:
+						errors = append(errors, fmt.Sprintf("%s must be a boolean value", label))
+					}
+				}
 				if f.Kind == parser.CustomFieldKindOption && len(f.Options) > 0 && val != "" {
 					valid := false
 					for _, opt := range f.Options {

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -422,6 +422,12 @@ func expandEachBlocks(content string, ctx *renderContext, nonce string) string {
 			}
 		} else {
 			for _, row := range rows {
+				// Rebind q.custom per row so {{each q.custom}} works on list pages (#66)
+				if sourceModel, ok := ctx.querySourceModels[queryName]; ok {
+					if manifest, ok := ctx.customManifests[sourceModel]; ok {
+						ctx.queries[queryName+".custom"] = buildCustomIterRows(row, manifest)
+					}
+				}
 				// Process raw filters inside each body with current row context
 				expanded := processRawInRow(body, row, ctx, nonce)
 				// Process nested {{each}} blocks

--- a/internal/runtime/render_test.go
+++ b/internal/runtime/render_test.go
@@ -11,9 +11,11 @@ import (
 
 func newTestContext() *renderContext {
 	return &renderContext{
-		queries:     make(map[string][]database.Row),
-		paginate:    make(map[string]PaginateInfo),
-		queryParams: make(map[string]string),
+		queries:           make(map[string][]database.Row),
+		paginate:          make(map[string]PaginateInfo),
+		queryParams:       make(map[string]string),
+		querySourceModels: make(map[string]string),
+		customManifests:   make(map[string]*parser.CustomFieldManifest),
 	}
 }
 
@@ -657,5 +659,36 @@ func TestBuildCustomIterRows_EmptyCustomColumn(t *testing.T) {
 	}
 	if result[0]["value"] != "" {
 		t.Errorf("expected empty value, got %q", result[0]["value"])
+	}
+}
+
+// TestEachCustomRebindPerRow verifies that {{each q.custom}} inside {{each q}}
+// shows each row's own custom fields, not always row[0] (#66).
+func TestEachCustomRebindPerRow(t *testing.T) {
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Label: "Revenue"},
+		},
+	}
+	ctx := newTestContext()
+	ctx.querySourceModels["d"] = "deal"
+	ctx.customManifests["deal"] = manifest
+	ctx.queries["d"] = []database.Row{
+		{"title": "Deal A", "custom": `{"revenue":"100"}`},
+		{"title": "Deal B", "custom": `{"revenue":"200"}`},
+	}
+	// Pre-populate with row[0] data (as server.go does at query time)
+	ctx.queries["d.custom"] = buildCustomIterRows(ctx.queries["d"][0], manifest)
+
+	// Inside {{each d}}, bare {title} uses current row; {d.title} always uses row[0]
+	tmpl := `{{each d}}<div>{title}:{{each d.custom}}{value}{{end}}</div>{{end}}`
+	result := renderHTML(tmpl, ctx)
+
+	if !strings.Contains(result, "Deal A:100") {
+		t.Errorf("expected Deal A:100 in output, got: %s", result)
+	}
+	if !strings.Contains(result, "Deal B:200") {
+		t.Errorf("expected Deal B:200 in output, got: %s", result)
 	}
 }

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -315,8 +315,9 @@ type renderContext struct {
 	queries           map[string][]database.Row
 	paginate          map[string]PaginateInfo
 	currentUser       *Session
-	queryParams       map[string]string // URL query parameters (?key=value)
-	querySourceModels map[string]string // query name -> primary model name (set by analyzer)
+	queryParams       map[string]string                      // URL query parameters (?key=value)
+	querySourceModels map[string]string                      // query name -> primary model name (set by analyzer)
+	customManifests   map[string]*parser.CustomFieldManifest // model name -> manifest (for list-page rebinding)
 }
 
 func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Request) string {
@@ -327,6 +328,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 		currentUser:       s.getSession(r),
 		queryParams:       make(map[string]string),
 		querySourceModels: make(map[string]string),
+		customManifests:   app.CustomManifests,
 	}
 
 	pathParams := matchPathParams(p.Path, r.URL.Path)
@@ -680,6 +682,7 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 		currentUser:       s.getSession(r),
 		queryParams:       make(map[string]string),
 		querySourceModels: make(map[string]string),
+		customManifests:   app.CustomManifests,
 	}
 
 	// Make current_user available in fragments
@@ -776,6 +779,7 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 		queries:           make(map[string][]database.Row),
 		paginate:          make(map[string]PaginateInfo),
 		querySourceModels: make(map[string]string),
+		customManifests:   app.CustomManifests,
 	}
 
 	var body strings.Builder
@@ -1187,9 +1191,11 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 				}
 				tx.Commit()
 				rows = expandCustomFields(rows)
+				respondApp := s.getApp()
 				ctx := &renderContext{
 					queries:           map[string][]database.Row{"_result": rows},
 					querySourceModels: make(map[string]string),
+					customManifests:   respondApp.CustomManifests,
 				}
 				if node.RespondTarget != "" {
 					w.Header().Set("HX-Retarget", node.RespondTarget)


### PR DESCRIPTION
## Summary

- **#62** `custom TEXT` → `JSONB` on PostgreSQL, `TEXT` on SQLite — enables native JSON operators and GIN indexes
- **#63** (safe kinds) New manifest field kinds: `email`, `phone`, `bool`, `richtext` — with form validation in `validateFormData`
- **#65** Analyzer now validates `json_extract(custom, '$.fieldName')` (SQLite) and `custom->>'fieldName'` (PostgreSQL) SQL patterns against the manifest; unknown field names emit compile-time errors
- **#66** Bug fix: `{{each q.custom}}` inside `{{each q}}` on list pages now rebinds synthetic custom rows per outer iteration row — previously always showed row[0]'s custom fields

## Test plan

- [ ] `go test -race ./...` passes (all 311+ tests)
- [ ] `kilnx check` on app with `json_extract(custom, '$.bad_field')` emits error
- [ ] `kilnx check` on app with `json_extract(custom, '$.valid_field')` passes
- [ ] PostgreSQL migration emits `ADD COLUMN "custom" JSONB`
- [ ] `{{each d.custom}}` inside `{{each d}}` on list page shows each row's own custom values
- [ ] Form submission with `kind: email` custom field validates email format
- [ ] Form submission with `kind: bool` custom field accepts `true`/`false`/`1`/`0`

Closes #62, closes #65, closes #66
Partially closes #63 (reference/image kinds deferred to PR D with column-mode)

Part of #67 custom-fields-v2 umbrella.