### PR TITLE
feat(custom-fields): per-tenant manifest resolution (#61)

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -375,26 +375,46 @@ func loadApp(filename string) (*parser.App, error) {
 		if model.CustomFieldsFile == "" {
 			continue
 		}
-		if !strings.HasSuffix(model.CustomFieldsFile, ".kilnx") {
-			return nil, fmt.Errorf("custom fields manifest must be a .kilnx file: %s", model.CustomFieldsFile)
+		// Dynamic paths (containing {placeholder}) are resolved at request time.
+		// Load the fallback manifest at startup if it is a static path.
+		if strings.Contains(model.CustomFieldsFile, "{") {
+			if model.CustomFieldsFallback != "" && !strings.Contains(model.CustomFieldsFallback, "{") {
+				m, err := loadManifest(projectRoot, model.CustomFieldsFallback, model.Name)
+				if err != nil {
+					return nil, err
+				}
+				app.CustomManifests[model.Name] = m
+			}
+			continue
 		}
-		manifestPath := filepath.Join(projectRoot, model.CustomFieldsFile)
-		rel, err := filepath.Rel(projectRoot, manifestPath)
-		if err != nil || strings.HasPrefix(rel, "..") {
-			return nil, fmt.Errorf("custom fields manifest escapes project directory: %s", model.CustomFieldsFile)
-		}
-		raw, err := os.ReadFile(manifestPath)
+		m, err := loadManifest(projectRoot, model.CustomFieldsFile, model.Name)
 		if err != nil {
-			return nil, fmt.Errorf("reading manifest %s: %w", model.CustomFieldsFile, err)
+			return nil, err
 		}
-		manifest, err := parser.ParseManifest(string(raw), model.Name)
-		if err != nil {
-			return nil, fmt.Errorf("parsing manifest %s: %w", model.CustomFieldsFile, err)
-		}
-		app.CustomManifests[model.Name] = manifest
+		app.CustomManifests[model.Name] = m
 	}
 
 	return app, nil
+}
+
+func loadManifest(projectRoot, path, modelName string) (*parser.CustomFieldManifest, error) {
+	if !strings.HasSuffix(path, ".kilnx") {
+		return nil, fmt.Errorf("custom fields manifest must be a .kilnx file: %s", path)
+	}
+	manifestPath := filepath.Join(projectRoot, path)
+	rel, err := filepath.Rel(projectRoot, manifestPath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return nil, fmt.Errorf("custom fields manifest escapes project directory: %s", path)
+	}
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest %s: %w", path, err)
+	}
+	m, err := parser.ParseManifest(string(raw), modelName)
+	if err != nil {
+		return nil, fmt.Errorf("parsing manifest %s: %w", path, err)
+	}
+	return m, nil
 }
 
 const maxImportDepth = 64

