### PR TITLE
feat: runtime custom field management via dynamic fields (closes #69)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -326,6 +326,72 @@ The optimizer rewrites queries based on template usage:
 - Missing CSRF protection
 - Webhooks without signature verification
 
+## Dynamic Custom Fields (end-user managed)
+
+Models can opt into DB-backed runtime field definitions so end-users can manage
+custom fields without touching `.kilnx` files and without an app restart.
+
+```kilnx
+model deal
+  name: text required
+  custom fields from "deal_base.kilnx"  // optional static baseline
+  dynamic fields                         // enables DB-backed field management
+```
+
+kilnx auto-creates `_deal_field_defs(id, name, kind, label, required, options,
+reference_model, tenant_id, sort_order)` at migration time. The developer writes
+the field management UI using normal pages and actions:
+
+```kilnx
+page /admin/fields requires auth
+  query fields: SELECT * FROM _deal_field_defs ORDER BY sort_order, id
+  html
+    <h1>Custom Fields</h1>
+    {{each fields}}
+      <div class="field-row">
+        <strong>{fields.label}</strong> — {fields.kind}
+        <button hx-post="/admin/fields/{fields.id}/delete"
+                hx-target="closest .field-row" hx-swap="outerHTML">Delete</button>
+      </div>
+    {{end}}
+    <form hx-post="/admin/fields/create" hx-target=".field-list" hx-swap="beforeend">
+      <input name="name" placeholder="field_name" required>
+      <select name="kind">
+        <option>text</option><option>number</option><option>date</option>
+        <option>bool</option><option>option</option><option>email</option>
+      </select>
+      <input name="label" placeholder="Label">
+      <button>Add Field</button>
+    </form>
+
+fragment /admin/fields/row
+  query f: SELECT * FROM _deal_field_defs WHERE id = :id
+  html
+    <div class="field-row">
+      <strong>{f.label}</strong> — {f.kind}
+      <button hx-post="/admin/fields/{f.id}/delete"
+              hx-target="closest .field-row" hx-swap="outerHTML">Delete</button>
+    </div>
+
+action /admin/fields/create method POST requires auth
+  query: INSERT INTO _deal_field_defs (name, kind, label, required)
+         VALUES (:name, :kind, :label, :required)
+  respond fragment /admin/fields/row with params: id = last_insert_id
+
+action /admin/fields/:id/delete method POST requires auth
+  query: DELETE FROM _deal_field_defs WHERE id = :id
+  respond 200
+```
+
+End-users can create a "Panel Brand" field for deals without any developer
+intervention or restart. The new field is available immediately via
+`{q.custom.panel_brand}` or `{{each q.custom}}` in any page querying `deal`.
+
+`kilnx check` emits warnings (not errors) for hardcoded `{q.custom.X}`
+references on dynamic-fields models. Run `kilnx check app.kilnx --db <url>`
+to validate against actual DB field names.
+
 ## LSP Server
 
 `kilnx lsp` provides IDE integration with completions, diagnostics, and hover documentation.
+

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -60,6 +60,91 @@ model comment
   created: timestamp auto
 ```
 
+#### custom fields from manifest
+
+A model can declare a versioned manifest of runtime-extensible fields. The
+manifest file (`*_fields.kilnx`) is edited by the developer and parsed at
+startup. Fields are stored as JSON in a `custom` column (`TEXT` on SQLite,
+`JSONB` on PostgreSQL).
+
+```kilnx
+model deal
+  name: text required
+  custom fields from "deal_fields.kilnx"
+```
+
+Manifest syntax:
+```
+field revenue
+  kind: number
+  label: "Revenue"
+  required: false
+  mode: column  // promotes to a real DB column instead of JSON storage
+
+field status
+  kind: option
+  option [open, won, lost]
+```
+
+Available kinds: `text`, `number`, `date`, `option`, `email`, `phone`, `bool`,
+`richtext`, `reference`, `image`.
+
+Access in templates: `{q.custom.revenue}`. Iterate: `{{each q.custom}}` (yields
+`name`, `value`, `label`, `kind` per field).
+
+Per-tenant manifests with runtime placeholders:
+```kilnx
+model quote
+  custom fields from "{user.tenant_id}_fields.kilnx" or "default_fields.kilnx"
+```
+
+`kilnx check` validates all hardcoded `{q.custom.X}` references against the
+manifest. Dynamic-path manifests are silenced.
+
+#### dynamic fields (runtime-mutable)
+
+A model can opt into DB-backed runtime field definitions. End-users (not
+developers) can then create, edit, and delete custom fields without touching
+`.kilnx` files and without an app restart.
+
+```kilnx
+model deal
+  name: text required
+  custom fields from "deal_base.kilnx"  // optional static baseline
+  dynamic fields                         // enables DB-backed field management
+```
+
+When `dynamic fields` is declared, kilnx auto-creates a `_deal_field_defs`
+table at migration time with columns: `id`, `name`, `kind`, `label`,
+`required`, `options`, `reference_model`, `tenant_id`, `sort_order`.
+
+The runtime merges the static manifest (if any) with rows from
+`_deal_field_defs` at request time. Static fields always win on name collision.
+
+The developer writes the field management UI using normal pages and actions:
+
+```kilnx
+page /admin/fields requires auth
+  query fields: SELECT * FROM _deal_field_defs ORDER BY sort_order
+  html
+    {{each fields}}
+      <div>{fields.label} ({fields.kind})</div>
+    {{end}}
+
+action /admin/fields/create method POST requires auth
+  query: INSERT INTO _deal_field_defs (name, kind, label)
+         VALUES (:name, :kind, :label)
+  redirect /admin/fields
+```
+
+**Static analysis**: `kilnx check` emits a warning (not an error) for hardcoded
+`{q.custom.X}` references on dynamic-fields models. Use `kilnx check --db
+<url>` to connect to a live database and validate against actual field names.
+
+**DB fields are JSON-only**: rows from `_field_defs` always write to the
+`custom` column. Column-mode (`mode: column`) is only available for static
+manifest fields.
+
 #### tenant scoping
 
 A model can declare that its rows belong to a tenant (another model) with

--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -67,10 +67,17 @@ func main() {
 		}
 	case "check":
 		if len(os.Args) < 3 {
-			fmt.Println("Usage: kilnx check <file.kilnx>")
+			fmt.Println("Usage: kilnx check <file.kilnx> [--db <url>]")
 			os.Exit(1)
 		}
-		if err := cmdCheck(os.Args[2]); err != nil {
+		dbURL := ""
+		args := os.Args[3:]
+		for i, arg := range args {
+			if arg == "--db" && i+1 < len(args) {
+				dbURL = args[i+1]
+			}
+		}
+		if err := cmdCheck(os.Args[2], dbURL); err != nil {
 			fmt.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
@@ -87,13 +94,24 @@ func main() {
 	}
 }
 
-func cmdCheck(filename string) error {
+func cmdCheck(filename, dbURL string) error {
 	app, err := loadApp(filename)
 	if err != nil {
 		return err
 	}
 
-	diags := analyzer.Analyze(app)
+	var diags []analyzer.Diagnostic
+	if dbURL != "" {
+		db, err := database.Open(dbURL)
+		if err != nil {
+			return fmt.Errorf("opening DB for check: %w", err)
+		}
+		defer db.Close()
+		diags = analyzer.AnalyzeWithDB(app, db)
+	} else {
+		diags = analyzer.Analyze(app)
+	}
+
 	if len(diags) == 0 {
 		fmt.Println("No issues found.")
 		return nil

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -73,7 +73,7 @@ func BuildSchema(models []parser.Model, manifests ...map[string]*parser.CustomFi
 				mf.ColumnToField[f.Name] = f.Name
 			}
 		}
-		if m.CustomFieldsFile != "" {
+		if m.CustomFieldsFile != "" || m.DynamicFields {
 			info.Columns["custom"] = &ColumnInfo{FieldType: parser.FieldText}
 			mf.FormFields["custom"] = true
 			mf.FieldToColumn["custom"] = "custom"

--- a/internal/analyzer/db_check.go
+++ b/internal/analyzer/db_check.go
@@ -1,0 +1,97 @@
+package analyzer
+
+import (
+	"fmt"
+
+	"github.com/kilnx-org/kilnx/internal/database"
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// AnalyzeWithDB runs the standard Analyze pass plus a DB-connected pass that
+// validates {q.custom.fieldName} references against the actual _field_defs tables.
+// db may be nil, in which case this is equivalent to Analyze.
+func AnalyzeWithDB(app *parser.App, db *database.DB) []Diagnostic {
+	diags := Analyze(app)
+	if db == nil {
+		return diags
+	}
+	return append(diags, checkDynamicFieldRefsWithDB(app, db)...)
+}
+
+// checkDynamicFieldRefsWithDB queries each _<model>_field_defs table and
+// validates hardcoded {q.custom.X} references against the actual field names.
+func checkDynamicFieldRefsWithDB(app *parser.App, db *database.DB) []Diagnostic {
+	// Build map of modelName -> known field names from DB + static manifests.
+	knownFields := make(map[string]map[string]bool)
+	for _, m := range app.Models {
+		if !m.DynamicFields {
+			continue
+		}
+		table := "_" + m.Name + "_field_defs"
+		rows, err := db.QueryRows(fmt.Sprintf(`SELECT "name" FROM "%s"`, table))
+		if err != nil {
+			// Table may not exist; skip this model.
+			continue
+		}
+		names := make(map[string]bool)
+		for _, row := range rows {
+			if n := row["name"]; n != "" {
+				names[n] = true
+			}
+		}
+		// Static manifest fields shadow DB rows; include them as known.
+		if manifest, ok := app.CustomManifests[m.Name]; ok {
+			for _, f := range manifest.Fields {
+				names[f.Name] = true
+			}
+		}
+		knownFields[m.Name] = names
+	}
+	if len(knownFields) == 0 {
+		return nil
+	}
+
+	qMap := queryModelMap(app.Pages, app.Fragments, app.APIs)
+	var diags []Diagnostic
+
+	scanHTML := func(htmlContent, context string) {
+		for _, match := range customFieldRefRe.FindAllStringSubmatch(htmlContent, -1) {
+			queryName, fieldName := match[1], match[2]
+			modelName, ok := qMap[queryName]
+			if !ok {
+				continue
+			}
+			fields, ok := knownFields[modelName]
+			if !ok {
+				continue
+			}
+			if !fields[fieldName] {
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("template reference '{%s.custom.%s}': field '%s' not found in _field_defs for model '%s'", queryName, fieldName, fieldName, modelName),
+					Context: context,
+				})
+			}
+		}
+	}
+
+	scanNodes := func(nodes []parser.Node, context string) {
+		for _, n := range nodes {
+			if n.Type == parser.NodeHTML {
+				scanHTML(n.HTMLContent, context)
+			}
+		}
+	}
+
+	for _, p := range app.Pages {
+		scanNodes(p.Body, fmt.Sprintf("page %s", p.Path))
+	}
+	for _, f := range app.Fragments {
+		scanNodes(f.Body, fmt.Sprintf("fragment %s", f.Path))
+	}
+	for _, a := range app.APIs {
+		scanNodes(a.Body, fmt.Sprintf("api %s", a.Path))
+	}
+
+	return diags
+}

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -667,11 +667,21 @@ func checkTableColumnRefs(app *parser.App, schema *Schema) []Diagnostic {
 // customFieldRefRe matches {queryName.custom.fieldName} in HTML content.
 var customFieldRefRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\.custom\.([a-zA-Z_][a-zA-Z0-9_]*)\}`)
 
