### PR TITLE
feat(custom-fields): SQL shorthand custom.field rewriting (#60)

### DIFF
--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -743,6 +743,9 @@ var jsonExtractSQLiteRe = regexp.MustCompile(`(?i)json_extract\s*\(\s*custom\s*,
 // jsonExtractPGRe matches custom->>'fieldName' and custom->'fieldName' in SQL.
 var jsonExtractPGRe = regexp.MustCompile(`\bcustom\s*->>?\s*'([a-zA-Z_][a-zA-Z0-9_]*)'`)
 
+// customShorthandAnalyzerRe matches the "custom.fieldName" shorthand in SQL.
+var customShorthandAnalyzerRe = regexp.MustCompile(`\bcustom\.([a-zA-Z_][a-zA-Z0-9_]*)\b`)
+
 // checkSQLCustomFieldRefs validates json_extract(custom, '$.field') and
 // custom->>'field' patterns in SQL query nodes against the custom field manifest.
 func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
@@ -778,6 +781,9 @@ func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
 				check(m[1])
 			}
 			for _, m := range jsonExtractPGRe.FindAllStringSubmatch(n.SQL, -1) {
+				check(m[1])
+			}
+			for _, m := range customShorthandAnalyzerRe.FindAllStringSubmatch(n.SQL, -1) {
 				check(m[1])
 			}
 		}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -888,3 +888,49 @@ func TestCustomFieldsColumn(t *testing.T) {
 		t.Errorf("expected 0 pending changes (custom column already exists), got %d: %v", len(pending), pending)
 	}
 }
+
+func TestRewriteCustomFieldShorthand_SQLite(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{
+			`SELECT * FROM deal WHERE custom.revenue > 100`,
+			`SELECT * FROM deal WHERE json_extract("custom", '$.revenue') > 100`,
+		},
+		{
+			`SELECT custom.region FROM deal ORDER BY custom.region`,
+			`SELECT json_extract("custom", '$.region') FROM deal ORDER BY json_extract("custom", '$.region')`,
+		},
+		{
+			`SELECT * FROM deal WHERE status = 'open'`,
+			`SELECT * FROM deal WHERE status = 'open'`, // no change
+		},
+	}
+	for _, c := range cases {
+		got := RewriteCustomFieldShorthand(c.in, false)
+		if got != c.want {
+			t.Errorf("SQLite rewrite:\n  in:   %s\n  want: %s\n  got:  %s", c.in, c.want, got)
+		}
+	}
+}
+
+func TestRewriteCustomFieldShorthand_Postgres(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{
+			`SELECT * FROM deal WHERE custom.revenue > 100`,
+			`SELECT * FROM deal WHERE "custom"->>'revenue' > 100`,
+		},
+		{
+			`SELECT custom.region FROM deal`,
+			`SELECT "custom"->>'region' FROM deal`,
+		},
+	}
+	for _, c := range cases {
+		got := RewriteCustomFieldShorthand(c.in, true)
+		if got != c.want {
+			t.Errorf("Postgres rewrite:\n  in:   %s\n  want: %s\n  got:  %s", c.in, c.want, got)
+		}
+	}
+}

--- a/internal/database/query.go
+++ b/internal/database/query.go
@@ -110,6 +110,27 @@ func QueryRowsWithParamsTx(tx *sql.Tx, dialect Dialect, sqlStr string, params ma
 
 // bindParams converts :name style params to dialect-specific positional params.
 // SQLite uses ?, PostgreSQL uses $1, $2, etc.
+// customShorthandRe matches "custom.fieldName" in SQL (shorthand for JSON extraction).
+var customShorthandRe = regexp.MustCompile(`\bcustom\.([a-zA-Z_]\w*)\b`)
+
+// RewriteCustomFieldShorthand rewrites the "custom.fieldName" shorthand to the
+// dialect-appropriate JSON extraction syntax. Only call for models with custom fields.
+// SQLite: custom.field -> json_extract("custom", '$.field')
+// PostgreSQL: custom.field -> "custom"->>'field'
+func RewriteCustomFieldShorthand(sqlStr string, isPostgres bool) string {
+	return customShorthandRe.ReplaceAllStringFunc(sqlStr, func(match string) string {
+		sub := customShorthandRe.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		field := sub[1]
+		if isPostgres {
+			return `"custom"->>'` + field + `'`
+		}
+		return `json_extract("custom", '$.` + field + `')`
+	})
+}
+
 func bindParams(dialect Dialect, sqlStr string, params map[string]string) (string, []interface{}) {
 	var args []interface{}
 	idx := 0

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -366,6 +366,11 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 			s.logger.LogSecurity("tenant guard rejected page query", tErr)
 			continue
 		}
+		if node.SourceModel != "" {
+			if _, hasCustom := app.CustomManifests[node.SourceModel]; hasCustom {
+				sql = database.RewriteCustomFieldShorthand(sql, s.db.Dialect().DriverName() == "pgx")
+			}
+		}
 
 		queryName := node.Name
 		if queryName == "" {
@@ -719,6 +724,11 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 					s.logger.LogSecurity("tenant guard rejected fragment query", tErr)
 					continue
 				}
+				if node.SourceModel != "" {
+					if _, hasCustom := app.CustomManifests[node.SourceModel]; hasCustom {
+						sql = database.RewriteCustomFieldShorthand(sql, s.db.Dialect().DriverName() == "pgx")
+					}
+				}
 				queryName := node.Name
 				if queryName == "" {
 					queryName = "_last"
@@ -793,6 +803,11 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 					s.logger.LogSecurity("tenant guard rejected fragment query", tErr)
 					body.WriteString("<p style=\"color:red\">Query rejected</p>")
 					continue
+				}
+				if node.SourceModel != "" {
+					if _, hasCustom := app.CustomManifests[node.SourceModel]; hasCustom {
+						sql = database.RewriteCustomFieldShorthand(sql, s.db.Dialect().DriverName() == "pgx")
+					}
 				}
 				rows, err := s.db.QueryRowsWithParams(sql, params)
 				if err != nil {


### PR DESCRIPTION
## Summary

- Adds `custom.field` shorthand in SQL queries — rewritten at runtime to the appropriate JSON extraction syntax
  - SQLite: `custom.revenue` → `json_extract("custom", '$.revenue')`
  - PostgreSQL: `custom.revenue` → `"custom"->>'revenue'`
- Rewriting only applies when the queried model has `custom fields from "..."` declared
- Analyzer validates `custom.field` shorthand references against manifest (same check as `json_extract` and `->>'` patterns added in PR A)

## Before / After

Before:
```sql
query deals: SELECT * FROM deal WHERE json_extract(custom, '$.revenue') > 1000
```

After:
```sql
query deals: SELECT * FROM deal WHERE custom.revenue > 1000
```

## Test plan

- [ ] `go test -race ./...` passes
- [ ] `kilnx check` on `WHERE custom.bad_field > 0` (unknown field) emits error
- [ ] `kilnx check` on `WHERE custom.revenue > 0` (valid field) passes
- [ ] Runtime query with `custom.field` returns correct rows (SQLite)

Closes #60. Builds on #70 (PR A). Part of #67 umbrella.