--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -152,7 +152,7 @@ func cmdRun(filename string) error {
 
 	// Auto-migrate if models exist
 	if len(app.Models) > 0 {
-		stmts, err := db.Migrate(app.Models)
+		stmts, err := db.Migrate(app.Models, app.CustomManifests)
 		if err != nil {
 			return err
 		}
@@ -219,7 +219,7 @@ func cmdMigrate(filename string, flags []string) error {
 		}
 
 		// Show pending changes
-		pending, err := db.PlanMigration(app.Models)
+		pending, err := db.PlanMigration(app.Models, app.CustomManifests)
 		if err != nil {
 			return err
 		}
@@ -236,7 +236,7 @@ func cmdMigrate(filename string, flags []string) error {
 	}
 
 	if dryRun {
-		stmts, err := db.PlanMigration(app.Models)
+		stmts, err := db.PlanMigration(app.Models, app.CustomManifests)
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func cmdMigrate(filename string, flags []string) error {
 		return nil
 	}
 
-	stmts, err := db.Migrate(app.Models)
+	stmts, err := db.Migrate(app.Models, app.CustomManifests)
 	if err != nil {
 		return err
 	}
@@ -319,7 +319,7 @@ func cmdTest(filename string) error {
 	}()
 
 	if len(app.Models) > 0 {
-		stmts, err := db.Migrate(app.Models)
+		stmts, err := db.Migrate(app.Models, app.CustomManifests)
 		if err != nil {
 			return err
 		}

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -37,7 +37,13 @@ type Schema struct {
 }
 
 // BuildSchema creates a compile-time view of the database from model declarations.
-func BuildSchema(models []parser.Model) *Schema {
+// Pass app.CustomManifests as the optional second argument to include column-mode
+// custom fields as real schema columns.
+func BuildSchema(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) *Schema {
+	var cm map[string]*parser.CustomFieldManifest
+	if len(manifests) > 0 {
+		cm = manifests[0]
+	}
 	s := &Schema{
 		Tables:      make(map[string]*TableInfo),
 		ModelFields: make(map[string]*ModelFieldInfo),
@@ -72,6 +78,19 @@ func BuildSchema(models []parser.Model) *Schema {
 			mf.FormFields["custom"] = true
 			mf.FieldToColumn["custom"] = "custom"
 			mf.ColumnToField["custom"] = "custom"
+			// column-mode custom fields become real DB columns visible to the analyzer
+			if manifest, ok := cm[m.Name]; ok {
+				for _, f := range manifest.Fields {
+					if f.Mode != parser.CustomFieldModeColumn {
+						continue
+					}
+					ft := customKindToFieldType(f.Kind)
+					info.Columns[f.Name] = &ColumnInfo{FieldType: ft}
+					mf.FormFields[f.Name] = true
+					mf.FieldToColumn[f.Name] = f.Name
+					mf.ColumnToField[f.Name] = f.Name
+				}
+			}
 		}
 		s.Tables[m.Name] = info
 		s.ModelFields[m.Name] = mf
@@ -79,11 +98,23 @@ func BuildSchema(models []parser.Model) *Schema {
 	return s
 }
 
+// customKindToFieldType maps a manifest field kind to a parser FieldType for schema purposes.
+func customKindToFieldType(kind parser.CustomFieldKind) parser.FieldType {
+	switch kind {
+	case parser.CustomFieldKindNumber:
+		return parser.FieldFloat
+	case parser.CustomFieldKindBool:
+		return parser.FieldBool
+	default:
+		return parser.FieldText
+	}
+}
+
 // Analyze performs static analysis on a parsed Kilnx app, checking SQL
 // references against declared models and type compatibility.
 func Analyze(app *parser.App) []Diagnostic {
 	var diags []Diagnostic
-	schema := BuildSchema(app.Models)
+	schema := BuildSchema(app.Models, app.CustomManifests)
 
 	populateSourceModels(app)
 
@@ -99,7 +130,35 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkTableColumnRefs(app, schema)...)
 	diags = append(diags, checkCustomFieldRefs(app, schema)...)
 	diags = append(diags, checkSQLCustomFieldRefs(app, schema)...)
+	diags = append(diags, checkCustomManifestRefs(app)...)
 
+	return diags
+}
+
+// checkCustomManifestRefs validates that kind: reference targets in manifests refer to known models.
+func checkCustomManifestRefs(app *parser.App) []Diagnostic {
+	if len(app.CustomManifests) == 0 {
+		return nil
+	}
+	modelSet := make(map[string]bool, len(app.Models))
+	for _, m := range app.Models {
+		modelSet[m.Name] = true
+	}
+	var diags []Diagnostic
+	for modelName, manifest := range app.CustomManifests {
+		for _, f := range manifest.Fields {
+			if f.Kind != parser.CustomFieldKindReference {
+				continue
+			}
+			if f.Reference == "" || !modelSet[f.Reference] {
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("custom field '%s' on model '%s': reference target '%s' is not a declared model", f.Name, modelName, f.Reference),
+					Context: fmt.Sprintf("manifest for %s", modelName),
+				})
+			}
+		}
+	}
 	return diags
 }
 

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -98,6 +98,7 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkTemplateInterpolations(app, schema)...)
 	diags = append(diags, checkTableColumnRefs(app, schema)...)
 	diags = append(diags, checkCustomFieldRefs(app, schema)...)
+	diags = append(diags, checkSQLCustomFieldRefs(app, schema)...)
 
 	return diags
 }

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -1790,3 +1790,80 @@ func TestCheckCustomFieldRefs(t *testing.T) {
 		t.Errorf("expected 'unknown' in diagnostic, got %q", diags[0].Message)
 	}
 }
+
+func TestCheckCustomManifestRefs_InvalidReference(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "deal", CustomFieldsFile: "deal_fields.kilnx"},
+		},
+		CustomManifests: map[string]*parser.CustomFieldManifest{
+			"deal": {
+				ModelName: "deal",
+				Fields: []parser.CustomFieldDef{
+					{Name: "client", Kind: parser.CustomFieldKindReference, Reference: "nonexistent"},
+				},
+			},
+		},
+	}
+	diags := checkCustomManifestRefs(app)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic for bad reference target, got %d", len(diags))
+	}
+	if !strings.Contains(diags[0].Message, "nonexistent") {
+		t.Errorf("expected model name in diagnostic, got %q", diags[0].Message)
+	}
+}
+
+func TestCheckCustomManifestRefs_ValidReference(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "deal", CustomFieldsFile: "deal_fields.kilnx"},
+			{Name: "client"},
+		},
+		CustomManifests: map[string]*parser.CustomFieldManifest{
+			"deal": {
+				ModelName: "deal",
+				Fields: []parser.CustomFieldDef{
+					{Name: "client_ref", Kind: parser.CustomFieldKindReference, Reference: "client"},
+				},
+			},
+		},
+	}
+	diags := checkCustomManifestRefs(app)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics for valid reference, got %v", diags)
+	}
+}
+
+func TestBuildSchemaColumnModeFields(t *testing.T) {
+	models := []parser.Model{
+		{
+			Name:             "deal",
+			CustomFieldsFile: "deal_fields.kilnx",
+			Fields:           []parser.Field{{Name: "title", Type: parser.FieldText}},
+		},
+	}
+	cm := map[string]*parser.CustomFieldManifest{
+		"deal": {
+			ModelName: "deal",
+			Fields: []parser.CustomFieldDef{
+				{Name: "revenue", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+				{Name: "region", Kind: parser.CustomFieldKindText, Mode: parser.CustomFieldModeJSON},
+			},
+		},
+	}
+	schema := BuildSchema(models, cm)
+	tbl := schema.Tables["deal"]
+	if tbl == nil {
+		t.Fatal("table 'deal' not in schema")
+	}
+	if _, ok := tbl.Columns["revenue"]; !ok {
+		t.Error("column-mode field 'revenue' should be a real schema column")
+	}
+	if _, ok := tbl.Columns["custom"]; !ok {
+		t.Error("'custom' JSON column should still be in schema")
+	}
+	if _, ok := tbl.Columns["region"]; ok {
+		t.Error("JSON-mode field 'region' should not be a real schema column")
+	}
+}

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -743,6 +743,9 @@ var jsonExtractSQLiteRe = regexp.MustCompile(`(?i)json_extract\s*\(\s*custom\s*,
 // jsonExtractPGRe matches custom->>'fieldName' and custom->'fieldName' in SQL.
 var jsonExtractPGRe = regexp.MustCompile(`\bcustom\s*->>?\s*'([a-zA-Z_][a-zA-Z0-9_]*)'`)
 
+// customShorthandAnalyzerRe matches the "custom.fieldName" shorthand in SQL.
+var customShorthandAnalyzerRe = regexp.MustCompile(`\bcustom\.([a-zA-Z_][a-zA-Z0-9_]*)\b`)
+
 // checkSQLCustomFieldRefs validates json_extract(custom, '$.field') and
 // custom->>'field' patterns in SQL query nodes against the custom field manifest.
 func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
@@ -778,6 +781,9 @@ func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
 				check(m[1])
 			}
 			for _, m := range jsonExtractPGRe.FindAllStringSubmatch(n.SQL, -1) {
+				check(m[1])
+			}
+			for _, m := range customShorthandAnalyzerRe.FindAllStringSubmatch(n.SQL, -1) {
 				check(m[1])
 			}
 		}

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -736,3 +736,63 @@ func checkCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
 
 	return diags
 }
+
+// jsonExtractSQLiteRe matches json_extract(custom, '$.fieldName') in SQL.
+var jsonExtractSQLiteRe = regexp.MustCompile(`(?i)json_extract\s*\(\s*custom\s*,\s*'\$\.([a-zA-Z_][a-zA-Z0-9_]*)'\s*\)`)
+
+// jsonExtractPGRe matches custom->>'fieldName' and custom->'fieldName' in SQL.
+var jsonExtractPGRe = regexp.MustCompile(`\bcustom\s*->>?\s*'([a-zA-Z_][a-zA-Z0-9_]*)'`)
+
+// checkSQLCustomFieldRefs validates json_extract(custom, '$.field') and
+// custom->>'field' patterns in SQL query nodes against the custom field manifest.
+func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
+	if len(app.CustomManifests) == 0 {
+		return nil
+	}
+
+	var diags []Diagnostic
+
+	scanSQL := func(nodes []parser.Node, context string) {
+		for _, n := range nodes {
+			if n.Type != parser.NodeQuery || n.SQL == "" || n.SourceModel == "" {
+				continue
+			}
+			manifest, ok := app.CustomManifests[n.SourceModel]
+			if !ok {
+				continue
+			}
+			known := make(map[string]bool, len(manifest.Fields))
+			for _, f := range manifest.Fields {
+				known[f.Name] = true
+			}
+			check := func(fieldName string) {
+				if !known[fieldName] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("SQL references unknown custom field '%s' (model '%s')", fieldName, n.SourceModel),
+						Context: context,
+					})
+				}
+			}
+			for _, m := range jsonExtractSQLiteRe.FindAllStringSubmatch(n.SQL, -1) {
+				check(m[1])
+			}
+			for _, m := range jsonExtractPGRe.FindAllStringSubmatch(n.SQL, -1) {
+				check(m[1])
+			}
+		}
+	}
+
+	scanPage := func(p parser.Page, context string) { scanSQL(p.Body, context) }
+	for _, p := range app.Pages {
+		scanPage(p, fmt.Sprintf("page %s", p.Path))
+	}
+	for _, f := range app.Fragments {
+		scanPage(f, fmt.Sprintf("fragment %s", f.Path))
+	}
+	for _, a := range app.APIs {
+		scanPage(a, fmt.Sprintf("api %s", a.Path))
+	}
+
+	return diags
+}

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -667,6 +667,16 @@ func checkTableColumnRefs(app *parser.App, schema *Schema) []Diagnostic {
 // customFieldRefRe matches {queryName.custom.fieldName} in HTML content.
 var customFieldRefRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\.custom\.([a-zA-Z_][a-zA-Z0-9_]*)\}`)
 
+// isDynamicManifest reports whether a model uses a dynamic manifest path.
+func isDynamicManifest(app *parser.App, modelName string) bool {
+	for _, m := range app.Models {
+		if m.Name == modelName {
+			return strings.Contains(m.CustomFieldsFile, "{")
+		}
+	}
+	return false
+}
+
 // checkCustomFieldRefs validates {q.custom.fieldName} template references
 // against the corresponding model's custom field manifest.
 func checkCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
@@ -689,6 +699,10 @@ func checkCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
 				continue // unknown query already reported by checkTemplateInterpolations
 			}
 
