### PR TITLE
chore(ci): auto-label PRs by changed file paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,69 @@
+area/lexer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/lexer/**
+
+area/parser:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/parser/**
+
+area/analyzer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/analyzer/**
+
+area/runtime:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/runtime/**
+
+area/database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/database/**
+
+area/lsp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/lsp/**
+
+area/build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - internal/build/**
+
+area/cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - cmd/kilnx/**
+
+area/docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - GRAMMAR.md
+          - FEATURES.md
+          - PRINCIPLES.md
+          - CONTRIBUTING.md
+          - README.md
+          - AGENTS.md
+
+area/examples:
+  - changed-files:
+      - any-glob-to-any-file:
+          - smoke/**
+
+area/ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/workflows/**
+          - .github/labeler.yml
+          - Dockerfile
+          - .dockerignore
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - go.mod
+          - go.sum

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## Summary

Adds a `Labeler` GitHub Action that applies `area/*` and `dependencies` labels to pull requests automatically, based on which directories the PR modifies.

## How it works

- `.github/labeler.yml` maps glob patterns to labels
- `.github/workflows/labeler.yml` runs `actions/labeler@v5` on PR open/sync/reopen
- `sync-labels: true` removes labels that no longer apply if files are removed from the PR

## Mapping

| Path | Label |
|------|-------|
| `internal/lexer/**` | `area/lexer` |
| `internal/parser/**` | `area/parser` |
| `internal/analyzer/**` | `area/analyzer` |
| `internal/runtime/**` | `area/runtime` |
| `internal/database/**` | `area/database` |
| `internal/lsp/**` | `area/lsp` |
| `internal/build/**` | `area/build` |
| `cmd/kilnx/**` | `area/cli` |
| `docs/**` + root `.md` files | `area/docs` |
| `smoke/**` | `area/examples` |
| `.github/workflows/**`, `Dockerfile` | `area/ci` |
| `go.mod`, `go.sum` | `dependencies` |

## Test plan

- [x] Merge and confirm labels are applied to subsequent PRs
- [x] Confirm `sync-labels` removes labels when files are reverted