### PR TITLE
feat: docs site at docs.kilnx.org (static HTML, GitHub Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "GRAMMAR.md"
+      - "PRINCIPLES.md"
+      - "CHANGELOG.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
+      - name: Build site
+        working-directory: docs
+        run: ./build.sh
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/pages
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 *.db-shm
 .claude/worktrees/
 cmd/benchmark
+
+# Docs site generated output
+docs/pages/
+docs/content/reference/grammar.md
+docs/content/principles.md
+docs/content/changelog.md

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.kilnx.org

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,46 @@
+# Kilnx documentation site
+
+Source for [docs.kilnx.org](https://docs.kilnx.org). Static HTML generated from markdown via pandoc. Deployed to GitHub Pages.
+
+## Structure
+
+```
+docs/
+├── CNAME                  # docs.kilnx.org
+├── index.html             # docs landing (generated from content/index.md)
+├── template.html          # pandoc HTML template (shell)
+├── build.sh               # markdown → html build script
+├── assets/
+│   └── style.css          # hand-written, no framework
+├── content/               # source markdown (edit these)
+│   ├── index.md
+│   ├── getting-started.md
+│   ├── guides/
+│   ├── reference/         # includes synced copies of GRAMMAR.md etc.
+│   └── tutorials/
+└── pages/                 # generated html (gitignored; built by CI)
+```
+
+## Building locally
+
+```bash
+cd docs
+./build.sh
+```
+
+Requires `pandoc` (macOS: `brew install pandoc`; Debian/Ubuntu: `apt install pandoc`).
+
+Open `index.html` in a browser or serve with `python3 -m http.server`.
+
+## Content rules
+
+- **Edit `content/*.md`** — the source of truth for everything except `reference/grammar.md`, `principles.md`, `changelog.md`. Those three are synced from the repo root (`GRAMMAR.md`, `PRINCIPLES.md`, `CHANGELOG.md`) by `build.sh`. Edit them in the repo root, not here.
+- **No frontmatter required.** The first `# heading` becomes the page title.
+- **Keep examples runnable.** Code blocks should copy-paste cleanly into an `app.kilnx` file.
+- **Prefer tables for reference material.** Prose for guides, tables for spec.
+
+## Deployment
+
+GitHub Actions (`.github/workflows/docs.yml`) builds on push to `main` when `docs/content/**` or canonical sources (`GRAMMAR.md`, `PRINCIPLES.md`, `CHANGELOG.md`) change, then deploys the built site to GitHub Pages.
+
+The `pages/` directory is generated, not committed. GitHub Pages reads the generated artifact directly from the Action.

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,251 @@
+:root {
+  --fg: #111;
+  --fg-muted: #555;
+  --bg: #fff;
+  --bg-code: #f4f4f4;
+  --bg-sidebar: #fafafa;
+  --border: #e5e5e5;
+  --accent: #b53f2a;
+  --accent-bg: #fff1ed;
+  --max-width: 1200px;
+  --sidebar-width: 260px;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --fg: #e8e8e8;
+    --fg-muted: #999;
+    --bg: #181818;
+    --bg-code: #242424;
+    --bg-sidebar: #1f1f1f;
+    --border: #2e2e2e;
+    --accent: #ff6b4a;
+    --accent-bg: #2a1814;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover { text-decoration: underline; }
+
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.site-header {
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: var(--fg);
+}
+
+.main-nav a {
+  margin-left: 1.5rem;
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+}
+
+.main-nav a.active,
+.main-nav a:hover { color: var(--accent); }
+
+.layout {
+  display: grid;
+  grid-template-columns: var(--sidebar-width) 1fr;
+  gap: 3rem;
+  padding-top: 2rem;
+  padding-bottom: 4rem;
+}
+
+.sidebar {
+  font-size: 0.9rem;
+  border-right: 1px solid var(--border);
+  padding-right: 1.5rem;
+}
+
+.sidebar h3 {
+  margin: 1.5rem 0 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+}
+
+.sidebar h3:first-child { margin-top: 0; }
+
+.sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar li { margin: 0.25rem 0; }
+
+.sidebar a {
+  color: var(--fg);
+  display: block;
+  padding: 0.25rem 0;
+}
+
+.sidebar a:hover,
+.sidebar a.active {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.content {
+  max-width: 760px;
+  min-width: 0;
+}
+
+.content h1 {
+  font-size: 2.25rem;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  line-height: 1.2;
+}
+
+.content h2 {
+  font-size: 1.5rem;
+  margin-top: 2.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.content h3 {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+}
+
+.content p { margin: 1rem 0; }
+
+.content code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+  background: var(--bg-code);
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+}
+
+.content pre {
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.content pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
+.content blockquote {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-bg);
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  color: var(--fg);
+}
+
+.content blockquote p { margin: 0.25rem 0; }
+
+.content ul, .content ol { padding-left: 1.5rem; }
+.content li { margin: 0.25rem 0; }
+
+.content table {
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.9rem;
+  width: 100%;
+}
+
+.content th, .content td {
+  border: 1px solid var(--border);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.content th { background: var(--bg-sidebar); }
+
+.content hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2.5rem 0;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 2rem 0;
+  font-size: 0.9rem;
+  color: var(--fg-muted);
+}
+
+/* Index page cards */
+.toc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin: 2rem 0;
+}
+
+.toc-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.25rem;
+}
+
+.toc-card h3 { margin-top: 0; }
+
+.toc-card ul { padding-left: 1.25rem; }
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding-right: 0;
+    padding-bottom: 1rem;
+  }
+}

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# build.sh — convert docs/content/**.md to docs/pages/**.html using pandoc
+#
+# Usage:
+#   ./build.sh             # build everything
+#   ./build.sh --clean     # remove pages/ before building
+#
+# Sources: content/**.md + canonical files sync'd from repo root
+# Output:  pages/**.html using template.html
+#
+# The generated pages/ directory is committed so GitHub Pages can serve
+# docs/ directly without a build step at deploy time.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$ROOT/.." && pwd)"
+CONTENT="$ROOT/content"
+PAGES="$ROOT/pages"
+TEMPLATE="$ROOT/template.html"
+
+if ! command -v pandoc >/dev/null; then
+  echo "error: pandoc not installed" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "--clean" ]]; then
+  rm -rf "$PAGES"
+fi
+
+mkdir -p "$PAGES"
+
+# Sync canonical sources from repo root into content/ with stable names.
+# These files are auto-generated — edits belong in the repo root, not here.
+sync_canonical() {
+  local src="$1" dest="$2" title="$3"
+  if [[ -f "$REPO/$src" ]]; then
+    {
+      echo "---"
+      echo "title: $title"
+      echo "canonical: true"
+      echo "---"
+      echo ""
+      cat "$REPO/$src"
+    } > "$CONTENT/$dest"
+  fi
+}
+
+sync_canonical "GRAMMAR.md"    "reference/grammar.md" "Grammar reference"
+sync_canonical "PRINCIPLES.md" "principles.md"        "Design principles"
+sync_canonical "CHANGELOG.md"  "changelog.md"         "Changelog"
+
+# Convert a markdown file to HTML via pandoc.
+build_page() {
+  local md="$1"
+  local rel="${md#$CONTENT/}"                    # e.g. guides/models.md
+  local out="$PAGES/${rel%.md}.html"             # pages/guides/models.html
+  local depth
+  depth="$(tr -cd '/' <<<"$rel" | wc -c)"
+  local root=""
+  for ((i=0; i<depth; i++)); do root+="../"; done
+
+  # Extract title from first # heading (fallback to filename stem)
+  local title
+  title="$(grep -m1 '^# ' "$md" 2>/dev/null | sed 's/^# //' || true)"
+  if [[ -z "$title" ]]; then
+    title="$(basename "${rel%.md}" | tr '-' ' ')"
+  fi
+
+  mkdir -p "$(dirname "$out")"
+  pandoc "$md" \
+    --from=gfm \
+    --to=html5 \
+    --standalone \
+    --template="$TEMPLATE" \
+    --metadata=title:"$title" \
+    --metadata=description:"$title — Kilnx documentation" \
+    --metadata=canonical:"${rel%.md}.html" \
+    --variable=root:"$root" \
+    --output="$out"
+}
+
+# Find all markdown files under content/ and build each.
+find "$CONTENT" -name '*.md' -print0 | while IFS= read -r -d '' md; do
+  echo "  building ${md#$ROOT/}"
+  build_page "$md"
+done
+
+# Build pages/index.html as the site landing (content/index.md)
+if [[ -f "$CONTENT/index.md" ]]; then
+  pandoc "$CONTENT/index.md" \
+    --from=gfm \
+    --to=html5 \
+    --standalone \
+    --template="$TEMPLATE" \
+    --metadata=title:"Documentation" \
+    --metadata=description:"Kilnx — declarative backend language. Official documentation." \
+    --metadata=canonical:"" \
+    --variable=root:"" \
+    --output="$PAGES/index.html"
+  echo "  building pages/index.html"
+fi
+
+# Copy static assets into pages/ so the built site is self-contained
+cp -R "$ROOT/assets" "$PAGES/assets"
+
+# CNAME must live at the site root for GitHub Pages custom domains
+if [[ -f "$ROOT/CNAME" ]]; then
+  cp "$ROOT/CNAME" "$PAGES/CNAME"
+fi
+
+# 404 fallback (copy of index for client-side nav)
+cp "$PAGES/index.html" "$PAGES/404.html"
+
+echo "done → $PAGES"

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -1,0 +1,92 @@
+# Getting started
+
+Kilnx runs on Linux, macOS, and Windows. A single binary, no runtime.
+
+## Install
+
+### Homebrew (macOS, Linux)
+
+```bash
+brew tap kilnx-org/tap
+brew install kilnx
+```
+
+### Direct download
+
+Grab the latest release from [github.com/kilnx-org/kilnx/releases](https://github.com/kilnx-org/kilnx/releases), extract, and place `kilnx` on your `PATH`.
+
+### Verify
+
+```bash
+kilnx version
+```
+
+## Hello world
+
+Create `app.kilnx`:
+
+```kilnx
+page /
+  "Hello World"
+```
+
+Run it:
+
+```bash
+kilnx run app.kilnx
+```
+
+Open `http://localhost:8080`. Two useful lines. That's a web server.
+
+## A real app in 20 lines
+
+```kilnx
+config
+  database: env DATABASE_URL default "sqlite://app.db"
+
+model post
+  title: text required min 2 max 200
+  body: richtext required
+  created: timestamp auto
+
+page /
+  query posts: SELECT title, body, created FROM post
+               ORDER BY created DESC paginate 10
+  html
+    <h1>Blog</h1>
+    {{each posts}}
+      <article>
+        <h2>{title}</h2>
+        <time>{created | timeago}</time>
+        <div>{body | raw}</div>
+      </article>
+    {{end}}
+
+action /posts/create method POST
+  validate post
+  query: INSERT INTO post (title, body) VALUES (:title, :body)
+  redirect /
+```
+
+On first run, Kilnx auto-creates the SQLite database, runs migrations based on the `model` definitions, and serves the page. There is no separate migration step to run.
+
+## CLI essentials
+
+| Command | Purpose |
+|---------|---------|
+| `kilnx run <file>` | Dev server with hot reload |
+| `kilnx build <file> -o <binary>` | Compile to standalone binary |
+| `kilnx check <file>` | Static analysis (types, security, SQL) |
+| `kilnx test <file>` | Run declarative `test` blocks |
+| `kilnx migrate <file>` | Apply schema migrations (also runs automatically at `run`) |
+| `kilnx lsp` | Language Server Protocol endpoint for editors |
+| `kilnx mcp` | Model Context Protocol server for AI tools |
+
+See the full [CLI reference](reference/cli.html) for flags and options.
+
+## Next steps
+
+- [Models](guides/models.html) — field types, constraints, references
+- [Pages &amp; actions](guides/pages-actions.html) — routing, mutations, redirects
+- [Auth &amp; permissions](guides/auth-permissions.html) — register, login, roles
+- [Grammar reference](reference/grammar.html) — the complete syntax specification

--- a/docs/content/guides/auth-permissions.md
+++ b/docs/content/guides/auth-permissions.md
@@ -1,0 +1,105 @@
+# Auth &amp; permissions
+
+Kilnx ships with declarative auth and role-based permissions. No middleware, no passport, no session library.
+
+## Auth block
+
+```kilnx
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /dashboard
+```
+
+Six lines. You get:
+
+- `GET /login` — login form (auto-generated HTML)
+- `POST /login` — verifies credentials, creates session
+- `GET /register` — registration form
+- `POST /register` — creates user (password auto-hashed with bcrypt)
+- `POST /logout` — clears session (CSRF-protected)
+- Session cookie (HMAC-signed)
+- `current_user.id`, `current_user.name`, `current_user.email`, `current_user.role` available in every query and template
+
+## Protecting routes
+
+```kilnx
+page /dashboard requires auth
+  ...
+
+page /admin requires admin
+  ...
+
+action /posts/create method POST requires auth
+  ...
+```
+
+`requires auth` redirects unauthenticated users to the configured login path. `requires <role>` additionally checks the user&apos;s `role` column. Both work on pages, actions, APIs, streams, and sockets.
+
+## Password hashing
+
+Passwords are hashed with bcrypt (cost 10) on INSERT. The hash is never returned to templates. The `password` field type is recognized specifically and stripped from `SELECT *` results by the query optimizer.
+
+## Current user in queries
+
+```kilnx
+page /my/posts requires auth
+  query posts: SELECT title FROM post WHERE author_id = :current_user.id
+  html
+    {{each posts}}<div>{title}</div>{{end}}
+```
+
+Available fields: `id`, `identity`, any columns on the auth table.
+
+## Permissions (role-based)
+
+```kilnx
+permissions
+  admin: all
+  editor: read post, write post where author = current_user
+  viewer: read post where status = published
+```
+
+Each line declares what a role can read and/or write. Supports ownership checks (`where author = current_user`) and column predicates (`where status = published`).
+
+Kilnx rewrites queries at runtime based on the current user&apos;s role. A `viewer` hitting a page that queries `post` only sees published rows. No `WHERE` clause required in the SQL.
+
+## Session configuration
+
+```kilnx
+config
+  secret: env SECRET_KEY required
+  session: 7d                      # default 24h
+```
+
+Sessions are signed with HMAC-SHA256 using the `secret`. Rotating the secret invalidates all sessions. Set a strong, random `SECRET_KEY` in production.
+
+## Password reset
+
+```kilnx
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /dashboard
+  reset: /forgot
+```
+
+Adds `GET /forgot`, `POST /forgot` (sends reset email), `GET /reset/:token`, `POST /reset/:token`. Tokens expire after 1 hour.
+
+## What is NOT built in
+
+Kilnx does not ship OAuth, SSO, 2FA, or magic links. For those, write custom actions against the auth table. The declarative auth covers the 80% case (email + password + sessions) in six lines.
+
+## Security defaults
+
+CSRF protection, SQL injection binding, XSS escaping, and session HMAC are all built in. You have to work to disable them, not to enable them.
+
+- CSRF tokens embedded in every form, verified on every POST
+- SQL parameters bound via `:name` — never string-interpolated
+- Template output HTML-escaped by default. `{field | raw}` is explicit opt-out for trusted content.
+- Passwords never stored or transmitted plaintext
+- Session cookies are `HttpOnly`, `Secure` (in production), `SameSite=Lax`

--- a/docs/content/guides/deployment.md
+++ b/docs/content/guides/deployment.md
@@ -1,0 +1,59 @@
+# Deployment
+
+> This page is a stub. Full content coming soon.
+
+## Single binary
+
+`kilnx build` produces a standalone binary. No runtime, no dependencies, no container required.
+
+```bash
+kilnx build app.kilnx -o myapp
+scp myapp server:/opt/myapp/
+ssh server "cd /opt/myapp && ./myapp"
+```
+
+The binary is ~15MB and self-contained. SQLite database is created in the working directory (or wherever `config database:` points).
+
+## Environment variables
+
+Production secrets belong in env vars:
+
+```kilnx
+config
+  database: env DATABASE_URL required
+  secret: env SECRET_KEY required
+  port: env PORT default 8080
+```
+
+`env VAR required` fails fast if the variable is unset.
+
+## Railway
+
+Deploy via the [Railway template](https://railway.com/deploy/kilnx) — one click, zero config.
+
+## Docker
+
+A minimal Dockerfile:
+
+```dockerfile
+FROM debian:bookworm-slim
+COPY myapp /usr/local/bin/myapp
+EXPOSE 8080
+CMD ["myapp"]
+```
+
+The binary is already statically linked. No base image tools needed beyond libc.
+
+## PostgreSQL
+
+Change the database URL:
+
+```bash
+DATABASE_URL=postgres://user:pass@host:5432/dbname ./myapp
+```
+
+Kilnx detects `postgres://` or `postgresql://` schemes and switches to the pgx driver automatically. Migrations run against the target database.
+
+## Health checks
+
+Every Kilnx app serves `GET /_kilnx/health` returning 200 OK with the app version. Point your load balancer at it.

--- a/docs/content/guides/fragments-htmx.md
+++ b/docs/content/guides/fragments-htmx.md
@@ -1,0 +1,34 @@
+# Fragments &amp; htmx
+
+> This page is a stub. Full content coming soon. For now see [FEATURES.md &sect; Fragments](https://github.com/kilnx-org/kilnx/blob/main/FEATURES.md) and the [grammar reference](../reference/grammar.html).
+
+Fragments are partial HTML responses designed for htmx swaps. Not a full page — just a piece the browser inserts into the existing DOM.
+
+```kilnx
+fragment /users/:id/card
+  query user: SELECT name, email FROM user WHERE id = :id
+  html
+    <div class="card">
+      <strong>{user.name}</strong>
+      <span>{user.email}</span>
+    </div>
+```
+
+## Swap targets
+
+Actions can respond with a fragment to drive htmx swaps:
+
+```kilnx
+action /posts/:id/delete method POST requires auth
+  query: DELETE FROM post WHERE id = :id
+  respond fragment delete
+```
+
+`respond fragment delete` tells htmx to remove the target element. Also supports:
+
+- `respond fragment <selector>` — swap the matched element
+- `respond fragment <selector> query: <SQL>` — swap with fresh data
+
+## Layouts do not apply
+
+Fragments bypass `layout` blocks. Full HTML shell is pages-only.

--- a/docs/content/guides/jobs-schedules.md
+++ b/docs/content/guides/jobs-schedules.md
@@ -1,0 +1,40 @@
+# Jobs &amp; schedules
+
+> This page is a stub. Full content coming soon.
+
+## Jobs (async work)
+
+```kilnx
+job send-welcome
+  retry 3
+  query data: SELECT name, email FROM user WHERE id = :user_id
+  send email to :email
+    subject: "Welcome {data.name}"
+```
+
+Dispatch from an action:
+
+```kilnx
+action /users/create method POST
+  query: INSERT INTO user (name, email) VALUES (:name, :email)
+  enqueue send-welcome
+    user_id: :id
+  redirect /users
+```
+
+Jobs run in the same binary, persisted in `_kilnx_jobs` (SQLite or PostgreSQL). `retry N` configures automatic retries with exponential backoff.
+
+## Schedules (cron)
+
+```kilnx
+schedule cleanup every 24h
+  query: DELETE FROM session WHERE expires_at < datetime('now')
+
+schedule weekly-report every monday at 9:00
+  query stats: SELECT count(*) as new_users FROM user
+               WHERE created > datetime('now', '-7 days')
+  send email to "admin@example.com"
+    subject: "Weekly report: {stats.new_users} new users"
+```
+
+Supports intervals (`every 5m`, `every 24h`) and cron-style expressions (`every monday at 9:00`).

--- a/docs/content/guides/models.md
+++ b/docs/content/guides/models.md
@@ -1,0 +1,133 @@
+# Models
+
+A `model` block defines a data type. From one declaration, Kilnx generates: a database table, server-side validation, HTML form generation, client-side validation attributes, and a listing fragment.
+
+## Basic model
+
+```kilnx
+model user
+  name: text required min 2 max 100
+  email: email unique
+  role: option [admin, editor, viewer] default viewer
+  active: bool default true
+  created: timestamp auto
+```
+
+Every model automatically gets an `id` column (INTEGER PRIMARY KEY AUTOINCREMENT in SQLite, BIGSERIAL in PostgreSQL). You do not declare it.
+
+## Field types
+
+See the [complete field types reference](../reference/field-types.html). Summary:
+
+- **Text:** `text`, `email`, `richtext`, `url`, `phone`, `password`, `option`, `tags`
+- **Numeric:** `int`, `float`, `decimal`, `bigint`
+- **Boolean &amp; time:** `bool`, `timestamp`, `date`
+- **Structured:** `json`, `uuid`
+- **Files:** `image`, `file`
+- **Relations:** `reference` (or use another model name)
+
+## Constraints
+
+| Constraint | Meaning |
+|------------|---------|
+| `required` | Column is NOT NULL |
+| `unique` | Column has UNIQUE index |
+| `default <val>` | Default value for INSERT |
+| `auto` | Auto-generated on INSERT (for `timestamp`, `date`, `uuid`) |
+| `auto_update` | Auto-set on every UPDATE (DB trigger) |
+| `min <n>` | Minimum length (text) or value (numeric) |
+| `max <n>` | Maximum length (text) or value (numeric) |
+
+```kilnx
+model post
+  title: text required min 5 max 200
+  views: int default 0 min 0
+  published_at: timestamp
+  updated_at: timestamp auto_update
+```
+
+`auto_update` emits a database trigger so the column auto-updates on every UPDATE statement. No application code required.
+
+## References (foreign keys)
+
+Use another model's name as the field type:
+
+```kilnx
+model post
+  title: text required
+  author: user required
+  created: timestamp auto
+```
+
+This creates an `author_id` column as a foreign key to `user(id)`. In queries, use `author_id` for the column and `author.name` for JOINed fields.
+
+## Options (enums)
+
+```kilnx
+field: option [val1, val2, val3]
+```
+
+Kilnx creates a `CHECK` constraint so the database rejects invalid values. HTML form generation produces a `<select>` automatically.
+
+## The `auto` constraint in detail
+
+| Field type | Behavior with `auto` |
+|------------|----------------------|
+| `timestamp` | Inserts current UTC time on INSERT |
+| `date` | Inserts today&apos;s date on INSERT |
+| `uuid` | Generates a UUID v4 on INSERT |
+| `bool` | Defaults to `false` |
+
+```kilnx
+model order
+  reference: uuid auto
+  placed_at: timestamp auto
+  delivery_date: date
+  status: option [pending, shipped, delivered] default pending
+```
+
+## Multi-tenant scoping
+
+A model can declare that its rows belong to a tenant (another model):
+
+```kilnx
+model org
+  name: text required unique
+
+model user
+  tenant: org
+  email: email unique
+  password: password required
+
+model quote
+  tenant: org
+  number: text required unique
+```
+
+The compiler auto-synthesizes a required `org_id` foreign key. The runtime rewrites `SELECT` queries to include `WHERE quote.org_id = :current_user.org_id`.
+
+The tenant rewriter **fails closed**: if the SQL shape is too complex to verify safely (CTEs, JOINs, subqueries, UNION, schema-qualified tables, multi-statement queries), the query is refused at runtime rather than passing through unscoped.
+
+## Custom fields
+
+Runtime-extensible fields stored as JSON in a `custom` column:
+
+```kilnx
+model deal
+  name: text required
+  custom fields from "deal_fields.kilnx"
+```
+
+See the [grammar reference](../reference/grammar.html#model) for the manifest syntax and per-tenant variants.
+
+## Migrations
+
+Schema changes detected from `model` edits. Applied on `kilnx run` (dev) or via `kilnx migrate` (prod). No manual migration files.
+
+```bash
+kilnx migrate app.kilnx --dry-run   # show SQL without applying
+kilnx migrate app.kilnx --status    # show applied migrations
+kilnx migrate app.kilnx             # apply pending migrations
+```
+
+The compiler detects added fields (emits `ALTER TABLE ADD COLUMN`). Removed or renamed fields are not auto-detected — handle those explicitly.

--- a/docs/content/guides/pages-actions.md
+++ b/docs/content/guides/pages-actions.md
@@ -1,0 +1,191 @@
+# Pages &amp; actions
+
+Pages are GET routes that return HTML. Actions are POST/PUT/DELETE routes that mutate data.
+
+## Pages
+
+```kilnx
+page /posts
+  query posts: SELECT title, created FROM post ORDER BY created DESC
+  html
+    <h1>All posts</h1>
+    {{each posts}}
+      <article><h2>{title}</h2></article>
+    {{end}}
+```
+
+### Modifiers
+
+```kilnx
+page /dashboard requires auth layout main title "Dashboard"
+```
+
+| Modifier | Effect |
+|----------|--------|
+| `requires auth` | Redirects to login if no session |
+| `requires <role>` | Requires a specific role (e.g. `requires admin`) |
+| `layout <name>` | Wraps output in the named `layout` block |
+| `title "<text>"` | Sets `{page.title}` for the layout |
+
+### Path parameters
+
+```kilnx
+page /posts/:slug
+  query post: SELECT title, body FROM post WHERE slug = :slug
+  html
+    <article>
+      <h1>{post.title}</h1>
+      <div>{post.body | raw}</div>
+    </article>
+```
+
+Named parameters use `:name` both in the path and in the SQL. Kilnx binds them automatically (safely — no string concatenation).
+
+### Inline text
+
+Short pages skip `html`:
+
+```kilnx
+page /about
+  "About us"
+```
+
+## Actions
+
+POST routes for mutations:
+
+```kilnx
+action /posts/create method POST
+  validate post
+  query: INSERT INTO post (title, body) VALUES (:title, :body)
+  redirect /posts
+```
+
+### The action body
+
+| Construct | Purpose |
+|-----------|---------|
+| `validate <model>` | Validate form against model constraints |
+| `validate` (block) | Inline validation rules |
+| `query: <SQL>` | Run SQL (INSERT/UPDATE/DELETE or SELECT) |
+| `query <name>: <SQL>` | Named query — result available in later steps |
+| `on success` / `on error` / `on not found` | Conditional branches |
+| `redirect <path>` | HTTP redirect (also supports htmx HX-Redirect) |
+| `respond fragment <selector>` | Return partial HTML for htmx swaps |
+| `enqueue <job>` | Dispatch an async job |
+| `send email to <recipient>` | Send an email |
+
+### Validation
+
+Against a model&apos;s constraints:
+
+```kilnx
+action /users/create method POST
+  validate user
+  query: INSERT INTO user (name, email) VALUES (:name, :email)
+  redirect /users
+```
+
+Inline rules:
+
+```kilnx
+action /login method POST
+  validate
+    email: required, is email
+    password: required, min 8
+  query user: SELECT id FROM user WHERE email = :email
+  on not found
+    redirect /login?error=invalid
+  redirect /dashboard
+```
+
+### Branching
+
+```kilnx
+action /posts/create method POST
+  validate post
+  query: INSERT INTO post (title, body, author_id)
+         VALUES (:title, :body, :current_user.id)
+  on success
+    redirect /posts
+  on error
+    alert "Could not create post"
+```
+
+### Transactions
+
+All queries within a single action run in an implicit transaction. If any query fails, all prior writes roll back.
+
+## Implicit queries
+
+Inside a page body, `query <name>: <SQL>` makes the result available for template interpolation:
+
+```kilnx
+page /posts/:id
+  query post: SELECT * FROM post WHERE id = :id
+  query comments: SELECT body, author FROM comment
+                  WHERE post_id = :id
+                  ORDER BY created ASC
+  html
+    <h1>{post.title}</h1>
+    <p>{post.body}</p>
+    <h2>Comments ({comments.count})</h2>
+    {{each comments}}
+      <div><strong>{author}</strong>: {body}</div>
+    {{end}}
+```
+
+Single-row queries give `{name.field}`. Multi-row queries are iterable via `{{each name}}...{{end}}`.
+
+## Pagination
+
+Add `paginate N` to a SELECT:
+
+```kilnx
+query posts: SELECT title FROM post ORDER BY created DESC paginate 20
+```
+
+Kilnx reads `?page=N` from the request, injects LIMIT/OFFSET, and exposes `{posts.pagination.next}`, `{posts.pagination.prev}`, `{posts.pagination.total}` in the template.
+
+## Template filters
+
+Built-in filters for formatting:
+
+```
+{name | upcase}                  ALICE
+{name | truncate:20}             Alice Wonderla...
+{created | timeago}              3 hours ago
+{created | date:"Jan 02, 2006"}  Mar 27, 2026
+{price | currency:"$"}           $1,234.56
+{bio | raw}                      unescaped HTML
+```
+
+## Layouts
+
+Wrap multiple pages in a common HTML shell:
+
+```kilnx
+layout main
+  html
+    <html>
+    <head>
+      <title>{page.title}</title>
+      {kilnx.js}
+    </head>
+    <body>
+      {nav}
+      {page.content}
+    </body>
+    </html>
+
+page /dashboard layout main title "Dashboard"
+  html
+    <h1>Welcome</h1>
+```
+
+Four placeholders:
+
+- `{page.title}` — escaped page title
+- `{page.content}` — the rendered page body
+- `{nav}` — auto-generated navigation bar
+- `{kilnx.js}` — **required.** htmx and SSE scripts. Without this, htmx functionality breaks.

--- a/docs/content/guides/queries.md
+++ b/docs/content/guides/queries.md
@@ -1,0 +1,47 @@
+# Queries
+
+> This page is a stub. Full content coming soon. For now see [pages &amp; actions](pages-actions.html#implicit-queries) and the [grammar reference](../reference/grammar.html).
+
+Kilnx queries are inline SQL. The database is first-class — not accessed through an ORM, not hidden behind abstractions.
+
+```kilnx
+page /users
+  query users: SELECT id, name, email FROM user ORDER BY created DESC
+  html
+    {{each users}}
+      <div>{name} ({email})</div>
+    {{end}}
+```
+
+## Parameter binding
+
+Always use `:name` placeholders. Never string-interpolate SQL.
+
+```kilnx
+query user: SELECT * FROM user WHERE id = :id AND active = :active
+```
+
+## Named queries (reusable)
+
+Top-level:
+
+```kilnx
+query active-users: SELECT name FROM user WHERE active = true
+
+page /users
+  query users: active-users
+```
+
+Reference by name inside any page/action/fragment/api body.
+
+## Transactions
+
+All queries inside a single `action` block run in an implicit transaction. Any failure rolls back all prior writes.
+
+## Pagination
+
+Add `paginate N` to a SELECT. Kilnx reads `?page=N` from the request and injects LIMIT/OFFSET automatically.
+
+```kilnx
+query posts: SELECT * FROM post ORDER BY created DESC paginate 20
+```

--- a/docs/content/guides/realtime.md
+++ b/docs/content/guides/realtime.md
@@ -1,0 +1,32 @@
+# Realtime
+
+> This page is a stub. Full content coming soon.
+
+## Server-Sent Events (SSE)
+
+`stream` creates an SSE endpoint that polls a SQL query at a fixed interval:
+
+```kilnx
+stream /notifications requires auth every 5s
+  query: SELECT message FROM notification
+         WHERE user_id = :current_user.id AND seen = false
+```
+
+The client connects via the embedded htmx SSE extension. Updates stream automatically.
+
+## WebSockets
+
+`socket` creates a bidirectional WebSocket endpoint with rooms and broadcast:
+
+```kilnx
+socket /chat/:room requires auth
+  on connect
+    query: SELECT body, author FROM message
+           WHERE room = :room ORDER BY created DESC LIMIT 50
+  on message
+    query: INSERT INTO message (body, author, room)
+           VALUES (:body, :current_user.id, :room)
+    broadcast to :room
+```
+
+Handlers: `on connect`, `on message`, `on disconnect`. Each runs SQL and optionally broadcasts to other clients in the same room.

--- a/docs/content/guides/testing.md
+++ b/docs/content/guides/testing.md
@@ -1,0 +1,46 @@
+# Testing
+
+> This page is a stub. Full content coming soon.
+
+Declarative HTTP tests in the same language — no Selenium, no Cypress.
+
+```kilnx
+test "user can register"
+  visit /register
+  fill name "Alice"
+  fill identity "alice@test.com"
+  fill password "secret123"
+  submit
+  expect page /login contains "Log in"
+
+test "homepage loads"
+  visit /
+  expect status 200
+  expect page / contains "Blog"
+
+test "admin access"
+  as admin
+  visit /admin
+  expect status 200
+```
+
+Run with:
+
+```bash
+kilnx test app.kilnx
+```
+
+Tests run against a real in-memory server with a fresh SQLite database. No mocks.
+
+## Step reference
+
+| Step | Effect |
+|------|--------|
+| `visit <path>` | GET the path |
+| `fill <field> "<value>"` | Set a form field |
+| `submit` | Submit the last form |
+| `expect status <N>` | Assert response status code |
+| `expect page <path> contains "<text>"` | Assert page body contains text |
+| `expect redirect to <path>` | Assert Location header |
+| `expect query: <SQL> returns <N>` | Run SQL, assert returned count |
+| `as <role>` | Log in as a user with the given role |

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,0 +1,85 @@
+# Kilnx documentation
+
+Kilnx is a declarative backend language that compiles `.kilnx` source to a single standalone binary. Models, routes, SQL, auth, jobs, WebSockets, SSE, and tests live in one file. SQLite and PostgreSQL are first-class.
+
+- Zero JavaScript, zero runtime dependencies for the user
+- ~15MB self-contained binary
+- Built for the htmx era
+
+<div class="toc-grid">
+
+<div class="toc-card">
+
+### Start here
+
+- [Install &amp; hello world](getting-started.html)
+- [Design principles](principles.html)
+
+</div>
+
+<div class="toc-card">
+
+### Guides
+
+- [Models](guides/models.html)
+- [Pages &amp; actions](guides/pages-actions.html)
+- [Auth &amp; permissions](guides/auth-permissions.html)
+- [Queries](guides/queries.html)
+- [Fragments &amp; htmx](guides/fragments-htmx.html)
+- [Realtime (SSE &amp; WS)](guides/realtime.html)
+- [Jobs &amp; schedules](guides/jobs-schedules.html)
+- [Testing](guides/testing.html)
+- [Deployment](guides/deployment.html)
+
+</div>
+
+<div class="toc-card">
+
+### Reference
+
+- [Grammar](reference/grammar.html)
+- [Field types](reference/field-types.html)
+- [Constraints](reference/constraints.html)
+- [CLI](reference/cli.html)
+
+</div>
+
+<div class="toc-card">
+
+### Tutorials
+
+- [Build a CRUD app](tutorials/crud-app.html)
+
+</div>
+
+</div>
+
+## Minimal example
+
+```kilnx
+config
+  database: env DATABASE_URL default "sqlite://app.db"
+  port: env PORT default 8080
+  secret: env SECRET_KEY required
+
+model user
+  name: text required min 2 max 100
+  email: email unique
+  password: password required
+  created: timestamp auto
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /dashboard
+
+page /dashboard requires auth
+  query stats: SELECT count(*) as total FROM user
+  html
+    <h1>Welcome, {current_user.name}</h1>
+    <p>Total users: {stats.total}</p>
+```
+
+One file. `kilnx run app.kilnx` starts a dev server with hot reload. `kilnx build` emits a standalone binary.

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -1,0 +1,113 @@
+# CLI
+
+## kilnx run
+
+Start a development server with hot reload.
+
+```bash
+kilnx run app.kilnx
+```
+
+- Auto-creates the database on first run
+- Applies pending migrations
+- Watches `app.kilnx` and reloads on change
+- Default port: 8080 (override with `PORT` env or `config port:`)
+
+## kilnx build
+
+Compile to a standalone binary.
+
+```bash
+kilnx build app.kilnx -o myapp
+./myapp
+```
+
+The output binary embeds the parsed app, htmx, and the Kilnx runtime. ~15MB, no runtime dependencies. Target platform follows the host (cross-compile via Go&apos;s `GOOS`/`GOARCH`).
+
+## kilnx check
+
+Static analysis.
+
+```bash
+kilnx check app.kilnx
+```
+
+Validates: grammar, field type usage, SQL parameter binding, template variable references, security concerns (password fields in public queries, unsafe `raw` filter usage), and tenant scoping.
+
+Exit code: 0 on clean, 1 on errors. Warnings do not fail.
+
+Options:
+
+```bash
+kilnx check app.kilnx --db sqlite://app.db    # validate against live DB
+```
+
+## kilnx test
+
+Run `test` blocks declaratively.
+
+```bash
+kilnx test app.kilnx
+```
+
+Spins up an in-memory server with a fresh SQLite database, executes each test as HTTP requests, reports pass/fail counts. No mocks. Tests run against the real routing, queries, and template engine.
+
+## kilnx migrate
+
+Schema migrations. Normally automatic during `run`; use this for production.
+
+```bash
+kilnx migrate app.kilnx                # apply pending
+kilnx migrate app.kilnx --dry-run      # show SQL without applying
+kilnx migrate app.kilnx --status       # show applied migrations
+```
+
+Detects: added fields (emits `ALTER TABLE ADD COLUMN`), new models (emits `CREATE TABLE`). Does not detect: removed or renamed fields.
+
+## kilnx lsp
+
+Language Server Protocol endpoint. For editor integrations.
+
+```bash
+kilnx lsp
+```
+
+Speaks LSP over stdin/stdout. Used by the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=atoolz.kilnx-vscode-toolkit). Provides: completions, diagnostics, hover docs, go-to-definition, document symbols.
+
+## kilnx mcp
+
+Model Context Protocol server. For AI tools (Claude, Cursor, etc.).
+
+```bash
+kilnx mcp
+```
+
+Exposes the grammar spec, keyword docs, example snippets, and the `check` tool to LLM clients. Configure in your MCP client&apos;s settings.
+
+## kilnx version
+
+```bash
+kilnx version
+```
+
+Prints the version and git commit hash.
+
+## Global flags
+
+| Flag | Effect |
+|------|--------|
+| `--help` | Show command help |
+| `--verbose` | Verbose output |
+
+## Environment variables
+
+Most config values are overridable via env vars declared in the `config` block:
+
+```kilnx
+config
+  database: env DATABASE_URL default "sqlite://app.db"
+  port: env PORT default 8080
+  secret: env SECRET_KEY required
+```
+
+`env VAR required` fails fast if the variable is unset. Useful for production secrets.

--- a/docs/content/reference/constraints.md
+++ b/docs/content/reference/constraints.md
@@ -1,0 +1,120 @@
+# Constraints
+
+Constraints modify field behavior. They attach to [field types](field-types.html) in a model block.
+
+## required
+
+Column is NOT NULL. Empty form submissions are rejected with a validation error.
+
+```kilnx
+name: text required
+```
+
+## unique
+
+Column has a UNIQUE index. Duplicate INSERT/UPDATE is rejected.
+
+```kilnx
+email: email unique
+slug: text required unique
+```
+
+Typical pairing: `required unique` for identity fields like username or slug.
+
+## default &lt;value&gt;
+
+Inserts the given value when the field is unset.
+
+```kilnx
+role: option [admin, editor, viewer] default viewer
+active: bool default true
+views: int default 0
+```
+
+Quoted strings are supported for text defaults:
+
+```kilnx
+status: text default "pending"
+```
+
+## auto
+
+Auto-generates a value on INSERT. Behavior depends on field type:
+
+| Field type | Behavior |
+|------------|----------|
+| `timestamp` | Current UTC time |
+| `date` | Today&apos;s date |
+| `uuid` | UUID v4 |
+| `bool` | `false` |
+
+```kilnx
+model order
+  created: timestamp auto
+  placed_on: date auto
+  reference: uuid auto
+```
+
+## auto_update
+
+Emits a database trigger that auto-updates the column on every UPDATE statement. Used for `updated_at` patterns.
+
+```kilnx
+model post
+  title: text required
+  updated: timestamp auto_update
+```
+
+SQLite generates an `AFTER UPDATE` trigger. PostgreSQL generates a `BEFORE UPDATE` trigger with a `plpgsql` function. The trigger is created/replaced automatically during migration. Applies to `timestamp` fields; other types will have the trigger defined but may not produce meaningful values.
+
+`auto_update` differs from `auto` — `auto` runs only on INSERT, `auto_update` runs on every UPDATE.
+
+## min &lt;n&gt;
+
+Minimum length (for text types) or minimum value (for numeric types).
+
+```kilnx
+name: text required min 2
+age: int min 18
+```
+
+Form validation rejects values below the minimum. For text, measured in characters.
+
+## max &lt;n&gt;
+
+Maximum length or value.
+
+```kilnx
+title: text required max 200
+score: int max 100
+```
+
+## Combining constraints
+
+Constraints appear space-separated after the field type:
+
+```kilnx
+model user
+  email: email required unique
+  age: int required min 13 max 120
+  bio: text max 500 default ""
+  role: option [admin, user] default user required
+  created: timestamp auto
+  updated: timestamp auto_update
+```
+
+Order is not significant.
+
+## Summary
+
+| Constraint | Applies to | Effect |
+|------------|------------|--------|
+| `required` | All | NOT NULL |
+| `unique` | All | UNIQUE index |
+| `default <val>` | All | Default value |
+| `auto` | `timestamp`, `date`, `uuid`, `bool` | Auto-generate on INSERT |
+| `auto_update` | `timestamp` | DB trigger: update on every UPDATE |
+| `min <n>` | Text (length) or numeric (value) | Lower bound |
+| `max <n>` | Text (length) or numeric (value) | Upper bound |
+
+Total: 7 constraints.

--- a/docs/content/reference/field-types.md
+++ b/docs/content/reference/field-types.md
@@ -1,0 +1,83 @@
+# Field types
+
+Field types map a Kilnx declaration to a SQL column. Every field has a type plus zero or more [constraints](constraints.html).
+
+## Text types
+
+| Kilnx type | SQLite | PostgreSQL | Notes |
+|------------|--------|------------|-------|
+| `text` | TEXT | TEXT | Plain string |
+| `email` | TEXT | TEXT | Format-validated on form submission |
+| `richtext` | TEXT | TEXT | Rendered unescaped. Use only with trusted input. |
+| `password` | TEXT | TEXT | Auto-hashed with bcrypt on INSERT. Never stored plaintext. |
+| `option` | TEXT | TEXT | Enum. Syntax: `field: option [a, b, c]`. Emits CHECK constraint. |
+| `url` | TEXT | TEXT | Format-validated (requires scheme and host) |
+| `phone` | TEXT | TEXT | Format-validated |
+| `tags` | TEXT | TEXT | Multi-value. Comma-separated storage. Optional allowed-list: `field: tags [a, b, c]` |
+| `uuid` | TEXT | UUID | With `auto`: SQLite uses `randomblob`, PostgreSQL uses `gen_random_uuid()` |
+
+## Numeric types
+
+| Kilnx type | SQLite | PostgreSQL | Notes |
+|------------|--------|------------|-------|
+| `int` | INTEGER | INTEGER | 32-bit integer |
+| `bigint` | INTEGER | BIGINT | 64-bit integer |
+| `float` | REAL | DOUBLE PRECISION | Floating point |
+| `decimal` | TEXT | NUMERIC | Fixed-point. Use for money and other exact arithmetic. |
+
+## Boolean &amp; time
+
+| Kilnx type | SQLite | PostgreSQL | Notes |
+|------------|--------|------------|-------|
+| `bool` | INTEGER (0/1) | BOOLEAN | With `auto`: defaults to false |
+| `timestamp` | TEXT (ISO8601) | TIMESTAMP | With `auto`: current UTC time on INSERT |
+| `date` | TEXT (YYYY-MM-DD) | DATE | With `auto`: today&apos;s date on INSERT |
+
+## Structured data
+
+| Kilnx type | SQLite | PostgreSQL | Notes |
+|------------|--------|------------|-------|
+| `json` | TEXT | JSONB | Arbitrary JSON. Validated on INSERT. |
+
+## File uploads
+
+| Kilnx type | SQLite | PostgreSQL | Notes |
+|------------|--------|------------|-------|
+| `image` | TEXT | TEXT | Stores upload path. Generates `<input type="file" accept="image/*">` |
+| `file` | TEXT | TEXT | Generic file upload. Stores path. |
+
+Upload handling is configured in `config`:
+
+```kilnx
+config
+  uploads: ./uploads max 50mb
+```
+
+## References
+
+Use another model name as the type:
+
+```kilnx
+model post
+  author: user required
+```
+
+Generates an `author_id` column. SQLite uses `INTEGER`, PostgreSQL uses `BIGINT`. Automatically adds a `REFERENCES user(id)` foreign key constraint.
+
+You can also write `author: reference` explicitly (rarely needed).
+
+## Summary table
+
+Quick reference of all types:
+
+```
+Text:       text, email, richtext, password, option,
+            url, phone, tags, uuid
+Numeric:    int, bigint, float, decimal
+Bool/time:  bool, timestamp, date
+Structured: json
+Files:      image, file
+Relations:  reference (or ModelName)
+```
+
+Total: 20 field types. See [constraints](constraints.html) for modifiers that apply across types.

--- a/docs/content/tutorials/crud-app.md
+++ b/docs/content/tutorials/crud-app.md
@@ -1,0 +1,91 @@
+# Build a CRUD app
+
+> This tutorial is a stub. Full walkthrough coming soon.
+
+Goal: a blog app with user registration, login, post creation, pagination, and inline editing — in under 80 lines of Kilnx.
+
+```kilnx
+config
+  database: env DATABASE_URL default "sqlite://blog.db"
+  secret: env SECRET_KEY required
+
+model user
+  name: text required min 2
+  email: email required unique
+  password: password required
+  role: option [admin, author, reader] default reader
+  created: timestamp auto
+
+model post
+  title: text required min 5 max 200
+  body: richtext required
+  author: user required
+  published: bool default false
+  created: timestamp auto
+  updated: timestamp auto_update
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /
+
+permissions
+  admin: all
+  author: read post, write post where author = current_user
+  reader: read post where published = true
+
+layout main
+  html
+    <!doctype html>
+    <html>
+    <head>
+      <title>{page.title} · Blog</title>
+      {kilnx.js}
+    </head>
+    <body>
+      <header>{nav}</header>
+      <main>{page.content}</main>
+    </body>
+    </html>
+
+page / layout main title "Blog"
+  query posts: SELECT title, body, author.name as author, created
+               FROM post
+               WHERE published = true
+               ORDER BY created DESC
+               paginate 10
+  html
+    {{each posts}}
+      <article>
+        <h2>{title}</h2>
+        <p><small>by {author} &middot; {created | timeago}</small></p>
+        <div>{body | raw}</div>
+      </article>
+    {{end}}
+
+page /compose requires author layout main title "New post"
+  html
+    <form method="post" action="/posts/create">
+      <input name="title" placeholder="Title" required>
+      <textarea name="body" placeholder="Body" required></textarea>
+      <button>Publish</button>
+    </form>
+
+action /posts/create method POST requires author
+  validate post
+  query: INSERT INTO post (title, body, author_id, published)
+         VALUES (:title, :body, :current_user.id, true)
+  redirect /
+```
+
+Run it:
+
+```bash
+kilnx run app.kilnx
+```
+
+Register at `/register`, then compose at `/compose` and see the post on `/`.
+
+A proper walkthrough covering form validation errors, draft vs published states, edit/delete actions, and htmx-powered inline editing is coming. For now, the code above is a working blog.

--- a/docs/template.html
+++ b/docs/template.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>$title$ · Kilnx Docs</title>
+<meta name="description" content="$description$">
+<link rel="canonical" href="https://docs.kilnx.org/$canonical$">
+<link rel="stylesheet" href="$root$assets/style.css">
+</head>
+<body>
+<header class="site-header">
+<div class="container">
+<a class="brand" href="$root$">Kilnx</a>
+<nav class="main-nav">
+<a href="https://kilnx.org/">Home</a>
+<a href="$root$" class="active">Docs</a>
+<a href="https://github.com/kilnx-org/kilnx">GitHub</a>
+</nav>
+</div>
+</header>
+
+<div class="layout container">
+<aside class="sidebar">
+<h3>Getting started</h3>
+<ul>
+<li><a href="$root$getting-started.html">Install &amp; hello world</a></li>
+</ul>
+<h3>Guides</h3>
+<ul>
+<li><a href="$root$guides/models.html">Models</a></li>
+<li><a href="$root$guides/pages-actions.html">Pages &amp; actions</a></li>
+<li><a href="$root$guides/auth-permissions.html">Auth &amp; permissions</a></li>
+<li><a href="$root$guides/queries.html">Queries</a></li>
+<li><a href="$root$guides/fragments-htmx.html">Fragments &amp; htmx</a></li>
+<li><a href="$root$guides/realtime.html">Realtime (SSE &amp; WS)</a></li>
+<li><a href="$root$guides/jobs-schedules.html">Jobs &amp; schedules</a></li>
+<li><a href="$root$guides/testing.html">Testing</a></li>
+<li><a href="$root$guides/deployment.html">Deployment</a></li>
+</ul>
+<h3>Reference</h3>
+<ul>
+<li><a href="$root$reference/grammar.html">Grammar</a></li>
+<li><a href="$root$reference/field-types.html">Field types</a></li>
+<li><a href="$root$reference/constraints.html">Constraints</a></li>
+<li><a href="$root$reference/cli.html">CLI</a></li>
+</ul>
+<h3>Tutorials</h3>
+<ul>
+<li><a href="$root$tutorials/crud-app.html">Build a CRUD app</a></li>
+</ul>
+<h3>Meta</h3>
+<ul>
+<li><a href="$root$principles.html">Principles</a></li>
+<li><a href="$root$changelog.html">Changelog</a></li>
+</ul>
+</aside>
+
+<main class="content">
+$body$
+</main>
+</div>
+
+<footer class="site-footer">
+<div class="container">
+<p>Kilnx is open source under the MIT license. <a href="https://github.com/kilnx-org/kilnx">Source on GitHub</a>.</p>
+</div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Scaffolds the documentation site at `docs.kilnx.org`. Static HTML generated from markdown via pandoc, deployed to GitHub Pages.

Landing page stays at `kilnx-org.github.io` (marketing). Docs live here (reference, acoplado ao código). This split lets a PR that adds a feature update the relevant docs in the same commit, eliminating drift like we just had to clean up for the `queries`/`with` keyword removal.

## What is in the PR

- **`docs/content/`** — source markdown (edit here)
- **`docs/template.html`** — pandoc shell with sidebar, header, footer
- **`docs/assets/style.css`** — hand-written CSS, respects `prefers-color-scheme` (light/dark)
- **`docs/build.sh`** — pandoc driver; also syncs `GRAMMAR.md`, `PRINCIPLES.md`, `CHANGELOG.md` from repo root so the docs copies never drift
- **`docs/pages/`** — generated output (gitignored)
- **`.github/workflows/docs.yml`** — builds + deploys on push to `main` when `docs/**` or canonical sources change

## Content included

Full pages: getting-started, guides/models, guides/pages-actions, guides/auth-permissions, reference/field-types, reference/constraints, reference/cli.

Stubs (real content referenced, stubs with pointers to FEATURES.md / GRAMMAR.md): guides/queries, guides/fragments-htmx, guides/realtime, guides/jobs-schedules, guides/testing, guides/deployment, tutorials/crud-app.

Synced automatically by `build.sh`: reference/grammar, principles, changelog.

## Required manual setup (post-merge)

Set once in repo settings:

- **Pages &rarr; Source:** GitHub Actions
- **Pages &rarr; Custom domain:** `docs.kilnx.org`
- **DNS:** CNAME `docs` &rarr; `kilnx-org.github.io`

After that, every push to `main` that touches `docs/**` or the canonical sources auto-rebuilds and deploys.

## Test plan

- [x] `./build.sh` runs clean locally (requires `pandoc`)
- [x] Output in `docs/pages/` has correct relative paths at every depth (root, guides/, reference/, tutorials/)
- [x] `docs/pages/index.html`, `404.html`, `CNAME`, `assets/` all present post-build
- [ ] After merge + Pages config, verify `https://docs.kilnx.org/` serves the landing
- [ ] Verify sidebar links work from every depth
- [ ] Verify dark mode toggles with browser preference