+			// Skip validation for models with dynamic manifest paths
+			if isDynamicManifest(app, modelName) {
+				continue
+			}
 			manifest, ok := app.CustomManifests[modelName]
 			if !ok {
 				diags = append(diags, Diagnostic{
@@ -758,6 +772,10 @@ func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
 	scanSQL := func(nodes []parser.Node, context string) {
 		for _, n := range nodes {
 			if n.Type != parser.NodeQuery || n.SQL == "" || n.SourceModel == "" {
+				continue
+			}
+			// Skip validation for models with dynamic manifest paths
+			if isDynamicManifest(app, n.SourceModel) {
 				continue
 			}
 			manifest, ok := app.CustomManifests[n.SourceModel]

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -155,7 +155,7 @@ func main() {
 	}
 
 	if len(app.Models) > 0 {
-		stmts, _ := db.Migrate(app.Models)
+		stmts, _ := db.Migrate(app.Models, app.CustomManifests)
 		if len(stmts) > 0 {
 			fmt.Printf("Migrated %d change(s)\n", len(stmts))
 		}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -109,7 +109,13 @@ func (db *DB) Conn() *sql.DB {
 
 // PlanMigration compares models with the current database state and returns
 // the SQL statements that would be executed, without applying them.
-func (db *DB) PlanMigration(models []parser.Model) ([]string, error) {
+// Pass a CustomManifests map as the optional second argument to include
+// column-mode custom field columns in the plan.
+func (db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]string, error) {
+	var cm map[string]*parser.CustomFieldManifest
+	if len(manifests) > 0 {
+		cm = manifests[0]
+	}
 	var stmts []string
 
 	for _, model := range models {
@@ -123,9 +129,9 @@ func (db *DB) PlanMigration(models []parser.Model) ([]string, error) {
 		}
 
 		if !exists {
-			stmts = append(stmts, db.generateCreateTable(model))
+			stmts = append(stmts, db.generateCreateTable(model, cm))
 		} else {
-			alterStmts, err := db.planExistingTable(model)
+			alterStmts, err := db.planExistingTable(model, cm)
 			if err != nil {
 				return stmts, err
 			}
@@ -137,8 +143,10 @@ func (db *DB) PlanMigration(models []parser.Model) ([]string, error) {
 }
 
 // Migrate compares models with the current database state and applies changes.
-func (db *DB) Migrate(models []parser.Model) ([]string, error) {
-	stmts, err := db.PlanMigration(models)
+// Pass a CustomManifests map as the optional second argument to include
+// column-mode custom field columns.
+func (db *DB) Migrate(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]string, error) {
+	stmts, err := db.PlanMigration(models, manifests...)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +238,7 @@ func (db *DB) tableExists(name string) (bool, error) {
 }
 
 // planExistingTable returns ALTER TABLE statements needed without executing them
-func (db *DB) planExistingTable(model parser.Model) ([]string, error) {
+func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.CustomFieldManifest) ([]string, error) {
 	var stmts []string
 
 	existing, err := db.getColumns(model.Name)
@@ -263,6 +271,22 @@ func (db *DB) planExistingTable(model parser.Model) ([]string, error) {
 			}
 			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" %s", model.Name, colType))
 		}
+		// column-mode custom fields become real columns
+		if manifest, ok := cm[model.Name]; ok {
+			for _, f := range manifest.Fields {
+				if f.Mode != parser.CustomFieldModeColumn {
+					continue
+				}
+				if !isValidIdentifier(f.Name) {
+					continue
+				}
+				if _, ok := existing[f.Name]; ok {
+					continue
+				}
+				sqlType := customKindToSQL(f.Kind, db.dialect.DriverName() == "pgx")
+				stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"%s\" %s", model.Name, f.Name, sqlType))
+			}
+		}
 	}
 
 	return stmts, nil
@@ -294,7 +318,7 @@ func (db *DB) getColumns(table string) (map[string]bool, error) {
 	return columns, nil
 }
 
-func (db *DB) generateCreateTable(model parser.Model) string {
+func (db *DB) generateCreateTable(model parser.Model, cm map[string]*parser.CustomFieldManifest) string {
 	var cols []string
 
 	cols = append(cols, db.dialect.AutoIncrementPK())
@@ -310,9 +334,47 @@ func (db *DB) generateCreateTable(model parser.Model) string {
 		} else {
 			cols = append(cols, `"custom" TEXT`)
 		}
+		// column-mode custom fields become real columns
+		if manifest, ok := cm[model.Name]; ok {
+			isPostgres := db.dialect.DriverName() == "pgx"
+			// build set of names already used by model fields + reserved names
+			usedNames := map[string]bool{"id": true, "custom": true}
+			for _, field := range model.Fields {
+				usedNames[fieldToColumnName(field)] = true
+			}
+			for _, f := range manifest.Fields {
+				if f.Mode != parser.CustomFieldModeColumn || !isValidIdentifier(f.Name) {
+					continue
+				}
+				if usedNames[f.Name] {
+					continue
+				}
+				cols = append(cols, fmt.Sprintf(`"%s" %s`, f.Name, customKindToSQL(f.Kind, isPostgres)))
+			}
+		}
 	}
 
 	return fmt.Sprintf("CREATE TABLE \"%s\" (\n  %s\n)", model.Name, strings.Join(cols, ",\n  "))
+}
+
+// customKindToSQL maps a manifest field kind to a SQL column type.
+func customKindToSQL(kind parser.CustomFieldKind, isPostgres bool) string {
+	switch kind {
+	case parser.CustomFieldKindNumber:
+		return "REAL"
+	case parser.CustomFieldKindBool:
+		if isPostgres {
+			return "BOOLEAN"
+		}
+		return "INTEGER"
+	case parser.CustomFieldKindReference:
+		if isPostgres {
+			return "BIGINT"
+		}
+		return "INTEGER"
+	default:
+		return "TEXT"
+	}
 }
 
 func (db *DB) fieldToColumnDef(f parser.Field) string {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -257,7 +257,11 @@ func (db *DB) planExistingTable(model parser.Model) ([]string, error) {
 
 	if model.CustomFieldsFile != "" {
 		if _, ok := existing["custom"]; !ok {
-			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" TEXT", model.Name))
+			colType := "TEXT"
+			if db.dialect.DriverName() == "pgx" {
+				colType = "JSONB"
+			}
+			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" %s", model.Name, colType))
 		}
 	}
 
@@ -301,7 +305,11 @@ func (db *DB) generateCreateTable(model parser.Model) string {
 	}
 
 	if model.CustomFieldsFile != "" {
-		cols = append(cols, `"custom" TEXT`)
+		if db.dialect.DriverName() == "pgx" {
+			cols = append(cols, `"custom" JSONB`)
+		} else {
+			cols = append(cols, `"custom" TEXT`)
+		}
 	}
 
 	return fmt.Sprintf("CREATE TABLE \"%s\" (\n  %s\n)", model.Name, strings.Join(cols, ",\n  "))

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -888,3 +888,49 @@ func TestCustomFieldsColumn(t *testing.T) {
 		t.Errorf("expected 0 pending changes (custom column already exists), got %d: %v", len(pending), pending)
 	}
 }
+
+func TestRewriteCustomFieldShorthand_SQLite(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{
+			`SELECT * FROM deal WHERE custom.revenue > 100`,
+			`SELECT * FROM deal WHERE json_extract("custom", '$.revenue') > 100`,
+		},
+		{
+			`SELECT custom.region FROM deal ORDER BY custom.region`,
+			`SELECT json_extract("custom", '$.region') FROM deal ORDER BY json_extract("custom", '$.region')`,
+		},
+		{
+			`SELECT * FROM deal WHERE status = 'open'`,
+			`SELECT * FROM deal WHERE status = 'open'`, // no change
+		},
+	}
+	for _, c := range cases {
+		got := RewriteCustomFieldShorthand(c.in, false)
+		if got != c.want {
+			t.Errorf("SQLite rewrite:\n  in:   %s\n  want: %s\n  got:  %s", c.in, c.want, got)
+		}
+	}
+}
+
+func TestRewriteCustomFieldShorthand_Postgres(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{
+			`SELECT * FROM deal WHERE custom.revenue > 100`,
+			`SELECT * FROM deal WHERE "custom"->>'revenue' > 100`,
+		},
+		{
+			`SELECT custom.region FROM deal`,
+			`SELECT "custom"->>'region' FROM deal`,
+		},
+	}
+	for _, c := range cases {
+		got := RewriteCustomFieldShorthand(c.in, true)
+		if got != c.want {
+			t.Errorf("Postgres rewrite:\n  in:   %s\n  want: %s\n  got:  %s", c.in, c.want, got)
+		}
+	}
+}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -680,7 +680,7 @@ func TestGenerateCreateTableContainsAutoincrement(t *testing.T) {
 			{Name: "title", Type: parser.FieldText, Required: true},
 		},
 	}