-// isDynamicManifest reports whether a model uses a dynamic manifest path.
+// isDynamicManifest reports whether a model uses a dynamic manifest path or dynamic DB fields.
 func isDynamicManifest(app *parser.App, modelName string) bool {
 	for _, m := range app.Models {
 		if m.Name == modelName {
-			return strings.Contains(m.CustomFieldsFile, "{")
+			return m.DynamicFields || strings.Contains(m.CustomFieldsFile, "{")
+		}
+	}
+	return false
+}
+
+// isDBDynamic reports whether a model opts into DB-backed runtime field definitions.
+func isDBDynamic(app *parser.App, modelName string) bool {
+	for _, m := range app.Models {
+		if m.Name == modelName {
+			return m.DynamicFields
 		}
 	}
 	return false
@@ -680,7 +690,14 @@ func isDynamicManifest(app *parser.App, modelName string) bool {
 // checkCustomFieldRefs validates {q.custom.fieldName} template references
 // against the corresponding model's custom field manifest.
 func checkCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
-	if len(app.CustomManifests) == 0 {
+	hasDynamic := false
+	for _, m := range app.Models {
+		if m.DynamicFields {
+			hasDynamic = true
+			break
+		}
+	}
+	if len(app.CustomManifests) == 0 && !hasDynamic {
 		return nil
 	}
 
@@ -699,8 +716,14 @@ func checkCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
 				continue // unknown query already reported by checkTemplateInterpolations
 			}
 
-			// Skip validation for models with dynamic manifest paths
 			if isDynamicManifest(app, modelName) {
+				if isDBDynamic(app, modelName) {
+					diags = append(diags, Diagnostic{
+						Level:   "warning",
+						Message: fmt.Sprintf("template reference '{%s.custom.%s}': field '%s' unverifiable at compile time — use kilnx check --db to validate", queryName, fieldName, fieldName),
+						Context: context,
+					})
+				}
 				continue
 			}
 			manifest, ok := app.CustomManifests[modelName]
@@ -763,7 +786,14 @@ var customShorthandAnalyzerRe = regexp.MustCompile(`\bcustom\.([a-zA-Z_][a-zA-Z0
 // checkSQLCustomFieldRefs validates json_extract(custom, '$.field') and
 // custom->>'field' patterns in SQL query nodes against the custom field manifest.
 func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
-	if len(app.CustomManifests) == 0 {
+	hasDynamic := false
+	for _, m := range app.Models {
+		if m.DynamicFields {
+			hasDynamic = true
+			break
+		}
+	}
+	if len(app.CustomManifests) == 0 && !hasDynamic {
 		return nil
 	}
 
@@ -774,8 +804,25 @@ func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic {
 			if n.Type != parser.NodeQuery || n.SQL == "" || n.SourceModel == "" {
 				continue
 			}
-			// Skip validation for models with dynamic manifest paths
 			if isDynamicManifest(app, n.SourceModel) {
+				if isDBDynamic(app, n.SourceModel) {
+					checkDynamic := func(fieldName string) {
+						diags = append(diags, Diagnostic{
+							Level:   "warning",
+							Message: fmt.Sprintf("SQL references custom field '%s' (model '%s'): unverifiable at compile time — use kilnx check --db to validate", fieldName, n.SourceModel),
+							Context: context,
+						})
+					}
+					for _, m := range jsonExtractSQLiteRe.FindAllStringSubmatch(n.SQL, -1) {
+						checkDynamic(m[1])
+					}
+					for _, m := range jsonExtractPGRe.FindAllStringSubmatch(n.SQL, -1) {
+						checkDynamic(m[1])
+					}
+					for _, m := range customShorthandAnalyzerRe.FindAllStringSubmatch(n.SQL, -1) {
+						checkDynamic(m[1])
+					}
+				}
 				continue
 			}
 			manifest, ok := app.CustomManifests[n.SourceModel]

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -137,6 +137,11 @@ func (db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*pars
 			}
 			stmts = append(stmts, alterStmts...)
 		}
+
+		if model.DynamicFields {
+			isPostgres := db.dialect.DriverName() == "pgx"
+			stmts = append(stmts, fieldDefsTableDDL(model.Name, isPostgres))
+		}
 	}
 
 	return stmts, nil
@@ -212,6 +217,9 @@ func schemaHash(models []parser.Model) string {
 	var b strings.Builder
 	for _, m := range models {
 		fmt.Fprintf(&b, "model:%s\n", m.Name)
+		if m.DynamicFields {
+			b.WriteString("  dynamic_fields:true\n")
+		}
 		for _, f := range m.Fields {
 			fmt.Fprintf(&b, "  %s:%s", f.Name, f.Type)
 			if f.Required {
@@ -263,7 +271,7 @@ func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.Custom
 		stmts = append(stmts, stmt)
 	}
 
-	if model.CustomFieldsFile != "" {
+	if model.CustomFieldsFile != "" || model.DynamicFields {
 		if _, ok := existing["custom"]; !ok {
 			colType := "TEXT"
 			if db.dialect.DriverName() == "pgx" {
@@ -328,7 +336,7 @@ func (db *DB) generateCreateTable(model parser.Model, cm map[string]*parser.Cust
 		cols = append(cols, col)
 	}
 
-	if model.CustomFieldsFile != "" {
+	if model.CustomFieldsFile != "" || model.DynamicFields {
 		if db.dialect.DriverName() == "pgx" {
 			cols = append(cols, `"custom" JSONB`)
 		} else {
@@ -375,6 +383,31 @@ func customKindToSQL(kind parser.CustomFieldKind, isPostgres bool) string {
 	default:
 		return "TEXT"
 	}
+}
+
+// fieldDefsTableDDL returns the CREATE TABLE IF NOT EXISTS for _<model>_field_defs.
+func fieldDefsTableDDL(modelName string, isPostgres bool) string {
+	pkDef := "id INTEGER PRIMARY KEY AUTOINCREMENT"
+	boolType := "INTEGER"
+	boolDefault := "DEFAULT 0"
+	if isPostgres {
+		pkDef = "id BIGSERIAL PRIMARY KEY"
+		boolType = "BOOLEAN"
+		boolDefault = "DEFAULT FALSE"
+	}
+	return fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS \"_%s_field_defs\" (\n"+
+			"  %s,\n"+
+			"  \"name\" TEXT NOT NULL,\n"+
+			"  \"kind\" TEXT NOT NULL,\n"+
+			"  \"label\" TEXT NOT NULL,\n"+
+			"  \"required\" %s NOT NULL %s,\n"+
+			"  \"options\" TEXT,\n"+
+			"  \"reference_model\" TEXT,\n"+
+			"  \"tenant_id\" TEXT,\n"+
+			"  \"sort_order\" INTEGER DEFAULT 0\n"+
+			")",
+		modelName, pkDef, boolType, boolDefault)
 }
 
 func (db *DB) fieldToColumnDef(f parser.Field) string {
@@ -431,4 +464,9 @@ func (db *DB) MigrateInternal() error {
 
 func isValidIdentifier(name string) bool {
 	return identifierRe.MatchString(name)
+}
+
+// IsValidIdentifier reports whether name is a safe SQL identifier.
+func IsValidIdentifier(name string) bool {
+	return isValidIdentifier(name)
 }

--- a/internal/database/dynamic_fields_test.go
+++ b/internal/database/dynamic_fields_test.go
@@ -1,0 +1,90 @@
+package database
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+func TestFieldDefsTableDDL_SQLite(t *testing.T) {
+	ddl := fieldDefsTableDDL("deal", false)
+	if !strings.Contains(ddl, `"_deal_field_defs"`) {
+		t.Error("DDL missing _deal_field_defs table name")
+	}
+	if !strings.Contains(ddl, "AUTOINCREMENT") {
+		t.Error("DDL missing AUTOINCREMENT for SQLite")
+	}
+	if !strings.Contains(ddl, "INTEGER NOT NULL DEFAULT 0") {
+		t.Error("DDL missing INTEGER required column for SQLite")
+	}
+	if !strings.Contains(ddl, "IF NOT EXISTS") {
+		t.Error("DDL must be CREATE TABLE IF NOT EXISTS")
+	}
+}
+
+func TestFieldDefsTableDDL_Postgres(t *testing.T) {
+	ddl := fieldDefsTableDDL("deal", true)
+	if !strings.Contains(ddl, "BIGSERIAL") {
+		t.Error("DDL missing BIGSERIAL for PostgreSQL")
+	}
+	if !strings.Contains(ddl, "BOOLEAN NOT NULL DEFAULT FALSE") {
+		t.Error("DDL missing BOOLEAN required column for PostgreSQL")
+	}
+}
+
+func TestMigrate_DynamicFields_CreatesFieldDefsTable(t *testing.T) {
+	db, err := Open("sqlite://")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	models := []parser.Model{
+		{Name: "deal", DynamicFields: true, Fields: []parser.Field{
+			{Name: "name", Type: parser.FieldText, Required: true},
+		}},
+	}
+
+	stmts, err := db.PlanMigration(models)
+	if err != nil {
+		t.Fatalf("PlanMigration: %v", err)
+	}
+
+	hasFieldDefs := false
+	hasCustomCol := false
+	for _, s := range stmts {
+		if strings.Contains(s, "_deal_field_defs") {
+			hasFieldDefs = true
+		}
+		if strings.Contains(s, `"custom"`) {
+			hasCustomCol = true
+		}
+	}
+	if !hasFieldDefs {
+		t.Error("expected _deal_field_defs CREATE TABLE in migration plan")
+	}
+	if !hasCustomCol {
+		t.Error("expected custom column in deal table")
+	}
+
+	// Apply and verify idempotency
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	// Second migrate must not error
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("Migrate second run: %v", err)
+	}
+}
+
+func TestSchemaHash_DynamicFields(t *testing.T) {
+	m1 := []parser.Model{{Name: "deal", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}}}
+	m2 := []parser.Model{{Name: "deal", DynamicFields: true, Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}}}
+
+	h1 := schemaHash(m1)
+	h2 := schemaHash(m2)
+	if h1 == h2 {
+		t.Error("schema hash must differ when DynamicFields toggles")
+	}
+}

--- a/internal/parser/dynamic_fields_test.go
+++ b/internal/parser/dynamic_fields_test.go
@@ -1,0 +1,84 @@
+package parser
+
+import "testing"
+
+func TestModelDynamicFieldsDirective(t *testing.T) {
+	src := `
+config
+  database: "sqlite://app.db"
+  port: 8080
+  secret: "s"
+
+model deal
+  name: text required
+  dynamic fields
+`
+	app := parse(t, src)
+	if len(app.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(app.Models))
+	}
+	if !app.Models[0].DynamicFields {
+		t.Error("expected DynamicFields=true")
+	}
+}
+
+func TestModelDynamicFieldsWithStaticManifest(t *testing.T) {
+	src := `
+config
+  database: "sqlite://app.db"
+  port: 8080
+  secret: "s"
+
+model deal
+  name: text required
+  custom fields from "base.kilnx"
+  dynamic fields
+`
+	app := parse(t, src)
+	m := app.Models[0]
+	if !m.DynamicFields {
+		t.Error("expected DynamicFields=true")
+	}
+	if m.CustomFieldsFile != "base.kilnx" {
+		t.Errorf("expected CustomFieldsFile=base.kilnx, got %q", m.CustomFieldsFile)
+	}
+}
+
+func TestModelDynamicFieldsDuplicate(t *testing.T) {
+	src := `
+config
+  database: "sqlite://app.db"
+  port: 8080
+  secret: "s"
+
+model deal
+  name: text required
+  dynamic fields
+  dynamic fields
+`
+	_, err := parseAllowErrors(t, src)
+	if err == nil {
+		t.Fatal("expected parse error for duplicate dynamic fields directive")
+	}
+}
+
+func TestModelDynamicFieldNotDirective(t *testing.T) {
+	// A field literally named "dynamic" with type text must parse correctly.
+	src := `
+config
+  database: "sqlite://app.db"
+  port: 8080
+  secret: "s"
+
+model deal
+  dynamic: text required
+`
+	app := parse(t, src)
+	m := app.Models[0]
+	if m.DynamicFields {
+		t.Error("expected DynamicFields=false for regular field named 'dynamic'")
+	}
+	if len(m.Fields) != 1 || m.Fields[0].Name != "dynamic" {
+		t.Errorf("expected field named 'dynamic', got %+v", m.Fields)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -149,6 +149,7 @@ type Model struct {
 	Fields               []Field
 	CustomFieldsFile     string // path to *_fields.kilnx manifest (may contain {placeholder})
 	CustomFieldsFallback string // fallback manifest path used when dynamic file not found
+	DynamicFields        bool   // opts model into DB-backed runtime field definitions
 }
 
 // CustomFieldKind is the type of a runtime-extensible custom field.
@@ -603,6 +604,21 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 			continue
 		}
 
+		// dynamic fields — opts model into DB-backed runtime field definitions.
+		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) &&
+			tok.Value == "dynamic" && p.peekIsDynamicFieldsDirective() {
+			if model.DynamicFields {
+				return model, fmt.Errorf("line %d: model '%s' already has a dynamic fields directive", tok.Line, model.Name)
+			}
+			p.advance() // consume "dynamic"
+			p.advance() // consume "fields"
+			for !p.isEOF() && p.current().Type != lexer.TokenNewline && p.current().Type != lexer.TokenDedent {
+				p.advance()
+			}
+			model.DynamicFields = true
+			continue
+		}
+
 		// tenant: <model> is a model-level meta directive, not a field.
 		// Must appear before any field declaration.
 		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) &&
@@ -676,6 +692,16 @@ func (p *parserState) parseTenantDirective() (string, error) {
 		p.advance()
 	}
 	return name, nil
+}
+
+// peekIsDynamicFieldsDirective returns true when the next token is `fields`,
+// distinguishing `dynamic fields` from a regular field named `dynamic`.
+func (p *parserState) peekIsDynamicFieldsDirective() bool {
+	if p.pos+1 >= len(p.tokens) {
+		return false
+	}
+	t1 := p.tokens[p.pos+1]
+	return t1.Type == lexer.TokenIdentifier && t1.Value == "fields"
 }
 
 // peekIsCustomFieldsDirective returns true when the next tokens form

--- a/internal/runtime/dynamic_fields.go
+++ b/internal/runtime/dynamic_fields.go
@@ -1,0 +1,77 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/kilnx-org/kilnx/internal/database"
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+var fieldDefsTableRe = regexp.MustCompile(`(?i)\b_([a-zA-Z_][a-zA-Z0-9_]*)_field_defs\b`)
+
+// mergeDBFieldDefs queries _<model>_field_defs and merges rows into base.
+// Static fields always win on name collision.
+func (s *Server) mergeDBFieldDefs(modelName string, base *parser.CustomFieldManifest) *parser.CustomFieldManifest {
+	merged := &parser.CustomFieldManifest{ModelName: modelName}
+	staticNames := make(map[string]bool, len(base.Fields))
+	for _, f := range base.Fields {
+		merged.Fields = append(merged.Fields, f)
+		staticNames[f.Name] = true
+	}
+
+	sql := fmt.Sprintf(
+		`SELECT "name","kind","label","required","options","reference_model" FROM "_%s_field_defs" ORDER BY "sort_order","id"`,
+		modelName)
+	rows, err := s.db.QueryRows(sql)
+	if err != nil {
+		// Table may not exist yet (migration not run); degrade gracefully.
+		return base
+	}
+
+	for _, row := range rows {
+		name := row["name"]
+		if name == "" || staticNames[name] || !database.IsValidIdentifier(name) {
+			continue
+		}
+		def := parser.CustomFieldDef{
+			Name:      name,
+			Kind:      parser.CustomFieldKind(row["kind"]),
+			Label:     row["label"],
+			Required:  row["required"] == "1" || row["required"] == "true",
+			Reference: row["reference_model"],
+		}
+		if optJSON := row["options"]; optJSON != "" {
+			var opts []string
+			if json.Unmarshal([]byte(optJSON), &opts) == nil {
+				def.Options = opts
+			}
+		}
+		merged.Fields = append(merged.Fields, def)
+		staticNames[name] = true
+	}
+	return merged
+}
+
+// invalidateDynamicManifestCache clears the manifest cache entry when a
+// mutation targets a _<model>_field_defs table.
+func (s *Server) invalidateDynamicManifestCache(sql string) {
+	if m := fieldDefsTableRe.FindStringSubmatch(sql); len(m) > 1 {
+		s.manifestCache.Delete("__dynamic__:" + m[1])
+	}
+}
+
+// modelHasCustomFields reports whether a model has any custom field support
+// (static manifest or dynamic fields).
+func (s *Server) modelHasCustomFields(app *parser.App, modelName string) bool {
+	if _, ok := app.CustomManifests[modelName]; ok {
+		return true
+	}
+	for _, m := range app.Models {
+		if m.Name == modelName {
+			return m.DynamicFields
+		}
+	}
+	return false
+}

--- a/internal/runtime/dynamic_fields_test.go
+++ b/internal/runtime/dynamic_fields_test.go
@@ -1,0 +1,180 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/database"
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+func newTestServerWithDB(t *testing.T) *Server {
+	t.Helper()
+	db, err := database.Open("sqlite://")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	s := &Server{db: db}
+	return s
+}
+
+func TestMergeDBFieldDefs_EmptyTable(t *testing.T) {
+	s := newTestServerWithDB(t)
+
+	// Create the _deal_field_defs table.
+	_, err := s.db.Conn().Exec(`CREATE TABLE "_deal_field_defs" (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		"name" TEXT NOT NULL, "kind" TEXT NOT NULL, "label" TEXT NOT NULL,
+		"required" INTEGER NOT NULL DEFAULT 0, "options" TEXT,
+		"reference_model" TEXT, "tenant_id" TEXT, "sort_order" INTEGER DEFAULT 0)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	base := &parser.CustomFieldManifest{ModelName: "deal", Fields: []parser.CustomFieldDef{
+		{Name: "revenue", Kind: parser.CustomFieldKindNumber, Label: "Revenue"},
+	}}
+	merged := s.mergeDBFieldDefs("deal", base)
+
+	if len(merged.Fields) != 1 {
+		t.Errorf("expected 1 field (from base), got %d", len(merged.Fields))
+	}
+	if merged.Fields[0].Name != "revenue" {
+		t.Errorf("expected field 'revenue', got %q", merged.Fields[0].Name)
+	}
+}
+
+func TestMergeDBFieldDefs_MergesRows(t *testing.T) {
+	s := newTestServerWithDB(t)
+
+	_, err := s.db.Conn().Exec(`CREATE TABLE "_deal_field_defs" (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		"name" TEXT NOT NULL, "kind" TEXT NOT NULL, "label" TEXT NOT NULL,
+		"required" INTEGER NOT NULL DEFAULT 0, "options" TEXT,
+		"reference_model" TEXT, "tenant_id" TEXT, "sort_order" INTEGER DEFAULT 0)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	_, err = s.db.Conn().Exec(`INSERT INTO "_deal_field_defs" (name,kind,label) VALUES ('panel_brand','text','Panel Brand')`)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	base := &parser.CustomFieldManifest{ModelName: "deal"}
+	merged := s.mergeDBFieldDefs("deal", base)
+
+	if len(merged.Fields) != 1 {
+		t.Fatalf("expected 1 merged field, got %d", len(merged.Fields))
+	}
+	f := merged.Fields[0]
+	if f.Name != "panel_brand" || f.Label != "Panel Brand" || f.Kind != parser.CustomFieldKindText {
+		t.Errorf("unexpected field: %+v", f)
+	}
+}
+
+func TestMergeDBFieldDefs_StaticFieldWins(t *testing.T) {
+	s := newTestServerWithDB(t)
+
+	_, err := s.db.Conn().Exec(`CREATE TABLE "_deal_field_defs" (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		"name" TEXT NOT NULL, "kind" TEXT NOT NULL, "label" TEXT NOT NULL,
+		"required" INTEGER NOT NULL DEFAULT 0, "options" TEXT,
+		"reference_model" TEXT, "tenant_id" TEXT, "sort_order" INTEGER DEFAULT 0)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	// Same name as a static field — must be skipped.
+	_, err = s.db.Conn().Exec(`INSERT INTO "_deal_field_defs" (name,kind,label) VALUES ('revenue','text','Override Attempt')`)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	base := &parser.CustomFieldManifest{ModelName: "deal", Fields: []parser.CustomFieldDef{
+		{Name: "revenue", Kind: parser.CustomFieldKindNumber, Label: "Revenue"},
+	}}
+	merged := s.mergeDBFieldDefs("deal", base)
+
+	if len(merged.Fields) != 1 {
+		t.Fatalf("expected 1 field, got %d", len(merged.Fields))
+	}
+	if merged.Fields[0].Kind != parser.CustomFieldKindNumber {
+		t.Error("static field must win over DB row with same name")
+	}
+}
+
+func TestMergeDBFieldDefs_InvalidIdentifierSkipped(t *testing.T) {
+	s := newTestServerWithDB(t)
+
+	_, err := s.db.Conn().Exec(`CREATE TABLE "_deal_field_defs" (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		"name" TEXT NOT NULL, "kind" TEXT NOT NULL, "label" TEXT NOT NULL,
+		"required" INTEGER NOT NULL DEFAULT 0, "options" TEXT,
+		"reference_model" TEXT, "tenant_id" TEXT, "sort_order" INTEGER DEFAULT 0)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	_, err = s.db.Conn().Exec(`INSERT INTO "_deal_field_defs" (name,kind,label) VALUES ('bad name!','text','Bad')`)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	base := &parser.CustomFieldManifest{ModelName: "deal"}
+	merged := s.mergeDBFieldDefs("deal", base)
+
+	if len(merged.Fields) != 0 {
+		t.Errorf("expected 0 fields (invalid name skipped), got %d", len(merged.Fields))
+	}
+}
+
+func TestMergeDBFieldDefs_TableMissing_GracefulDegrade(t *testing.T) {
+	s := newTestServerWithDB(t)
+	// Table does NOT exist.
+	base := &parser.CustomFieldManifest{ModelName: "deal", Fields: []parser.CustomFieldDef{
+		{Name: "revenue", Kind: parser.CustomFieldKindNumber},
+	}}
+	merged := s.mergeDBFieldDefs("deal", base)
+	if len(merged.Fields) != 1 || merged.Fields[0].Name != "revenue" {
+		t.Error("expected base manifest returned unchanged when table missing")
+	}
+}
+
+func TestInvalidateDynamicManifestCache(t *testing.T) {
+	s := &Server{}
+	s.manifestCache.Store("__dynamic__:deal", &parser.CustomFieldManifest{ModelName: "deal"})
+
+	// SQL that targets _deal_field_defs should invalidate.
+	s.invalidateDynamicManifestCache(`INSERT INTO "_deal_field_defs" (name,kind,label) VALUES (?,?,?)`)
+	if _, ok := s.manifestCache.Load("__dynamic__:deal"); ok {
+		t.Error("cache entry must be deleted after invalidation")
+	}
+
+	// SQL not targeting _field_defs must be a no-op.
+	s.manifestCache.Store("__dynamic__:deal", &parser.CustomFieldManifest{ModelName: "deal"})
+	s.invalidateDynamicManifestCache(`INSERT INTO "deal" (name) VALUES (?)`)
+	if _, ok := s.manifestCache.Load("__dynamic__:deal"); !ok {
+		t.Error("cache entry must not be deleted for unrelated SQL")
+	}
+}
+
+func TestModelHasCustomFields(t *testing.T) {
+	s := &Server{}
+	app := &parser.App{
+		Models: []parser.Model{
+			{Name: "deal", DynamicFields: true},
+			{Name: "user"},
+		},
+		CustomManifests: map[string]*parser.CustomFieldManifest{
+			"user": {ModelName: "user"},
+		},
+	}
+
+	if !s.modelHasCustomFields(app, "deal") {
+		t.Error("deal has DynamicFields=true — must return true")
+	}
+	if !s.modelHasCustomFields(app, "user") {
+		t.Error("user has manifest — must return true")
+	}
+	if s.modelHasCustomFields(app, "other") {
+		t.Error("other has no custom fields — must return false")
+	}
+}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -368,7 +368,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 			continue
 		}
 		if node.SourceModel != "" {
-			if _, hasCustom := app.CustomManifests[node.SourceModel]; hasCustom {
+			if s.modelHasCustomFields(app, node.SourceModel) {
 				sql = database.RewriteCustomFieldShorthand(sql, s.db.Dialect().DriverName() == "pgx")
 			}
 		}
@@ -993,6 +993,7 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 					}
 					lastQueryOk = true
 					lastQueryNotFound = false
+					s.invalidateDynamicManifestCache(sql)
 				}
 			}
 
@@ -1544,48 +1545,58 @@ var tenantPlaceholderRe = regexp.MustCompile(`\{[^}]+\}`)
 // resolveManifest returns the custom field manifest for a model, resolving dynamic
 // paths at request time. Results are cached per resolved path.
 func (s *Server) resolveManifest(model *parser.Model, app *parser.App, session *Session, pathParams map[string]string, r *http.Request) *parser.CustomFieldManifest {
-	if model.CustomFieldsFile == "" {
+	if model.CustomFieldsFile == "" && !model.DynamicFields {
 		return nil
 	}
-	if !strings.Contains(model.CustomFieldsFile, "{") {
-		// Static path: already loaded into app.CustomManifests at startup
-		if m, ok := app.CustomManifests[model.Name]; ok {
-			return m
-		}
-		return nil
-	}
-	// Dynamic path: resolve placeholder and load on demand
-	resolved := resolveTenantPlaceholder(model.CustomFieldsFile, session, pathParams, r)
-	if resolved == "" || strings.Contains(resolved, "{") {
-		// Placeholder couldn't be resolved; fall back to static manifest
-		if m, ok := app.CustomManifests[model.Name]; ok {
-			return m
-		}
-		return nil
-	}
-	// Sanitize: must end in .kilnx, no path traversal
-	if !strings.HasSuffix(resolved, ".kilnx") || strings.Contains(resolved, "..") {
-		return nil
-	}
-	if cached, ok := s.manifestCache.Load(resolved); ok {
-		return cached.(*parser.CustomFieldManifest)
-	}
-	raw, err := os.ReadFile(resolved)
-	if err != nil {
-		// File not found — try fallback
-		if model.CustomFieldsFallback != "" && !strings.Contains(model.CustomFieldsFallback, "{") {
-			if m, ok := app.CustomManifests[model.Name]; ok {
-				return m // fallback was loaded at startup
+
+	// Resolve the static file portion (may be nil for dynamic-only models).
+	var base *parser.CustomFieldManifest
+	if model.CustomFieldsFile != "" {
+		if !strings.Contains(model.CustomFieldsFile, "{") {
+			// Static path: already loaded into app.CustomManifests at startup
+			base, _ = app.CustomManifests[model.Name]
+		} else {
+			// Dynamic path: resolve placeholder and load on demand
+			resolved := resolveTenantPlaceholder(model.CustomFieldsFile, session, pathParams, r)
+			if resolved == "" || strings.Contains(resolved, "{") {
+				// Placeholder couldn't be resolved; fall back to static manifest
+				base, _ = app.CustomManifests[model.Name]
+			} else if strings.HasSuffix(resolved, ".kilnx") && !strings.Contains(resolved, "..") {
+				if cached, ok := s.manifestCache.Load(resolved); ok {
+					base = cached.(*parser.CustomFieldManifest)
+				} else {
+					raw, err := os.ReadFile(resolved)
+					if err != nil {
+						if model.CustomFieldsFallback != "" && !strings.Contains(model.CustomFieldsFallback, "{") {
+							base, _ = app.CustomManifests[model.Name]
+						}
+					} else {
+						m, err := parser.ParseManifest(string(raw), model.Name)
+						if err == nil {
+							s.manifestCache.Store(resolved, m)
+							base = m
+						}
+					}
+				}
 			}
 		}
-		return nil
 	}
-	m, err := parser.ParseManifest(string(raw), model.Name)
-	if err != nil {
-		return nil
+
+	if !model.DynamicFields || s.db == nil {
+		return base
 	}
-	s.manifestCache.Store(resolved, m)
-	return m
+
+	// Merge DB-backed field definitions.
+	cacheKey := "__dynamic__:" + model.Name
+	if cached, ok := s.manifestCache.Load(cacheKey); ok {
+		return cached.(*parser.CustomFieldManifest)
+	}
+	if base == nil {
+		base = &parser.CustomFieldManifest{ModelName: model.Name}
+	}
+	merged := s.mergeDBFieldDefs(model.Name, base)
+	s.manifestCache.Store(cacheKey, merged)
+	return merged
 }
 
 // buildCustomIterRows creates synthetic rows for {{each q.custom}} iteration.


### PR DESCRIPTION
## Summary

- Adds `dynamic fields` directive to `model` blocks — opts a model into DB-backed runtime field definitions
- Runtime auto-creates `_<model>_field_defs` table on migrate; merges file manifest + DB rows per request
- `kilnx check` warns (not errors) for `{q.custom.X}` on dynamic models; `--db <url>` flag validates against live DB
- Dev writes field management UI using normal `page`/`action`/`fragment` — no generated UI, no new primitives

## Test plan

- [ ] `go test -race ./...` — all tests pass (parser, database, runtime, analyzer)
- [ ] `kilnx run` with `dynamic fields` model starts without error; `_field_defs` table created
- [ ] INSERT into `_deal_field_defs` clears `manifestCache`; new field appears on next request without restart
- [ ] `kilnx check` emits warning for hardcoded `{q.custom.X}` on dynamic model, not error
- [ ] `kilnx check --db sqlite://app.db` validates field names against actual DB rows
- [ ] Static manifest + `dynamic fields` coexist; static field wins on name collision