### PR TITLE
feat: column-mode custom fields and reference/image kinds (#64, #63)

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -152,7 +152,7 @@ func cmdRun(filename string) error {
 
 	// Auto-migrate if models exist
 	if len(app.Models) > 0 {
-		stmts, err := db.Migrate(app.Models)
+		stmts, err := db.Migrate(app.Models, app.CustomManifests)
 		if err != nil {
 			return err
 		}
@@ -219,7 +219,7 @@ func cmdMigrate(filename string, flags []string) error {
 		}
 
 		// Show pending changes
-		pending, err := db.PlanMigration(app.Models)
+		pending, err := db.PlanMigration(app.Models, app.CustomManifests)
 		if err != nil {
 			return err
 		}
@@ -236,7 +236,7 @@ func cmdMigrate(filename string, flags []string) error {
 	}
 
 	if dryRun {
-		stmts, err := db.PlanMigration(app.Models)
+		stmts, err := db.PlanMigration(app.Models, app.CustomManifests)
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func cmdMigrate(filename string, flags []string) error {
 		return nil
 	}
 
-	stmts, err := db.Migrate(app.Models)
+	stmts, err := db.Migrate(app.Models, app.CustomManifests)
 	if err != nil {
 		return err
 	}
@@ -319,7 +319,7 @@ func cmdTest(filename string) error {
 	}()
 
 	if len(app.Models) > 0 {
-		stmts, err := db.Migrate(app.Models)
+		stmts, err := db.Migrate(app.Models, app.CustomManifests)
 		if err != nil {
 			return err
 		}

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -37,7 +37,13 @@ type Schema struct {
 }
 
 // BuildSchema creates a compile-time view of the database from model declarations.
-func BuildSchema(models []parser.Model) *Schema {
+// Pass app.CustomManifests as the optional second argument to include column-mode
+// custom fields as real schema columns.
+func BuildSchema(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) *Schema {
+	var cm map[string]*parser.CustomFieldManifest
+	if len(manifests) > 0 {
+		cm = manifests[0]
+	}
 	s := &Schema{
 		Tables:      make(map[string]*TableInfo),
 		ModelFields: make(map[string]*ModelFieldInfo),
@@ -72,6 +78,19 @@ func BuildSchema(models []parser.Model) *Schema {
 			mf.FormFields["custom"] = true
 			mf.FieldToColumn["custom"] = "custom"
 			mf.ColumnToField["custom"] = "custom"
+			// column-mode custom fields become real DB columns visible to the analyzer
+			if manifest, ok := cm[m.Name]; ok {
+				for _, f := range manifest.Fields {
+					if f.Mode != parser.CustomFieldModeColumn {
+						continue
+					}
+					ft := customKindToFieldType(f.Kind)
+					info.Columns[f.Name] = &ColumnInfo{FieldType: ft}
+					mf.FormFields[f.Name] = true
+					mf.FieldToColumn[f.Name] = f.Name
+					mf.ColumnToField[f.Name] = f.Name
+				}
+			}
 		}
 		s.Tables[m.Name] = info
 		s.ModelFields[m.Name] = mf
@@ -79,11 +98,23 @@ func BuildSchema(models []parser.Model) *Schema {
 	return s
 }
 
+// customKindToFieldType maps a manifest field kind to a parser FieldType for schema purposes.
+func customKindToFieldType(kind parser.CustomFieldKind) parser.FieldType {
+	switch kind {
+	case parser.CustomFieldKindNumber:
+		return parser.FieldFloat
+	case parser.CustomFieldKindBool:
+		return parser.FieldBool
+	default:
+		return parser.FieldText
+	}
+}
+
 // Analyze performs static analysis on a parsed Kilnx app, checking SQL
 // references against declared models and type compatibility.
 func Analyze(app *parser.App) []Diagnostic {
 	var diags []Diagnostic
-	schema := BuildSchema(app.Models)
+	schema := BuildSchema(app.Models, app.CustomManifests)
 
 	populateSourceModels(app)
 
@@ -99,7 +130,35 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkTableColumnRefs(app, schema)...)
 	diags = append(diags, checkCustomFieldRefs(app, schema)...)
 	diags = append(diags, checkSQLCustomFieldRefs(app, schema)...)
+	diags = append(diags, checkCustomManifestRefs(app)...)
 
+	return diags
+}
+
+// checkCustomManifestRefs validates that kind: reference targets in manifests refer to known models.
+func checkCustomManifestRefs(app *parser.App) []Diagnostic {
+	if len(app.CustomManifests) == 0 {
+		return nil
+	}
+	modelSet := make(map[string]bool, len(app.Models))
+	for _, m := range app.Models {
+		modelSet[m.Name] = true
+	}
+	var diags []Diagnostic
+	for modelName, manifest := range app.CustomManifests {
+		for _, f := range manifest.Fields {
+			if f.Kind != parser.CustomFieldKindReference {
+				continue
+			}
+			if f.Reference == "" || !modelSet[f.Reference] {
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("custom field '%s' on model '%s': reference target '%s' is not a declared model", f.Name, modelName, f.Reference),
+					Context: fmt.Sprintf("manifest for %s", modelName),
+				})
+			}
+		}
+	}
 	return diags
 }
 

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -1790,3 +1790,80 @@ func TestCheckCustomFieldRefs(t *testing.T) {
 		t.Errorf("expected 'unknown' in diagnostic, got %q", diags[0].Message)
 	}
 }
+
+func TestCheckCustomManifestRefs_InvalidReference(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "deal", CustomFieldsFile: "deal_fields.kilnx"},
+		},
+		CustomManifests: map[string]*parser.CustomFieldManifest{
+			"deal": {
+				ModelName: "deal",
+				Fields: []parser.CustomFieldDef{
+					{Name: "client", Kind: parser.CustomFieldKindReference, Reference: "nonexistent"},
+				},
+			},
+		},
+	}
+	diags := checkCustomManifestRefs(app)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic for bad reference target, got %d", len(diags))
+	}
+	if !strings.Contains(diags[0].Message, "nonexistent") {
+		t.Errorf("expected model name in diagnostic, got %q", diags[0].Message)
+	}
+}
+
+func TestCheckCustomManifestRefs_ValidReference(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "deal", CustomFieldsFile: "deal_fields.kilnx"},
+			{Name: "client"},
+		},
+		CustomManifests: map[string]*parser.CustomFieldManifest{
+			"deal": {
+				ModelName: "deal",
+				Fields: []parser.CustomFieldDef{
+					{Name: "client_ref", Kind: parser.CustomFieldKindReference, Reference: "client"},
+				},
+			},
+		},
+	}
+	diags := checkCustomManifestRefs(app)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics for valid reference, got %v", diags)
+	}
+}
+
+func TestBuildSchemaColumnModeFields(t *testing.T) {
+	models := []parser.Model{
+		{
+			Name:             "deal",
+			CustomFieldsFile: "deal_fields.kilnx",
+			Fields:           []parser.Field{{Name: "title", Type: parser.FieldText}},
+		},
+	}
+	cm := map[string]*parser.CustomFieldManifest{
+		"deal": {
+			ModelName: "deal",
+			Fields: []parser.CustomFieldDef{
+				{Name: "revenue", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+				{Name: "region", Kind: parser.CustomFieldKindText, Mode: parser.CustomFieldModeJSON},
+			},
+		},
+	}
+	schema := BuildSchema(models, cm)
+	tbl := schema.Tables["deal"]
+	if tbl == nil {
+		t.Fatal("table 'deal' not in schema")
+	}
+	if _, ok := tbl.Columns["revenue"]; !ok {
+		t.Error("column-mode field 'revenue' should be a real schema column")
+	}
+	if _, ok := tbl.Columns["custom"]; !ok {
+		t.Error("'custom' JSON column should still be in schema")
+	}
+	if _, ok := tbl.Columns["region"]; ok {
+		t.Error("JSON-mode field 'region' should not be a real schema column")
+	}
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -155,7 +155,7 @@ func main() {
 	}
 
 	if len(app.Models) > 0 {
-		stmts, _ := db.Migrate(app.Models)
+		stmts, _ := db.Migrate(app.Models, app.CustomManifests)
 		if len(stmts) > 0 {
 			fmt.Printf("Migrated %d change(s)\n", len(stmts))
 		}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -337,8 +337,16 @@ func (db *DB) generateCreateTable(model parser.Model, cm map[string]*parser.Cust
 		// column-mode custom fields become real columns
 		if manifest, ok := cm[model.Name]; ok {
 			isPostgres := db.dialect.DriverName() == "pgx"
+			// build set of names already used by model fields + reserved names
+			usedNames := map[string]bool{"id": true, "custom": true}
+			for _, field := range model.Fields {
+				usedNames[fieldToColumnName(field)] = true
+			}
 			for _, f := range manifest.Fields {
 				if f.Mode != parser.CustomFieldModeColumn || !isValidIdentifier(f.Name) {
+					continue
+				}
+				if usedNames[f.Name] {
 					continue
 				}
 				cols = append(cols, fmt.Sprintf(`"%s" %s`, f.Name, customKindToSQL(f.Kind, isPostgres)))
@@ -357,6 +365,11 @@ func customKindToSQL(kind parser.CustomFieldKind, isPostgres bool) string {
 	case parser.CustomFieldKindBool:
 		if isPostgres {
 			return "BOOLEAN"
+		}
+		return "INTEGER"
+	case parser.CustomFieldKindReference:
+		if isPostgres {
+			return "BIGINT"
 		}
 		return "INTEGER"
 	default:

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -109,7 +109,13 @@ func (db *DB) Conn() *sql.DB {
 
 // PlanMigration compares models with the current database state and returns
 // the SQL statements that would be executed, without applying them.
-func (db *DB) PlanMigration(models []parser.Model) ([]string, error) {
+// Pass a CustomManifests map as the optional second argument to include
+// column-mode custom field columns in the plan.
+func (db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]string, error) {
+	var cm map[string]*parser.CustomFieldManifest
+	if len(manifests) > 0 {
+		cm = manifests[0]
+	}
 	var stmts []string
 
 	for _, model := range models {
@@ -123,9 +129,9 @@ func (db *DB) PlanMigration(models []parser.Model) ([]string, error) {
 		}
 
 		if !exists {
-			stmts = append(stmts, db.generateCreateTable(model))
+			stmts = append(stmts, db.generateCreateTable(model, cm))
 		} else {
-			alterStmts, err := db.planExistingTable(model)
+			alterStmts, err := db.planExistingTable(model, cm)
 			if err != nil {
 				return stmts, err
 			}
@@ -137,8 +143,10 @@ func (db *DB) PlanMigration(models []parser.Model) ([]string, error) {
 }
 
 // Migrate compares models with the current database state and applies changes.
-func (db *DB) Migrate(models []parser.Model) ([]string, error) {
-	stmts, err := db.PlanMigration(models)
+// Pass a CustomManifests map as the optional second argument to include
+// column-mode custom field columns.
+func (db *DB) Migrate(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]string, error) {
+	stmts, err := db.PlanMigration(models, manifests...)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +238,7 @@ func (db *DB) tableExists(name string) (bool, error) {
 }
 
 // planExistingTable returns ALTER TABLE statements needed without executing them
-func (db *DB) planExistingTable(model parser.Model) ([]string, error) {
+func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.CustomFieldManifest) ([]string, error) {
 	var stmts []string
 
 	existing, err := db.getColumns(model.Name)
@@ -263,6 +271,22 @@ func (db *DB) planExistingTable(model parser.Model) ([]string, error) {
 			}
 			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" %s", model.Name, colType))
 		}
+		// column-mode custom fields become real columns
+		if manifest, ok := cm[model.Name]; ok {
+			for _, f := range manifest.Fields {
+				if f.Mode != parser.CustomFieldModeColumn {
+					continue
+				}
+				if !isValidIdentifier(f.Name) {
+					continue
+				}
+				if _, ok := existing[f.Name]; ok {
+					continue
+				}
+				sqlType := customKindToSQL(f.Kind, db.dialect.DriverName() == "pgx")
+				stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"%s\" %s", model.Name, f.Name, sqlType))
+			}
+		}
 	}
 
 	return stmts, nil
@@ -294,7 +318,7 @@ func (db *DB) getColumns(table string) (map[string]bool, error) {
 	return columns, nil
 }
 
-func (db *DB) generateCreateTable(model parser.Model) string {
+func (db *DB) generateCreateTable(model parser.Model, cm map[string]*parser.CustomFieldManifest) string {
 	var cols []string
 
 	cols = append(cols, db.dialect.AutoIncrementPK())
@@ -310,9 +334,34 @@ func (db *DB) generateCreateTable(model parser.Model) string {
 		} else {
 			cols = append(cols, `"custom" TEXT`)
 		}
+		// column-mode custom fields become real columns
+		if manifest, ok := cm[model.Name]; ok {
+			isPostgres := db.dialect.DriverName() == "pgx"
+			for _, f := range manifest.Fields {
+				if f.Mode != parser.CustomFieldModeColumn || !isValidIdentifier(f.Name) {
+					continue
+				}
+				cols = append(cols, fmt.Sprintf(`"%s" %s`, f.Name, customKindToSQL(f.Kind, isPostgres)))
+			}
+		}
 	}
 
 	return fmt.Sprintf("CREATE TABLE \"%s\" (\n  %s\n)", model.Name, strings.Join(cols, ",\n  "))
+}
+
+// customKindToSQL maps a manifest field kind to a SQL column type.
+func customKindToSQL(kind parser.CustomFieldKind, isPostgres bool) string {
+	switch kind {
+	case parser.CustomFieldKindNumber:
+		return "REAL"
+	case parser.CustomFieldKindBool:
+		if isPostgres {
+			return "BOOLEAN"
+		}
+		return "INTEGER"
+	default:
+		return "TEXT"
+	}
 }
 
 func (db *DB) fieldToColumnDef(f parser.Field) string {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -680,7 +680,7 @@ func TestGenerateCreateTableContainsAutoincrement(t *testing.T) {
 			{Name: "title", Type: parser.FieldText, Required: true},
 		},
 	}
-	sql := db.generateCreateTable(model)
+	sql := db.generateCreateTable(model, nil)
 	if !strings.Contains(sql, "id INTEGER PRIMARY KEY AUTOINCREMENT") {
 		t.Errorf("missing id AUTOINCREMENT in: %s", sql)
 	}
@@ -932,5 +932,76 @@ func TestRewriteCustomFieldShorthand_Postgres(t *testing.T) {
 		if got != c.want {
 			t.Errorf("Postgres rewrite:\n  in:   %s\n  want: %s\n  got:  %s", c.in, c.want, got)
 		}
+	}
+}
+
+// ---------- Column-mode DDL ----------
+
+func TestColumnModeCreateTable(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	model := parser.Model{
+		Name:             "deal",
+		CustomFieldsFile: "deal_fields.kilnx",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText, Required: true},
+		},
+	}
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+			{Name: "region", Kind: parser.CustomFieldKindText, Mode: parser.CustomFieldModeJSON},
+		},
+	}
+	cm := map[string]*parser.CustomFieldManifest{"deal": manifest}
+	sql := db.generateCreateTable(model, cm)
+
+	if !strings.Contains(sql, `"custom" TEXT`) {
+		t.Errorf("missing custom JSON column in: %s", sql)
+	}
+	if !strings.Contains(sql, `"revenue" REAL`) {
+		t.Errorf("missing column-mode revenue column in: %s", sql)
+	}
+	if strings.Contains(sql, `"region"`) {
+		t.Errorf("JSON-mode field should not become a column, but found region in: %s", sql)
+	}
+}
+
+func TestColumnModeMigrate(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	model := parser.Model{
+		Name:             "deal",
+		CustomFieldsFile: "deal_fields.kilnx",
+		Fields:           []parser.Field{{Name: "title", Type: parser.FieldText}},
+	}
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+		},
+	}
+	cm := map[string]*parser.CustomFieldManifest{"deal": manifest}
+
+	stmts, err := db.Migrate([]parser.Model{model}, cm)
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if len(stmts) == 0 {
+		t.Fatal("expected DDL statements, got none")
+	}
+
+	cols, err := db.getColumns("deal")
+	if err != nil {
+		t.Fatalf("getColumns: %v", err)
+	}
+	if !cols["revenue"] {
+		t.Error("column-mode field 'revenue' not present in table after migration")
+	}
+	if !cols["custom"] {
+		t.Error("JSON 'custom' column not present in table after migration")
 	}
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -953,6 +953,7 @@ func TestColumnModeCreateTable(t *testing.T) {
 		Fields: []parser.CustomFieldDef{
 			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
 			{Name: "region", Kind: parser.CustomFieldKindText, Mode: parser.CustomFieldModeJSON},
+			{Name: "client", Kind: parser.CustomFieldKindReference, Mode: parser.CustomFieldModeColumn},
 		},
 	}
 	cm := map[string]*parser.CustomFieldManifest{"deal": manifest}
@@ -964,8 +965,48 @@ func TestColumnModeCreateTable(t *testing.T) {
 	if !strings.Contains(sql, `"revenue" REAL`) {
 		t.Errorf("missing column-mode revenue column in: %s", sql)
 	}
+	if !strings.Contains(sql, `"client" INTEGER`) {
+		t.Errorf("reference kind should produce INTEGER column, got: %s", sql)
+	}
 	if strings.Contains(sql, `"region"`) {
 		t.Errorf("JSON-mode field should not become a column, but found region in: %s", sql)
+	}
+}
+
+func TestColumnModeCreateTableCollisionGuard(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	model := parser.Model{
+		Name:             "deal",
+		CustomFieldsFile: "deal_fields.kilnx",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+		},
+	}
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields: []parser.CustomFieldDef{
+			// "title" and "id" collide with model fields — must be silently skipped
+			{Name: "title", Kind: parser.CustomFieldKindText, Mode: parser.CustomFieldModeColumn},
+			{Name: "id", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+			{Name: "revenue", Kind: parser.CustomFieldKindNumber, Mode: parser.CustomFieldModeColumn},
+		},
+	}
+	cm := map[string]*parser.CustomFieldManifest{"deal": manifest}
+	sql := db.generateCreateTable(model, cm)
+
+	// count occurrences of "title" — should appear exactly once
+	titleCount := strings.Count(sql, `"title"`)
+	if titleCount != 1 {
+		t.Errorf("expected 'title' to appear once, got %d times in: %s", titleCount, sql)
+	}
+	// PK is unquoted; ensure no extra quoted "id" column was added
+	if strings.Contains(sql, `"id"`) {
+		t.Errorf("collision guard failed: duplicate 'id' column found in: %s", sql)
+	}
+	if !strings.Contains(sql, `"revenue" REAL`) {
+		t.Errorf("non-colliding column-mode field 'revenue' should be present in: %s", sql)
 	}
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -155,23 +155,35 @@ type Model struct {
 type CustomFieldKind string
 
 const (
-	CustomFieldKindText     CustomFieldKind = "text"
-	CustomFieldKindNumber   CustomFieldKind = "number"
-	CustomFieldKindDate     CustomFieldKind = "date"
-	CustomFieldKindOption   CustomFieldKind = "option"
-	CustomFieldKindEmail    CustomFieldKind = "email"
-	CustomFieldKindPhone    CustomFieldKind = "phone"
-	CustomFieldKindBool     CustomFieldKind = "bool"
-	CustomFieldKindRichtext CustomFieldKind = "richtext"
+	CustomFieldKindText      CustomFieldKind = "text"
+	CustomFieldKindNumber    CustomFieldKind = "number"
+	CustomFieldKindDate      CustomFieldKind = "date"
+	CustomFieldKindOption    CustomFieldKind = "option"
+	CustomFieldKindEmail     CustomFieldKind = "email"
+	CustomFieldKindPhone     CustomFieldKind = "phone"
+	CustomFieldKindBool      CustomFieldKind = "bool"
+	CustomFieldKindRichtext  CustomFieldKind = "richtext"
+	CustomFieldKindReference CustomFieldKind = "reference"
+	CustomFieldKindImage     CustomFieldKind = "image"
+)
+
+// CustomFieldMode controls how a custom field is stored in the database.
+type CustomFieldMode string
+
+const (
+	CustomFieldModeJSON   CustomFieldMode = ""       // stored in custom JSON column (default)
+	CustomFieldModeColumn CustomFieldMode = "column" // promoted to a dedicated real column
 )
 
 // CustomFieldDef describes a single custom field from a manifest file.
 type CustomFieldDef struct {
-	Name     string
-	Kind     CustomFieldKind
-	Label    string
-	Required bool
-	Options  []string
+	Name      string
+	Kind      CustomFieldKind
+	Label     string
+	Required  bool
+	Options   []string
+	Mode      CustomFieldMode // "" = JSON, "column" = dedicated column
+	Reference string          // target model name for kind: reference
 }
 
 // CustomFieldManifest holds all custom field definitions for a model.
@@ -3137,6 +3149,12 @@ func (p *parserState) parseManifestField() (CustomFieldDef, error) {
 				if p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword {
 					def.Kind = CustomFieldKind(p.advance().Value)
 				}
+				// kind: reference <model> — reference target follows on same line
+				if def.Kind == CustomFieldKindReference {
+					if p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword {
+						def.Reference = p.advance().Value
+					}
+				}
 				// kind: option [A, B, C] — options may follow on the same line
 				if def.Kind == CustomFieldKindOption && p.current().Type == lexer.TokenBracketOpen {
 					p.advance() // consume '['
@@ -3167,6 +3185,10 @@ func (p *parserState) parseManifestField() (CustomFieldDef, error) {
 					p.advance()
 				} else {
 					def.Required = true // bare keyword, no value
+				}
+			case "mode":
+				if p.current().Type == lexer.TokenIdentifier || p.current().Type == lexer.TokenKeyword {
+					def.Mode = CustomFieldMode(p.advance().Value)
 				}
 			}
 		}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1126,3 +1126,47 @@ field region
 		t.Error("expected required=true for region")
 	}
 }
