### PR TITLE
docs: add CODE_OF_CONDUCT and SECURITY policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in Kilnx a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experience
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy toward other community members
+
+Behavior that is not acceptable:
+
+- Sexualized language or imagery, and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned to this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when an individual is representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue on [GitHub](https://github.com/kilnx-org/kilnx/issues) or contacting the maintainers directly.
+
+All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | Yes       |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities by emailing **security@kilnx.org** with:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fix (optional)
+
+You will receive a response within **48 hours**. If the issue is confirmed, a patch will be released as soon as possible depending on severity.
+
+## Scope
+
+Security issues in scope:
+
+- SQL injection via Kilnx query or model definitions
+- Authentication bypass (auth block, session handling, HMAC)
+- CSRF protection gaps
+- Path traversal in file upload handling
+- Remote code execution via compiled binaries
+- Privilege escalation via permissions block
+
+Out of scope:
+
+- Vulnerabilities in apps built with Kilnx (report to the app's maintainer)
+- Issues in dependencies (report upstream)
+- Denial of service via resource exhaustion
+
+## Disclosure Policy
+
+Once a fix is released, the vulnerability will be publicly disclosed in the [CHANGELOG](CHANGELOG.md) with credit to the reporter (unless anonymity is requested).


### PR DESCRIPTION
## Summary

- Adds `CODE_OF_CONDUCT.md` based on Contributor Covenant 2.1
- Adds `SECURITY.md` with GitHub-standard security policy and Kilnx-specific vulnerability scope (auth block, HMAC, permissions, SQL injection, path traversal)

## Test plan

- [ ] Verify both files render correctly on GitHub
- [ ] Confirm GitHub picks up SECURITY.md for the "Report a vulnerability" button