-	sql := db.generateCreateTable(model)
+	sql := db.generateCreateTable(model, nil)
 	if !strings.Contains(sql, "id INTEGER PRIMARY KEY AUTOINCREMENT") {
 		t.Errorf("missing id AUTOINCREMENT in: %s", sql)
 	}
@@ -932,5 +932,117 @@ func TestRewriteCustomFieldShorthand_Postgres(t *testing.T) {
 		if got != c.want {
 			t.Errorf("Postgres rewrite:\n  in:   %s\n  want: %s\n  got:  %s", c.in, c.want, got)
 		}
+	}
+}
+
+// ---------- Column-mode DDL ----------
+
+func TestColumnModeCreateTable(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	model := parser.Model{
+		Name:             "deal",
+		CustomFieldsFile: "deal_fields.kilnx",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText, Required: true},
+		},
+	}
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+			{Name: "region", Kind: parser.CustomFieldKindText, Mode: parser.CustomFieldModeJSON},
+			{Name: "client", Kind: parser.CustomFieldKindReference, Mode: parser.CustomFieldModeColumn},
+		},
+	}
+	cm := map[string]*parser.CustomFieldManifest{"deal": manifest}
+	sql := db.generateCreateTable(model, cm)
+
+	if !strings.Contains(sql, `"custom" TEXT`) {
+		t.Errorf("missing custom JSON column in: %s", sql)
+	}
+	if !strings.Contains(sql, `"revenue" REAL`) {
+		t.Errorf("missing column-mode revenue column in: %s", sql)
+	}
+	if !strings.Contains(sql, `"client" INTEGER`) {
+		t.Errorf("reference kind should produce INTEGER column, got: %s", sql)
+	}
+	if strings.Contains(sql, `"region"`) {
+		t.Errorf("JSON-mode field should not become a column, but found region in: %s", sql)
+	}
+}
+
+func TestColumnModeCreateTableCollisionGuard(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	model := parser.Model{
+		Name:             "deal",
+		CustomFieldsFile: "deal_fields.kilnx",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+		},
+	}
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			// "title" and "id" collide with model fields — must be silently skipped
+			{Name: "title", Kind: parser.CustomFieldKindText, Mode: parser.CustomFieldModeColumn},
+			{Name: "id", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+		},
+	}
+	cm := map[string]*parser.CustomFieldManifest{"deal": manifest}
+	sql := db.generateCreateTable(model, cm)
+
+	// count occurrences of "title" — should appear exactly once
+	titleCount := strings.Count(sql, `"title"`)
+	if titleCount != 1 {
+		t.Errorf("expected 'title' to appear once, got %d times in: %s", titleCount, sql)
+	}
+	// PK is unquoted; ensure no extra quoted "id" column was added
+	if strings.Contains(sql, `"id"`) {
+		t.Errorf("collision guard failed: duplicate 'id' column found in: %s", sql)
+	}
+	if !strings.Contains(sql, `"revenue" REAL`) {
+		t.Errorf("non-colliding column-mode field 'revenue' should be present in: %s", sql)
+	}
+}
+
+func TestColumnModeMigrate(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	model := parser.Model{
+		Name:             "deal",
+		CustomFieldsFile: "deal_fields.kilnx",
+		Fields:           []parser.Field{{Name: "title", Type: parser.FieldText}},
+	}
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+		},
+	}
+	cm := map[string]*parser.CustomFieldManifest{"deal": manifest}
+
+	stmts, err := db.Migrate([]parser.Model{model}, cm)
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if len(stmts) == 0 {
+		t.Fatal("expected DDL statements, got none")
+	}
+
+	cols, err := db.getColumns("deal")
+	if err != nil {
+		t.Fatalf("getColumns: %v", err)
+	}
+	if !cols["revenue"] {
+		t.Error("column-mode field 'revenue' not present in table after migration")
+	}
+	if !cols["custom"] {
+		t.Error("JSON 'custom' column not present in table after migration")
 	}
 }