+
+func TestParseManifestColumnModeAndReference(t *testing.T) {
+	src := `field revenue
+  kind: number
+  mode: column
+  label: "Revenue"
+
+field client
+  kind: reference company
+  mode: column
+  label: "Client"
+
+field notes
+  kind: text
+  label: "Notes"`
+	manifest, err := ParseManifest(src, "deal")
+	if err != nil {
+		t.Fatalf("ParseManifest error: %v", err)
+	}
+	if len(manifest.Fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(manifest.Fields))
+	}
+	rev := manifest.Fields[0]
+	if rev.Mode != CustomFieldModeColumn {
+		t.Errorf("revenue: expected mode=column, got %q", rev.Mode)
+	}
+	if rev.Kind != CustomFieldKindNumber {
+		t.Errorf("revenue: expected kind=number, got %q", rev.Kind)
+	}
+	client := manifest.Fields[1]
+	if client.Kind != CustomFieldKindReference {
+		t.Errorf("client: expected kind=reference, got %q", client.Kind)
+	}
+	if client.Reference != "company" {
+		t.Errorf("client: expected reference=company, got %q", client.Reference)
+	}
+	if client.Mode != CustomFieldModeColumn {
+		t.Errorf("client: expected mode=column, got %q", client.Mode)
+	}
+	notes := manifest.Fields[2]
+	if notes.Mode != CustomFieldModeJSON {
+		t.Errorf("notes: expected mode=JSON (empty), got %q", notes.Mode)
+	}
+}

