### PR TITLE
chore(docs): remove custom domain CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-docs.kilnx.org


### PR DESCRIPTION
Custom domain `docs.kilnx.org` is blocked by Cloudflare DNS pointing to Railway fallback. Removing CNAME so the site serves from the default Pages URL `kilnx-org.github.io/kilnx/`. Re-add CNAME once Cloudflare record is fixed.