--- a/internal/database/query.go
+++ b/internal/database/query.go
@@ -110,6 +110,27 @@ func QueryRowsWithParamsTx(tx *sql.Tx, dialect Dialect, sqlStr string, params ma
 
 // bindParams converts :name style params to dialect-specific positional params.
 // SQLite uses ?, PostgreSQL uses $1, $2, etc.
+// customShorthandRe matches "custom.fieldName" in SQL (shorthand for JSON extraction).
+var customShorthandRe = regexp.MustCompile(`\bcustom\.([a-zA-Z_]\w*)\b`)
+
+// RewriteCustomFieldShorthand rewrites the "custom.fieldName" shorthand to the
+// dialect-appropriate JSON extraction syntax. Only call for models with custom fields.
+// SQLite: custom.field -> json_extract("custom", '$.field')
+// PostgreSQL: custom.field -> "custom"->>'field'
+func RewriteCustomFieldShorthand(sqlStr string, isPostgres bool) string {
+	return customShorthandRe.ReplaceAllStringFunc(sqlStr, func(match string) string {
+		sub := customShorthandRe.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		field := sub[1]
+		if isPostgres {
+			return `"custom"->>'` + field + `'`
+		}
+		return `json_extract("custom", '$.` + field + `')`
+	})
+}
+
 func bindParams(dialect Dialect, sqlStr string, params map[string]string) (string, []interface{}) {
 	var args []interface{}
 	idx := 0

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -154,10 +154,14 @@ type Model struct {
 type CustomFieldKind string
 
 const (
-	CustomFieldKindText   CustomFieldKind = "text"
-	CustomFieldKindNumber CustomFieldKind = "number"
-	CustomFieldKindDate   CustomFieldKind = "date"
-	CustomFieldKindOption CustomFieldKind = "option"
+	CustomFieldKindText     CustomFieldKind = "text"
+	CustomFieldKindNumber   CustomFieldKind = "number"
+	CustomFieldKindDate     CustomFieldKind = "date"
+	CustomFieldKindOption   CustomFieldKind = "option"
+	CustomFieldKindEmail    CustomFieldKind = "email"
+	CustomFieldKindPhone    CustomFieldKind = "phone"
+	CustomFieldKindBool     CustomFieldKind = "bool"
+	CustomFieldKindRichtext CustomFieldKind = "richtext"
 )
 
 // CustomFieldDef describes a single custom field from a manifest file.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -155,23 +155,35 @@ type Model struct {
 type CustomFieldKind string
 
 const (
-	CustomFieldKindText     CustomFieldKind = "text"
-	CustomFieldKindNumber   CustomFieldKind = "number"
-	CustomFieldKindDate     CustomFieldKind = "date"
-	CustomFieldKindOption   CustomFieldKind = "option"
-	CustomFieldKindEmail    CustomFieldKind = "email"
-	CustomFieldKindPhone    CustomFieldKind = "phone"
-	CustomFieldKindBool     CustomFieldKind = "bool"
-	CustomFieldKindRichtext CustomFieldKind = "richtext"
+	CustomFieldKindText      CustomFieldKind = "text"
+	CustomFieldKindNumber    CustomFieldKind = "number"
+	CustomFieldKindDate      CustomFieldKind = "date"
+	CustomFieldKindOption    CustomFieldKind = "option"
+	CustomFieldKindEmail     CustomFieldKind = "email"
+	CustomFieldKindPhone     CustomFieldKind = "phone"
+	CustomFieldKindBool      CustomFieldKind = "bool"
+	CustomFieldKindRichtext  CustomFieldKind = "richtext"
+	CustomFieldKindReference CustomFieldKind = "reference"
+	CustomFieldKindImage     CustomFieldKind = "image"
+)
+
+// CustomFieldMode controls how a custom field is stored in the database.
+type CustomFieldMode string
+
+const (
+	CustomFieldModeJSON   CustomFieldMode = ""       // stored in custom JSON column (default)
+	CustomFieldModeColumn CustomFieldMode = "column" // promoted to a dedicated real column
 )
 
 // CustomFieldDef describes a single custom field from a manifest file.
 type CustomFieldDef struct {
-	Name     string
-	Kind     CustomFieldKind
-	Label    string
-	Required bool
-	Options  []string
+	Name      string
+	Kind      CustomFieldKind
+	Label     string
+	Required  bool
+	Options   []string
+	Mode      CustomFieldMode // "" = JSON, "column" = dedicated column
+	Reference string          // target model name for kind: reference
 }
 
 // CustomFieldManifest holds all custom field definitions for a model.
@@ -3137,6 +3149,12 @@ func (p *parserState) parseManifestField() (CustomFieldDef, error) {
 				if p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword {
 					def.Kind = CustomFieldKind(p.advance().Value)
 				}
+				// kind: reference <model> — reference target follows on same line
+				if def.Kind == CustomFieldKindReference {
+					if p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword {
+						def.Reference = p.advance().Value
+					}
+				}
 				// kind: option [A, B, C] — options may follow on the same line
 				if def.Kind == CustomFieldKindOption && p.current().Type == lexer.TokenBracketOpen {
 					p.advance() // consume '['
@@ -3167,6 +3185,10 @@ func (p *parserState) parseManifestField() (CustomFieldDef, error) {
 					p.advance()
 				} else {
 					def.Required = true // bare keyword, no value
+				}
+			case "mode":
+				if p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword {
+					def.Mode = CustomFieldMode(p.advance().Value)
 				}
 			}
 		}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -145,9 +145,10 @@ type Model struct {
 	// field named after the tenant model (e.g. `tenant: org` adds an
 	// `org_id` column) and the runtime injects a WHERE filter on SELECT
 	// queries against this table.
-	Tenant           string
-	Fields           []Field
-	CustomFieldsFile string // path to *_fields.kilnx manifest; empty if unused
+	Tenant               string
+	Fields               []Field
+	CustomFieldsFile     string // path to *_fields.kilnx manifest (may contain {placeholder})
+	CustomFieldsFallback string // fallback manifest path used when dynamic file not found
 }
 
 // CustomFieldKind is the type of a runtime-extensible custom field.
@@ -578,7 +579,7 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 		// custom fields from "<file>" is a model-level meta directive.
 		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) &&
 			tok.Value == "custom" && p.peekIsCustomFieldsDirective() {
-			path, err := p.parseCustomFieldsDirective()
+			path, fallback, err := p.parseCustomFieldsDirective()
 			if err != nil {
 				return model, err
 			}
@@ -586,6 +587,7 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 				return model, fmt.Errorf("line %d: model '%s' already has a custom fields directive", tok.Line, model.Name)
 			}
 			model.CustomFieldsFile = path
+			model.CustomFieldsFallback = fallback
 			continue
 		}
 
@@ -678,20 +680,29 @@ func (p *parserState) peekIsCustomFieldsDirective() bool {
 		t3.Type == lexer.TokenString
 }
 
-// parseCustomFieldsDirective parses `custom fields from "<path>"` and
-// returns the manifest file path. Caller verified with peekIsCustomFieldsDirective.
-func (p *parserState) parseCustomFieldsDirective() (string, error) {
+// parseCustomFieldsDirective parses `custom fields from "<path>" [or "<fallback>"]`
+// and returns (path, fallback, error). Caller verified with peekIsCustomFieldsDirective.
+func (p *parserState) parseCustomFieldsDirective() (string, string, error) {
 	p.advance() // consume "custom"
 	p.advance() // consume "fields"
 	p.advance() // consume "from"
 	pathTok := p.advance()
 	if pathTok.Type != lexer.TokenString {
-		return "", fmt.Errorf("line %d: expected file path string after 'custom fields from'", pathTok.Line)
+		return "", "", fmt.Errorf("line %d: expected file path string after 'custom fields from'", pathTok.Line)
+	}
+	path := pathTok.Value
+	fallback := ""
+	// Optional: or "<fallback>"
+	if !p.isEOF() && p.current().Type == lexer.TokenIdentifier && p.current().Value == "or" {
+		p.advance() // consume "or"
+		if p.current().Type == lexer.TokenString {
+			fallback = p.advance().Value
+		}
 	}
 	for !p.isEOF() && p.current().Type != lexer.TokenNewline && p.current().Type != lexer.TokenDedent {
 		p.advance()
 	}
-	return pathTok.Value, nil
+	return path, fallback, nil
 }
 
 func (p *parserState) parseField(app *App) (Field, error) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1126,3 +1126,47 @@ field region
 		t.Error("expected required=true for region")
 	}
 }