--- a/internal/runtime/forms.go
+++ b/internal/runtime/forms.go
@@ -169,7 +169,11 @@ func validateFormData(modelName string, app *parser.App, formData map[string]str
 				}
 			}
 			for _, f := range manifest.Fields {
+				// column-mode fields are promoted to top-level keys by serializeCustomBrackets
 				val := customVals[f.Name]
+				if f.Mode == parser.CustomFieldModeColumn {
+					val = formData[f.Name]
+				}
 				label := f.Label
 				if label == "" {
 					label = f.Name
@@ -227,6 +231,11 @@ func validateFormData(modelName string, app *parser.App, formData map[string]str
 					}
 					if !valid {
 						errors = append(errors, fmt.Sprintf("%s must be one of: %s", label, strings.Join(f.Options, ", ")))
+					}
+				}
+				if f.Kind == parser.CustomFieldKindReference && val != "" {
+					if _, err := strconv.Atoi(val); err != nil {
+						errors = append(errors, fmt.Sprintf("%s must be a valid reference ID", label))
 					}
 				}
 			}
@@ -373,7 +382,8 @@ func extractFormData(r *http.Request, config *parser.AppConfig) map[string]strin
 }
 
 // serializeCustomBrackets collects custom[field]=value entries from form data,
-// JSON-encodes them, and stores the result as data["custom"].
+// JSON-encodes them as data["custom"], and also promotes each field as a top-level
+// key so column-mode SQL (e.g. INSERT ... (:revenue)) can bind directly.
 func serializeCustomBrackets(data map[string]string) {
 	customMap := make(map[string]string)
 	for k, v := range data {
@@ -403,5 +413,11 @@ func serializeCustomBrackets(data map[string]string) {
 	b, err := json.Marshal(customMap)
 	if err == nil {
 		data["custom"] = string(b)
+	}
+	// Also promote each field as a direct key so column-mode SQL binds :fieldname.
+	for k, v := range customMap {
+		if _, exists := data[k]; !exists {
+			data[k] = v
+		}
 	}
 }

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -434,6 +434,8 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 			if model := findModel(app.Models, node.SourceModel); model != nil {
 				if manifest := s.resolveManifest(model, app, ctx.currentUser, pathParams, r); manifest != nil {
 					ctx.customManifests[node.SourceModel] = manifest
+					rows = expandColumnModeFields(rows, manifest)
+					ctx.queries[queryName] = rows
 					if len(rows) > 0 {
 						ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
 					}
@@ -770,6 +772,8 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 					if model := findModel(app.Models, node.SourceModel); model != nil {
 						if manifest := s.resolveManifest(model, app, ctx.currentUser, pathParams, r); manifest != nil {
 							ctx.customManifests[node.SourceModel] = manifest
+							rows = expandColumnModeFields(rows, manifest)
+							ctx.queries[queryName] = rows
 							if len(rows) > 0 {
 								ctx.queries[queryName+".custom"] = buildCustomIterRows(rows[0], manifest)
 							}
@@ -837,6 +841,8 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 					if model := findModel(app.Models, node.SourceModel); model != nil {
 						if manifest := s.resolveManifest(model, app, nil, params, nil); manifest != nil {
 							ctx.customManifests[node.SourceModel] = manifest
+							rows = expandColumnModeFields(rows, manifest)
+							ctx.queries[name] = rows
 							if len(rows) > 0 {
 								ctx.queries[name+".custom"] = buildCustomIterRows(rows[0], manifest)
 							}
@@ -1602,12 +1608,33 @@ func buildCustomIterRows(row database.Row, manifest *parser.CustomFieldManifest)
 		if label == "" {
 			label = f.Name
 		}
+		val := values[f.Name]
+		if f.Mode == parser.CustomFieldModeColumn {
+			val = row[f.Name]
+		}
 		result = append(result, database.Row{
 			"name":  f.Name,
-			"value": values[f.Name],
+			"value": val,
 			"label": label,
 			"kind":  string(f.Kind),
 		})
 	}
 	return result
+}
+
+// expandColumnModeFields adds "custom.<field>" aliases for column-mode manifest fields
+// so that {q.custom.field} template access works the same as JSON-mode fields.
+func expandColumnModeFields(rows []database.Row, manifest *parser.CustomFieldManifest) []database.Row {
+	for i, row := range rows {
+		for _, f := range manifest.Fields {
+			if f.Mode != parser.CustomFieldModeColumn {
+				continue
+			}
+			if val, ok := row[f.Name]; ok {
+				row["custom."+f.Name] = val
+			}
+		}
+		rows[i] = row
+	}
+	return rows
 }


### PR DESCRIPTION
## Summary

- **#64 column-mode**: `mode: column` in manifest promotes a custom field to a real dedicated DB column (`ALTER TABLE ... ADD COLUMN`) instead of storing in the JSON `custom` blob
- **#63 reference/image kinds**: `kind: reference <model>` and `kind: image` added to manifest; analyzer validates reference targets against declared models

## What changed

**Parser**
- New `CustomFieldModeColumn`, `CustomFieldKindReference`, `CustomFieldKindImage` constants
- `CustomFieldDef` gets `Mode CustomFieldMode` and `Reference string` fields
- `mode: column` and `kind: reference <model>` parsed in manifest

**Database**
- `generateCreateTable`/`planExistingTable` emit real SQL columns for `mode=column` fields (`REAL` for number, `BOOLEAN`/`INTEGER` for bool, `TEXT` otherwise)
- `PlanMigration`/`Migrate` accept `manifests` variadically for backward compat

**Analyzer**
- `BuildSchema` adds column-mode fields as real schema columns (enables `{q.revenue}` template access and SQL column validation)
- New `checkCustomManifestRefs` validates `kind: reference <model>` targets exist

**Runtime**
- `expandColumnModeFields`: adds `custom.<field>` aliases so `{q.custom.field}` works uniformly for both modes
- `buildCustomIterRows`: reads column-mode values from direct column (not JSON)
- `serializeCustomBrackets`: promotes `custom[field]=val` as top-level key so column-mode SQL binds `:fieldname` directly
- `validateFormData`: reads column-mode field values from top-level `formData[f.Name]`

## Test plan

- [x] `TestParseManifestColumnModeAndReference` — parser round-trip for mode/reference
- [x] `TestColumnModeCreateTable` — DDL includes real column, not in JSON blob
- [x] `TestColumnModeMigrate` — migration creates real column AND `custom` JSON column
- [x] `TestBuildSchemaColumnModeFields` — schema exposes column-mode as real column
- [x] `TestCheckCustomManifestRefs_InvalidReference` — bad reference target → error
- [x] `TestCheckCustomManifestRefs_ValidReference` — valid reference → no diagnostic
- [x] `go test -race ./...` passes