+
+func TestParseManifestColumnModeAndReference(t *testing.T) {
+	src := `field revenue
+  kind: number
+  mode: column
+  label: "Revenue"
+
+field client
+  kind: reference company
+  mode: column
+  label: "Client"
+
+field notes
+  kind: text
+  label: "Notes"`
+	manifest, err := ParseManifest(src, "deal")
+	if err != nil {
+		t.Fatalf("ParseManifest error: %v", err)
+	}
+	if len(manifest.Fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(manifest.Fields))
+	}
+	rev := manifest.Fields[0]
+	if rev.Mode != CustomFieldModeColumn {
+		t.Errorf("revenue: expected mode=column, got %q", rev.Mode)
+	}
+	if rev.Kind != CustomFieldKindNumber {
+		t.Errorf("revenue: expected kind=number, got %q", rev.Kind)
+	}
+	client := manifest.Fields[1]
+	if client.Kind != CustomFieldKindReference {
+		t.Errorf("client: expected kind=reference, got %q", client.Kind)
+	}
+	if client.Reference != "company" {
+		t.Errorf("client: expected reference=company, got %q", client.Reference)
+	}
+	if client.Mode != CustomFieldModeColumn {
+		t.Errorf("client: expected mode=column, got %q", client.Mode)
+	}
+	notes := manifest.Fields[2]
+	if notes.Mode != CustomFieldModeJSON {
+		t.Errorf("notes: expected mode=JSON (empty), got %q", notes.Mode)
+	}
+}

--- a/internal/runtime/forms.go
+++ b/internal/runtime/forms.go
@@ -169,7 +169,11 @@ func validateFormData(modelName string, app *parser.App, formData map[string]str
 				}
 			}
 			for _, f := range manifest.Fields {
+				// column-mode fields are promoted to top-level keys by serializeCustomBrackets
 				val := customVals[f.Name]
+				if f.Mode == parser.CustomFieldModeColumn {
+					val = formData[f.Name]
+				}
 				label := f.Label
 				if label == "" {
 					label = f.Name
@@ -227,6 +231,11 @@ func validateFormData(modelName string, app *parser.App, formData map[string]str
 					}
 					if !valid {
 						errors = append(errors, fmt.Sprintf("%s must be one of: %s", label, strings.Join(f.Options, ", ")))
+					}
+				}
+				if f.Kind == parser.CustomFieldKindReference && val != "" {
+					if _, err := strconv.Atoi(val); err != nil {
+						errors = append(errors, fmt.Sprintf("%s must be a valid reference ID", label))
 					}
 				}
 			}
@@ -373,7 +382,8 @@ func extractFormData(r *http.Request, config *parser.AppConfig) map[string]strin
 }
 
 // serializeCustomBrackets collects custom[field]=value entries from form data,
-// JSON-encodes them, and stores the result as data["custom"].
+// JSON-encodes them as data["custom"], and also promotes each field as a top-level
+// key so column-mode SQL (e.g. INSERT ... (:revenue)) can bind directly.
 func serializeCustomBrackets(data map[string]string) {
 	customMap := make(map[string]string)
 	for k, v := range data {
@@ -403,5 +413,11 @@ func serializeCustomBrackets(data map[string]string) {
 	b, err := json.Marshal(customMap)
 	if err == nil {
 		data["custom"] = string(b)
+	}
+	// Also promote each field as a direct key so column-mode SQL binds :fieldname.
+	for k, v := range customMap {
+		if _, exists := data[k]; !exists {
+			data[k] = v
+		}
 	}
 }

--- a/internal/runtime/forms.go
+++ b/internal/runtime/forms.go
@@ -194,6 +194,29 @@ func validateFormData(modelName string, app *parser.App, formData map[string]str
 						errors = append(errors, fmt.Sprintf("%s must be a valid date", label))
 					}
 				}
+				if f.Kind == parser.CustomFieldKindEmail && val != "" {
+					if !strings.Contains(val, "@") || !strings.Contains(val, ".") {
+						errors = append(errors, fmt.Sprintf("%s must be a valid email address", label))
+					}
+				}
+				if f.Kind == parser.CustomFieldKindPhone && val != "" {
+					stripped := strings.Map(func(r rune) rune {
+						if r >= '0' && r <= '9' {
+							return r
+						}
+						return -1
+					}, val)
+					if len(stripped) < 7 {
+						errors = append(errors, fmt.Sprintf("%s must be a valid phone number", label))
+					}
+				}
+				if f.Kind == parser.CustomFieldKindBool && val != "" {
+					switch strings.ToLower(val) {
+					case "true", "false", "1", "0", "on", "off", "yes", "no":
+					default:
+						errors = append(errors, fmt.Sprintf("%s must be a boolean value", label))
+					}
+				}
 				if f.Kind == parser.CustomFieldKindOption && len(f.Options) > 0 && val != "" {
 					valid := false
 					for _, opt := range f.Options {

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -422,6 +422,12 @@ func expandEachBlocks(content string, ctx *renderContext, nonce string) string {
 			}
 		} else {
 			for _, row := range rows {
+				// Rebind q.custom per row so {{each q.custom}} works on list pages (#66)
+				if sourceModel, ok := ctx.querySourceModels[queryName]; ok {
+					if manifest, ok := ctx.customManifests[sourceModel]; ok {
+						ctx.queries[queryName+".custom"] = buildCustomIterRows(row, manifest)
+					}
+				}
 				// Process raw filters inside each body with current row context
 				expanded := processRawInRow(body, row, ctx, nonce)
 				// Process nested {{each}} blocks

--- a/internal/runtime/render_test.go
+++ b/internal/runtime/render_test.go
@@ -11,9 +11,11 @@ import (
 
 func newTestContext() *renderContext {
 	return &renderContext{
-		queries:     make(map[string][]database.Row),
-		paginate:    make(map[string]PaginateInfo),
-		queryParams: make(map[string]string),
+		queries:           make(map[string][]database.Row),
+		paginate:          make(map[string]PaginateInfo),
+		queryParams:       make(map[string]string),
+		querySourceModels: make(map[string]string),
+		customManifests:   make(map[string]*parser.CustomFieldManifest),
 	}
 }
 
@@ -657,5 +659,36 @@ func TestBuildCustomIterRows_EmptyCustomColumn(t *testing.T) {
 	}
 	if result[0]["value"] != "" {
 		t.Errorf("expected empty value, got %q", result[0]["value"])
+	}
+}
+
+// TestEachCustomRebindPerRow verifies that {{each q.custom}} inside {{each q}}
+// shows each row's own custom fields, not always row[0] (#66).
+func TestEachCustomRebindPerRow(t *testing.T) {
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Label: "Revenue"},
+		},
+	}
+	ctx := newTestContext()
+	ctx.querySourceModels["d"] = "deal"
+	ctx.customManifests["deal"] = manifest
+	ctx.queries["d"] = []database.Row{
+		{"title": "Deal A", "custom": `{"revenue":"100"}`},
+		{"title": "Deal B", "custom": `{"revenue":"200"}`},
+	}
+	// Pre-populate with row[0] data (as server.go does at query time)
+	ctx.queries["d.custom"] = buildCustomIterRows(ctx.queries["d"][0], manifest)
+
+	// Inside {{each d}}, bare {title} uses current row; {d.title} always uses row[0]
+	tmpl := `{{each d}}<div>{title}:{{each d.custom}}{value}{{end}}</div>{{end}}`
+	result := renderHTML(tmpl, ctx)
+
+	if !strings.Contains(result, "Deal A:100") {
+		t.Errorf("expected Deal A:100 in output, got: %s", result)
+	}
+	if !strings.Contains(result, "Deal B:200") {
+		t.Errorf("expected Deal B:200 in output, got: %s", result)
 	}
 }

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -366,6 +366,11 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 			s.logger.LogSecurity("tenant guard rejected page query", tErr)
 			continue
 		}
+		if node.SourceModel != "" {
+			if _, hasCustom := app.CustomManifests[node.SourceModel]; hasCustom {
+				sql = database.RewriteCustomFieldShorthand(sql, s.db.Dialect().DriverName() == "pgx")
+			}
+		}
 
 		queryName := node.Name
 		if queryName == "" {
@@ -719,6 +724,11 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 					s.logger.LogSecurity("tenant guard rejected fragment query", tErr)
 					continue
 				}
+				if node.SourceModel != "" {
+					if _, hasCustom := app.CustomManifests[node.SourceModel]; hasCustom {
+						sql = database.RewriteCustomFieldShorthand(sql, s.db.Dialect().DriverName() == "pgx")
+					}
+				}
 				queryName := node.Name
 				if queryName == "" {
 					queryName = "_last"
@@ -793,6 +803,11 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 					s.logger.LogSecurity("tenant guard rejected fragment query", tErr)
 					body.WriteString("<p style=\"color:red\">Query rejected</p>")
 					continue
+				}
+				if node.SourceModel != "" {
+					if _, hasCustom := app.CustomManifests[node.SourceModel]; hasCustom {
+						sql = database.RewriteCustomFieldShorthand(sql, s.db.Dialect().DriverName() == "pgx")
+					}
 				}
 				rows, err := s.db.QueryRowsWithParams(sql, params)
 				if err != nil {

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -315,8 +315,9 @@ type renderContext struct {
 	queries           map[string][]database.Row
 	paginate          map[string]PaginateInfo
 	currentUser       *Session
-	queryParams       map[string]string // URL query parameters (?key=value)
-	querySourceModels map[string]string // query name -> primary model name (set by analyzer)
+	queryParams       map[string]string                      // URL query parameters (?key=value)
+	querySourceModels map[string]string                      // query name -> primary model name (set by analyzer)
+	customManifests   map[string]*parser.CustomFieldManifest // model name -> manifest (for list-page rebinding)
 }
 
 func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Request) string {
@@ -327,6 +328,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 		currentUser:       s.getSession(r),
 		queryParams:       make(map[string]string),
 		querySourceModels: make(map[string]string),
+		customManifests:   app.CustomManifests,
 	}
 
 	pathParams := matchPathParams(p.Path, r.URL.Path)
@@ -680,6 +682,7 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 		currentUser:       s.getSession(r),
 		queryParams:       make(map[string]string),
 		querySourceModels: make(map[string]string),
+		customManifests:   app.CustomManifests,
 	}
 
 	// Make current_user available in fragments
@@ -776,6 +779,7 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 		queries:           make(map[string][]database.Row),
 		paginate:          make(map[string]PaginateInfo),
 		querySourceModels: make(map[string]string),
+		customManifests:   app.CustomManifests,
 	}
 
 	var body strings.Builder
@@ -1187,9 +1191,11 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 				}
 				tx.Commit()
 				rows = expandCustomFields(rows)
+				respondApp := s.getApp()
 				ctx := &renderContext{
 					queries:           map[string][]database.Row{"_result": rows},
 					querySourceModels: make(map[string]string),
+					customManifests:   respondApp.CustomManifests,
 				}
 				if node.RespondTarget != "" {
 					w.Header().Set("HX-Retarget", node.RespondTarget)

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -434,6 +434,8 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 			if model := findModel(app.Models, node.SourceModel); model != nil {
 				if manifest := s.resolveManifest(model, app, ctx.currentUser, pathParams, r); manifest != nil {
 					ctx.customManifests[node.SourceModel] = manifest
+					rows = expandColumnModeFields(rows, manifest)
+					ctx.queries[queryName] = rows
 					if len(rows) > 0 {
 						ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
 					}
@@ -770,6 +772,8 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 					if model := findModel(app.Models, node.SourceModel); model != nil {
 						if manifest := s.resolveManifest(model, app, ctx.currentUser, pathParams, r); manifest != nil {
 							ctx.customManifests[node.SourceModel] = manifest
+							rows = expandColumnModeFields(rows, manifest)
+							ctx.queries[queryName] = rows
 							if len(rows) > 0 {
 								ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
 							}
@@ -837,6 +841,8 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 					if model := findModel(app.Models, node.SourceModel); model != nil {
 						if manifest := s.resolveManifest(model, app, nil, params, nil); manifest != nil {
 							ctx.customManifests[node.SourceModel] = manifest
+							rows = expandColumnModeFields(rows, manifest)
+							ctx.queries[name] = rows
 							if len(rows) > 0 {
 								ctx.queries[name+".custom"] = buildCustomIterRows(rows[0], manifest)
 							}
@@ -1602,12 +1608,33 @@ func buildCustomIterRows(row database.Row, manifest *parser.CustomFieldManifest)
 		if label == "" {
 			label = f.Name
 		}
+		val := values[f.Name]
+		if f.Mode == parser.CustomFieldModeColumn {
+			val = row[f.Name]
+		}
 		result = append(result, database.Row{
 			"name":  f.Name,
-			"value": values[f.Name],
+			"value": val,
 			"label": label,
 			"kind":  string(f.Kind),
 		})
 	}
 	return result
+}
+
+// expandColumnModeFields adds "custom.<field>" aliases for column-mode manifest fields
+// so that {q.custom.field} template access works the same as JSON-mode fields.
+func expandColumnModeFields(rows []database.Row, manifest *parser.CustomFieldManifest) []database.Row {
+	for i, row := range rows {
+		for _, f := range manifest.Fields {
+			if f.Mode != parser.CustomFieldModeColumn {
+				continue
+			}
+			if val, ok := row[f.Name]; ok {
+				row["custom."+f.Name] = val
+			}
+		}
+		rows[i] = row
+	}
+	return rows
 }

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -24,17 +24,18 @@ var staticFS embed.FS
 var interpolateRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\}`)
 
 type Server struct {
-	app          *parser.App
-	db           *database.DB
-	sessions     *SessionStore
-	jobQueue     *JobQueue
-	rateLimiter  *RateLimiter
-	logger       *Logger
-	i18n         *I18n
-	tenants      TenantMap // models with a `tenant: <model>` directive
-	mu           sync.RWMutex
-	port         int
-	scheduleStop chan struct{}
+	app           *parser.App
+	db            *database.DB
+	sessions      *SessionStore
+	jobQueue      *JobQueue
+	rateLimiter   *RateLimiter
+	logger        *Logger
+	i18n          *I18n
+	tenants       TenantMap // models with a `tenant: <model>` directive
+	manifestCache sync.Map  // resolved path -> *parser.CustomFieldManifest (dynamic manifests)
+	mu            sync.RWMutex
+	port          int
+	scheduleStop  chan struct{}
 }
 
 func NewServer(app *parser.App, db *database.DB, port int) *Server {
@@ -430,8 +431,13 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 		ctx.queries[queryName] = rows
 		if node.SourceModel != "" {
 			ctx.querySourceModels[queryName] = node.SourceModel
-			if manifest, ok := app.CustomManifests[node.SourceModel]; ok && len(rows) > 0 {
-				ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
+			if model := findModel(app.Models, node.SourceModel); model != nil {
+				if manifest := s.resolveManifest(model, app, ctx.currentUser, pathParams, r); manifest != nil {
+					ctx.customManifests[node.SourceModel] = manifest
+					if len(rows) > 0 {
+						ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
+					}
+				}
 			}
 		}
 	}
@@ -761,8 +767,13 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 				ctx.queries[queryName] = rows
 				if node.SourceModel != "" {
 					ctx.querySourceModels[queryName] = node.SourceModel
-					if manifest, ok := app.CustomManifests[node.SourceModel]; ok && len(rows) > 0 {
-						ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
+					if model := findModel(app.Models, node.SourceModel); model != nil {
+						if manifest := s.resolveManifest(model, app, ctx.currentUser, pathParams, r); manifest != nil {
+							ctx.customManifests[node.SourceModel] = manifest
+							if len(rows) > 0 {
+								ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
+							}
+						}
 					}
 				}
 			}
@@ -823,8 +834,13 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 				ctx.queries[name] = rows
 				if node.SourceModel != "" {
 					ctx.querySourceModels[name] = node.SourceModel
-					if manifest, ok := app.CustomManifests[node.SourceModel]; ok && len(rows) > 0 {
-						ctx.queries[name+".custom"] = buildCustomIterRows(rows[0], manifest)
+					if model := findModel(app.Models, node.SourceModel); model != nil {
+						if manifest := s.resolveManifest(model, app, nil, params, nil); manifest != nil {
+							ctx.customManifests[node.SourceModel] = manifest
+							if len(rows) > 0 {
+								ctx.queries[name+".custom"] = buildCustomIterRows(rows[0], manifest)
+							}
+						}
 					}
 				}
 			}
@@ -1478,6 +1494,92 @@ func expandCustomFields(rows []database.Row) []database.Row {
 		rows[i] = row
 	}
 	return rows
+}
+
+// findModel returns a pointer to the model with the given name, or nil if not found.
+func findModel(models []parser.Model, name string) *parser.Model {
+	for i := range models {
+		if models[i].Name == name {
+			return &models[i]
+		}
+	}
+	return nil
+}
+
+// resolveTenantPlaceholder replaces {user.field}, {:param}, {header.H} in a manifest
+// path template using session, path params, and request headers.
+func resolveTenantPlaceholder(template string, session *Session, pathParams map[string]string, r *http.Request) string {
+	return tenantPlaceholderRe.ReplaceAllStringFunc(template, func(m string) string {
+		inner := m[1 : len(m)-1] // strip { }
+		parts := strings.SplitN(inner, ".", 2)
+		switch {
+		case parts[0] == "header" && len(parts) == 2:
+			if r != nil {
+				return r.Header.Get(parts[1])
+			}
+		case parts[0] == "user" && len(parts) == 2:
+			if session != nil {
+				if v, ok := session.Data[parts[1]]; ok {
+					return v
+				}
+			}
+		case strings.HasPrefix(inner, ":"):
+			key := inner[1:]
+			if v, ok := pathParams[key]; ok {
+				return v
+			}
+		}
+		return ""
+	})
+}
+
+var tenantPlaceholderRe = regexp.MustCompile(`\{[^}]+\}`)
+
+// resolveManifest returns the custom field manifest for a model, resolving dynamic
+// paths at request time. Results are cached per resolved path.
+func (s *Server) resolveManifest(model *parser.Model, app *parser.App, session *Session, pathParams map[string]string, r *http.Request) *parser.CustomFieldManifest {
+	if model.CustomFieldsFile == "" {
+		return nil
+	}
+	if !strings.Contains(model.CustomFieldsFile, "{") {
+		// Static path: already loaded into app.CustomManifests at startup
+		if m, ok := app.CustomManifests[model.Name]; ok {
+			return m
+		}
+		return nil
+	}
+	// Dynamic path: resolve placeholder and load on demand
+	resolved := resolveTenantPlaceholder(model.CustomFieldsFile, session, pathParams, r)
+	if resolved == "" || strings.Contains(resolved, "{") {
+		// Placeholder couldn't be resolved; fall back to static manifest
+		if m, ok := app.CustomManifests[model.Name]; ok {
+			return m
+		}
+		return nil
+	}
+	// Sanitize: must end in .kilnx, no path traversal
+	if !strings.HasSuffix(resolved, ".kilnx") || strings.Contains(resolved, "..") {
+		return nil
+	}
+	if cached, ok := s.manifestCache.Load(resolved); ok {
+		return cached.(*parser.CustomFieldManifest)
+	}
+	raw, err := os.ReadFile(resolved)
+	if err != nil {
+		// File not found — try fallback
+		if model.CustomFieldsFallback != "" && !strings.Contains(model.CustomFieldsFallback, "{") {
+			if m, ok := app.CustomManifests[model.Name]; ok {
+				return m // fallback was loaded at startup
+			}
+		}
+		return nil
+	}
+	m, err := parser.ParseManifest(string(raw), model.Name)
+	if err != nil {
+		return nil
+	}
+	s.manifestCache.Store(resolved, m)
+	return m
 }
 
 // buildCustomIterRows creates synthetic rows for {{each q.custom}} iteration.


### PR DESCRIPTION
## Summary

Enables per-tenant (per-request) custom field manifests via dynamic path resolution.

**Syntax:**
```kilnx
model deal
  custom fields from "manifests/{user.company}.kilnx" or "manifests/default.kilnx"
```

**Placeholder support:**
- `{user.fieldName}` — from auth session (e.g. `user.company`, `user.tenant`)
- `{:routeparam}` — from URL path params (e.g. `{:tenant}`)
- `{header.X-Tenant-ID}` — from HTTP request headers

**Behavior:**
- Static paths (no `{}`) still loaded at startup — no change
- Dynamic paths resolved per request, cached by resolved path (`sync.Map`)
- Fallback (`or "path"`) loaded at startup if static; used when tenant file not found
- Analyzer skips field-level validation for dynamic-manifest models (unknown at compile time)

## Test plan

- [ ] Static `custom fields from "file.kilnx"` works as before
- [ ] Dynamic `custom fields from "manifests/{user.company}.kilnx"` loads correct manifest per user
- [ ] Missing tenant file falls back to `or "default.kilnx"`
- [ ] `kilnx check` emits no false positives for `{d.custom.field}` on dynamic-manifest models
- [ ] Concurrent requests to different tenants get correct (isolated) manifests

Closes #61. Builds on #71. Part of #67 umbrella.