### PR TITLE
feat: composite UNIQUE via model-level unique(...) directive

### DIFF
--- a/.cursor/rules/kilnx.mdc
+++ b/.cursor/rules/kilnx.mdc
@@ -68,6 +68,8 @@ Full references:
 
 `required` `unique` `default <val>` `auto` `min <n>` `max <n>`
 
+Composite UNIQUE: `unique (field_a, field_b, ...)` as a model-level line (two or more fields; references resolve to `_id` columns).
+
 ---
 
 ## Syntax examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versio
 ## [Unreleased]
 
 ### Added
+- Composite UNIQUE via model-level `unique (field_a, field_b, ...)` directive; emits idempotent `CREATE UNIQUE INDEX IF NOT EXISTS` and is validated by the analyzer (unknown fields, duplicated fields within a group, or duplicate groups)
 - `tenant` modifier on `model` for multi-tenant scoping with fail-closed guards across every query path (refs [#48](https://github.com/kilnx-org/kilnx/issues/48), [#52](https://github.com/kilnx-org/kilnx/pull/52))
 - PostgreSQL support via `Dialect` abstraction; switch engines with `database: postgres://...` ([#46](https://github.com/kilnx-org/kilnx/pull/46))
 - Multi-file support via `import` statement with `.kilnx` extension enforcement and path traversal protection (closes [#20](https://github.com/kilnx-org/kilnx/issues/20), [#43](https://github.com/kilnx-org/kilnx/pull/43))

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,6 +24,8 @@ model post
 
 Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`. Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`.
 
+Composite uniqueness: declare `unique (field_a, field_b, ...)` at the model level for two or more fields. References resolve to their `_id` column automatically.
+
 ## Auth
 
 Six lines. Registration, login, logout, bcrypt hashing, session cookies, and `current_user` available everywhere.

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -198,6 +198,27 @@ authorization. The rewriter closes the "forgot the tenant predicate"
 failure mode; other access-control concerns remain the developer's
 responsibility.
 
+#### composite unique
+
+For uniqueness spanning more than one field, declare a model-level
+`unique (...)` directive:
+
+```kilnx
+model membership
+  user: user required
+  project: project required
+  role: option [owner, admin, member] default member
+  unique (user, project)
+```
+
+The directive takes two or more field names (single-field uniqueness
+uses the field-level `unique` constraint). Reference fields resolve to
+their `<name>_id` column. Migration emits `CREATE UNIQUE INDEX IF NOT
+EXISTS "uq_<table>_<col>_<col>" ON "<table>" (...)`, which is
+idempotent on both SQLite and PostgreSQL. Multiple `unique (...)` lines
+are allowed for independent groups. The analyzer rejects unknown field
+names, fields repeated within a group, and duplicate groups.
+
 ### permissions
 
 Access rules by role.

--- a/docs/content/guides/models.md
+++ b/docs/content/guides/models.md
@@ -48,6 +48,26 @@ model post
 
 `auto_update` emits a database trigger so the column auto-updates on every UPDATE statement. No application code required.
 
+## Composite unique
+
+For uniqueness that spans two or more columns, declare a model-level `unique (...)` directive:
+
+```kilnx
+model membership
+  user: user required
+  project: project required
+  role: option [owner, admin, member] default member
+  unique (user, project)
+```
+
+Rules:
+
+- At least two fields. Use the field-level `unique` constraint for single-column uniqueness.
+- Reference fields resolve to their `<name>_id` column automatically (above: `user_id`, `project_id`).
+- Multiple `unique (...)` lines are allowed for independent groups on the same model.
+
+Migration emits `CREATE UNIQUE INDEX IF NOT EXISTS "uq_<table>_<col>_<col>" ON "<table>" (...)`, which is idempotent on SQLite and PostgreSQL. `kilnx check` rejects unknown field names, fields repeated within a group, and duplicated groups.
+
 ## References (foreign keys)
 
 Use another model's name as the field type:

--- a/docs/content/reference/constraints.md
+++ b/docs/content/reference/constraints.md
@@ -89,6 +89,26 @@ title: text required max 200
 score: int max 100
 ```
 
+## Composite unique
+
+For uniqueness across two or more fields, declare a model-level `unique (...)` directive instead of marking a single field `unique`:
+
+```kilnx
+model membership
+  user: user required
+  project: project required
+  role: option [owner, admin, member] default member
+  unique (user, project)
+```
+
+Rules:
+
+- At least two fields. Single-column uniqueness uses the field-level `unique` constraint.
+- Fields must be declared on the same model. Reference fields resolve to their `<name>_id` column automatically.
+- Multiple `unique (...)` lines are allowed for independent composite groups.
+
+Migration emits `CREATE UNIQUE INDEX IF NOT EXISTS "uq_&lt;table&gt;_&lt;col&gt;_&lt;col&gt;" ON "&lt;table&gt;" (...)`, safe to rerun on both SQLite and PostgreSQL.
+
 ## Combining constraints
 
 Constraints appear space-separated after the field type:
@@ -116,5 +136,6 @@ Order is not significant.
 | `auto_update` | `timestamp` | DB trigger: update on every UPDATE |
 | `min <n>` | Text (length) or numeric (value) | Lower bound |
 | `max <n>` | Text (length) or numeric (value) | Upper bound |
+| `unique (a, b, ...)` | Model-level, 2+ fields | Composite UNIQUE index |
 
-Total: 7 constraints.
+Total: 7 field constraints plus 1 model-level directive.

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -124,6 +124,7 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkAuthPages(app)...)
 	diags = append(diags, checkModelRefs(app, schema)...)
 	diags = append(diags, checkTenantRefs(app, schema)...)
+	diags = append(diags, checkUniqueConstraints(app)...)
 	diags = append(diags, checkAllSQL(app, schema)...)
 	diags = append(diags, checkSecurity(app, schema)...)
 	diags = append(diags, checkTemplateInterpolations(app, schema)...)
@@ -284,6 +285,54 @@ func checkTenantRefs(app *parser.App, schema *Schema) []Diagnostic {
 				Message: fmt.Sprintf("model '%s' declares tenant '%s' which is not a defined model", m.Name, m.Tenant),
 				Context: "model " + m.Name,
 			})
+		}
+	}
+	return diags
+}
+
+// checkUniqueConstraints validates that every field named inside a
+// `unique (a, b, ...)` directive exists on its model, that no field is
+// repeated within a single group, and that no two groups are identical.
+func checkUniqueConstraints(app *parser.App) []Diagnostic {
+	var diags []Diagnostic
+	for _, m := range app.Models {
+		if len(m.UniqueConstraints) == 0 {
+			continue
+		}
+		fieldSet := make(map[string]bool, len(m.Fields))
+		for _, f := range m.Fields {
+			fieldSet[f.Name] = true
+		}
+		seenGroups := make(map[string]bool)
+		for _, group := range m.UniqueConstraints {
+			seenInGroup := make(map[string]bool, len(group))
+			for _, name := range group {
+				if !fieldSet[name] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("unique constraint references unknown field '%s' on model '%s'", name, m.Name),
+						Context: "model " + m.Name,
+					})
+					continue
+				}
+				if seenInGroup[name] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("unique constraint on model '%s' repeats field '%s'", m.Name, name),
+						Context: "model " + m.Name,
+					})
+				}
+				seenInGroup[name] = true
+			}
+			key := strings.Join(group, "\x00")
+			if seenGroups[key] {
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("duplicate unique constraint on model '%s': (%s)", m.Name, strings.Join(group, ", ")),
+					Context: "model " + m.Name,
+				})
+			}
+			seenGroups[key] = true
 		}
 	}
 	return diags

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -1867,3 +1867,90 @@ func TestBuildSchemaColumnModeFields(t *testing.T) {
 		t.Error("JSON-mode field 'region' should not be a real schema column")
 	}
 }
+
+func TestAnalyze_UniqueConstraintUnknownField(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "m",
+			Fields: []parser.Field{
+				{Name: "a", Type: parser.FieldText},
+				{Name: "b", Type: parser.FieldText},
+			},
+			UniqueConstraints: [][]string{{"a", "c"}}, // c doesn't exist
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "unknown field 'c'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected error for unknown field in unique(), got: %+v", diags)
+	}
+}
+
+func TestAnalyze_UniqueConstraintDuplicateFieldInGroup(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "m",
+			Fields: []parser.Field{
+				{Name: "a", Type: parser.FieldText},
+			},
+			UniqueConstraints: [][]string{{"a", "a"}},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "repeats field") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected repeat-field error, got: %+v", diags)
+	}
+}
+
+func TestAnalyze_UniqueConstraintDuplicateGroup(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "m",
+			Fields: []parser.Field{
+				{Name: "a", Type: parser.FieldText},
+				{Name: "b", Type: parser.FieldText},
+			},
+			UniqueConstraints: [][]string{{"a", "b"}, {"a", "b"}},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "duplicate unique constraint") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected duplicate-group error, got: %+v", diags)
+	}
+}
+
+func TestAnalyze_UniqueConstraintValid(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "m",
+			Fields: []parser.Field{
+				{Name: "a", Type: parser.FieldText},
+				{Name: "b", Type: parser.FieldText},
+			},
+			UniqueConstraints: [][]string{{"a", "b"}},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "unique constraint") {
+			t.Fatalf("unexpected error on valid constraint: %+v", d)
+		}
+	}
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -148,9 +148,60 @@ func (db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*pars
 				stmts = append(stmts, db.dialect.AutoUpdateTriggerDDL(model.Name, field.Name)...)
 			}
 		}
+
+		stmts = append(stmts, uniqueIndexDDLs(model)...)
 	}
 
 	return stmts, nil
+}
+
+// uniqueIndexDDLs emits `CREATE UNIQUE INDEX IF NOT EXISTS` statements for
+// each composite UNIQUE group declared on the model. Field names are
+// resolved to their DB column names via fieldToColumnName (so references
+// map to their `<name>_id` columns). Groups that reference unknown fields
+// are skipped, the analyzer surfaces the error.
+func uniqueIndexDDLs(model parser.Model) []string {
+	if len(model.UniqueConstraints) == 0 {
+		return nil
+	}
+	byName := make(map[string]parser.Field, len(model.Fields))
+	for _, f := range model.Fields {
+		byName[f.Name] = f
+	}
+	var stmts []string
+	for _, group := range model.UniqueConstraints {
+		cols := make([]string, 0, len(group))
+		ok := true
+		for _, name := range group {
+			f, found := byName[name]
+			if !found {
+				ok = false
+				break
+			}
+			col := fieldToColumnName(f)
+			if !isValidIdentifier(col) {
+				ok = false
+				break
+			}
+			cols = append(cols, col)
+		}
+		if !ok || len(cols) < 2 {
+			continue
+		}
+		indexName := "uq_" + model.Name + "_" + strings.Join(cols, "_")
+		if !isValidIdentifier(indexName) {
+			continue
+		}
+		quoted := make([]string, len(cols))
+		for i, c := range cols {
+			quoted[i] = fmt.Sprintf("\"%s\"", c)
+		}
+		stmts = append(stmts, fmt.Sprintf(
+			"CREATE UNIQUE INDEX IF NOT EXISTS \"%s\" ON \"%s\" (%s)",
+			indexName, model.Name, strings.Join(quoted, ", "),
+		))
+	}
+	return stmts
 }
 
 // Migrate compares models with the current database state and applies changes.
@@ -238,6 +289,9 @@ func schemaHash(models []parser.Model) string {
 				fmt.Fprintf(&b, ":def=%s", f.Default)
 			}
 			b.WriteString("\n")
+		}
+		for _, group := range m.UniqueConstraints {
+			fmt.Fprintf(&b, "  unique:%s\n", strings.Join(group, ","))
 		}
 	}
 	h := sha256.Sum256([]byte(b.String()))

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1046,3 +1046,93 @@ func TestColumnModeMigrate(t *testing.T) {
 		t.Error("JSON 'custom' column not present in table after migration")
 	}
 }
+
+// ---------- Composite UNIQUE ----------
+
+func TestMigrateCompositeUnique(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{
+		{Name: "user", Fields: []parser.Field{{Name: "email", Type: parser.FieldText}}},
+		{Name: "project", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
+		{Name: "membership", Fields: []parser.Field{
+			{Name: "user", Type: parser.FieldReference, Reference: "user", Required: true},
+			{Name: "project", Type: parser.FieldReference, Reference: "project", Required: true},
+			{Name: "role", Type: parser.FieldText},
+		}, UniqueConstraints: [][]string{{"user", "project"}}},
+	}
+
+	stmts, err := db.Migrate(models)
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	foundIdx := false
+	for _, s := range stmts {
+		if strings.Contains(s, `CREATE UNIQUE INDEX IF NOT EXISTS "uq_membership_user_id_project_id"`) &&
+			strings.Contains(s, `("user_id", "project_id")`) {
+			foundIdx = true
+		}
+	}
+	if !foundIdx {
+		t.Fatalf("expected CREATE UNIQUE INDEX for membership (user_id, project_id); got %v", stmts)
+	}
+
+	if err := db.ExecWithParams(`INSERT INTO "user" (email) VALUES (:e)`, map[string]string{"e": "a@b"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ExecWithParams(`INSERT INTO "project" (name) VALUES (:n)`, map[string]string{"n": "p1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.ExecWithParams(`INSERT INTO "membership" (user_id, project_id, role) VALUES (1, 1, 'owner')`, nil); err != nil {
+		t.Fatal(err)
+	}
+	err = db.ExecWithParams(`INSERT INTO "membership" (user_id, project_id, role) VALUES (1, 1, 'member')`, nil)
+	if err == nil {
+		t.Fatal("expected UNIQUE constraint violation on duplicate (user_id, project_id)")
+	}
+}
+
+func TestMigrateCompositeUniqueIdempotent(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{{
+		Name: "tag",
+		Fields: []parser.Field{
+			{Name: "scope", Type: parser.FieldText},
+			{Name: "name", Type: parser.FieldText},
+		},
+		UniqueConstraints: [][]string{{"scope", "name"}},
+	}}
+
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("first Migrate: %v", err)
+	}
+	stmts, err := db.Migrate(models)
+	if err != nil {
+		t.Fatalf("second Migrate: %v", err)
+	}
+	// IF NOT EXISTS makes repeated runs safe; the statement may still be
+	// re-emitted but must succeed without error.
+	for _, s := range stmts {
+		if strings.Contains(s, "CREATE UNIQUE INDEX") && !strings.Contains(s, "IF NOT EXISTS") {
+			t.Errorf("expected IF NOT EXISTS guard, got %q", s)
+		}
+	}
+}
+
+func TestSchemaHashIncludesUniqueConstraints(t *testing.T) {
+	a := []parser.Model{{
+		Name:              "m",
+		Fields:            []parser.Field{{Name: "x", Type: parser.FieldText}, {Name: "y", Type: parser.FieldText}},
+		UniqueConstraints: [][]string{{"x", "y"}},
+	}}
+	b := []parser.Model{{
+		Name:   "m",
+		Fields: []parser.Field{{Name: "x", Type: parser.FieldText}, {Name: "y", Type: parser.FieldText}},
+	}}
+	if schemaHash(a) == schemaHash(b) {
+		t.Error("schemaHash must differ when composite UNIQUE groups differ")
+	}
+}

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -17,6 +17,8 @@ const (
 	TokenComma                         // ,
 	TokenBracketOpen                   // [
 	TokenBracketClose                  // ]
+	TokenParenOpen                     // (
+	TokenParenClose                    // )
 	TokenNewline                       // end of line
 	TokenIndent                        // increase in indentation
 	TokenDedent                        // decrease in indentation
@@ -202,6 +204,14 @@ func tokenizeLine(line string, lineNum int) []Token {
 			continue
 		case ']':
 			tokens = append(tokens, Token{Type: TokenBracketClose, Value: "]", Line: lineNum, Column: i})
+			i++
+			continue
+		case '(':
+			tokens = append(tokens, Token{Type: TokenParenOpen, Value: "(", Line: lineNum, Column: i})
+			i++
+			continue
+		case ')':
+			tokens = append(tokens, Token{Type: TokenParenClose, Value: ")", Line: lineNum, Column: i})
 			i++
 			continue
 		}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -170,6 +170,11 @@ type Model struct {
 	CustomFieldsFile     string // path to *_fields.kilnx manifest (may contain {placeholder})
 	CustomFieldsFallback string // fallback manifest path used when dynamic file not found
 	DynamicFields        bool   // opts model into DB-backed runtime field definitions
+	// UniqueConstraints lists composite UNIQUE groups declared with
+	// `unique (a, b, ...)` directives. Each group is the list of field
+	// names as written; references resolve to their `<name>_id` column
+	// at DDL generation time.
+	UniqueConstraints [][]string
 }
 
 // CustomFieldKind is the type of a runtime-extensible custom field.
@@ -656,6 +661,19 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 			continue
 		}
 
+		// unique (a, b, ...) is a composite UNIQUE constraint directive.
+		// Distinguished from the field-level `unique` constraint by the
+		// presence of '(' immediately after.
+		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) &&
+			tok.Value == "unique" && p.peekIsUniqueDirective() {
+			group, err := p.parseUniqueDirective()
+			if err != nil {
+				return model, err
+			}
+			model.UniqueConstraints = append(model.UniqueConstraints, group)
+			continue
+		}
+
 		// tenant: <model> is a model-level meta directive, not a field.
 		// Must appear before any field declaration.
 		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) &&
@@ -696,6 +714,58 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 	}
 
 	return model, nil
+}
+
+// peekIsUniqueDirective reports whether the tokens at the current position
+// match `unique (` — a composite UNIQUE directive — rather than the field
+// constraint `unique` appearing as part of `<name>: <type> unique`.
+func (p *parserState) peekIsUniqueDirective() bool {
+	if p.pos+1 >= len(p.tokens) {
+		return false
+	}
+	return p.tokens[p.pos+1].Type == lexer.TokenParenOpen
+}
+
+// parseUniqueDirective consumes `unique ( ident (, ident)+ )` and returns
+// the list of field names. Caller has already verified with
+// peekIsUniqueDirective. Groups with fewer than two fields are rejected
+// because single-field uniqueness is expressed with the field-level
+// constraint `field: <type> unique`.
+func (p *parserState) parseUniqueDirective() ([]string, error) {
+	line := p.current().Line
+	p.advance() // consume 'unique'
+	if p.current().Type != lexer.TokenParenOpen {
+		return nil, fmt.Errorf("line %d: expected '(' after 'unique'", line)
+	}
+	p.advance() // consume '('
+
+	var names []string
+	for !p.isEOF() && p.current().Type != lexer.TokenParenClose {
+		tok := p.current()
+		if tok.Type == lexer.TokenComma {
+			p.advance()
+			continue
+		}
+		if tok.Type != lexer.TokenIdentifier && tok.Type != lexer.TokenKeyword {
+			return nil, fmt.Errorf("line %d: expected field name in unique(), got %q", tok.Line, tok.Value)
+		}
+		names = append(names, tok.Value)
+		p.advance()
+	}
+	if p.isEOF() || p.current().Type != lexer.TokenParenClose {
+		return nil, fmt.Errorf("line %d: unclosed unique(...) directive", line)
+	}
+	p.advance() // consume ')'
+
+	if len(names) < 2 {
+		return nil, fmt.Errorf("line %d: unique() requires at least two fields; use field-level 'unique' for single-column uniqueness", line)
+	}
+
+	// consume trailing tokens to end of line (forgiving)
+	for !p.isEOF() && p.current().Type != lexer.TokenNewline && p.current().Type != lexer.TokenDedent {
+		p.advance()
+	}
+	return names, nil
 }
 
 // peekIsTenantDirective returns true if the tokens at the current position

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1168,3 +1168,80 @@ field notes
 		t.Errorf("notes: expected mode=JSON (empty), got %q", notes.Mode)
 	}
 }
+
+func TestParseUniqueDirective_TwoFields(t *testing.T) {
+	src := `model membership
+  user: user required
+  project: project required
+  unique (user, project)
+`
+	app := parse(t, src)
+	if len(app.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(app.Models))
+	}
+	m := app.Models[0]
+	if len(m.UniqueConstraints) != 1 {
+		t.Fatalf("expected 1 unique constraint group, got %d", len(m.UniqueConstraints))
+	}
+	g := m.UniqueConstraints[0]
+	if len(g) != 2 || g[0] != "user" || g[1] != "project" {
+		t.Errorf("unexpected unique group: %#v", g)
+	}
+}
+
+func TestParseUniqueDirective_MultipleGroups(t *testing.T) {
+	src := `model doc
+  slug: text required
+  tenant: text required
+  locale: text required
+  unique (tenant, slug)
+  unique (tenant, locale, slug)
+`
+	app := parse(t, src)
+	m := app.Models[0]
+	if len(m.UniqueConstraints) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(m.UniqueConstraints))
+	}
+	if len(m.UniqueConstraints[1]) != 3 {
+		t.Errorf("expected 3-field second group, got %v", m.UniqueConstraints[1])
+	}
+}
+
+func TestParseUniqueDirective_RejectsSingleField(t *testing.T) {
+	src := `model m
+  name: text required
+  unique (name)
+`
+	_, err := parseAllowErrors(t, src)
+	if err == nil {
+		t.Fatal("expected error for single-field unique()")
+	}
+	if !strings.Contains(err.Error(), "at least two") {
+		t.Errorf("expected message about at least two fields, got: %v", err)
+	}
+}
+
+func TestParseUniqueDirective_RejectsUnclosed(t *testing.T) {
+	src := `model m
+  a: text
+  b: text
+  unique (a, b
+`
+	_, err := parseAllowErrors(t, src)
+	if err == nil {
+		t.Fatal("expected error for unclosed unique(")
+	}
+}
+
+func TestParseFieldLevelUniqueStillWorks(t *testing.T) {
+	src := `model m
+  email: email unique
+`
+	app := parse(t, src)
+	if !app.Models[0].Fields[0].Unique {
+		t.Error("field-level unique not set")
+	}
+	if len(app.Models[0].UniqueConstraints) != 0 {
+		t.Error("composite constraints should be empty for field-level unique")
+	}
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -675,6 +675,8 @@ model post
 
 Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`. Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`.
 
+Composite uniqueness: add a `unique (field_a, field_b, ...)` line at the model level for two or more fields. References resolve to their `_id` column. The migration emits an idempotent `CREATE UNIQUE INDEX IF NOT EXISTS`.
+
 ## Auth
 
 Six lines. Registration, login, logout, bcrypt hashing, session cookies, and `current_user` available everywhere.

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@ Top-level blocks: `config`, `model`, `auth`, `permissions`, `layout`, `page`, `a
 
 Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`.
 
-Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`.
+Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`. Composite UNIQUE on a model: `unique (field_a, field_b, ...)` as a separate line (two or more fields; references resolve to their `_id` column).
 
 ## CLI
 


### PR DESCRIPTION
## Summary
- Adds a model-level `unique (field_a, field_b, ...)` directive so Kilnx models can express multi-column uniqueness without raw SQL. Accepts two or more fields; reference fields resolve to their `<name>_id` column.
- Migration emits `CREATE UNIQUE INDEX IF NOT EXISTS "uq_<table>_<col>_<col>" ON "<table>" (...)`, idempotent on SQLite and PostgreSQL, driven from a single code path for new and existing tables.
- `kilnx check` rejects unknown field names inside the directive, fields repeated within a single group, and duplicated groups across the model.

## Syntax

```kilnx
model membership
  user: user required
  project: project required
  role: option [owner, admin, member] default member
  unique (user, project)
```

Multiple `unique (...)` lines are allowed on the same model for independent composite groups. Single-column uniqueness continues to use the field-level `unique` constraint.

## Implementation notes
- Lexer: adds `TokenParenOpen` / `TokenParenClose`; parens were previously silently skipped so no existing grammar relies on them. SQL is captured from the raw source line, not reconstructed from tokens, so adding these tokens does not affect any query path.
- Parser: `Model.UniqueConstraints [][]string`; `parseModel` peeks for `unique (` and dispatches to `parseUniqueDirective`, which rejects groups with fewer than two fields and unclosed parens.
- Analyzer: `checkUniqueConstraints` validates field existence, intra-group duplicates, and duplicate groups against the model.
- Database: `uniqueIndexDDLs` resolves field names to columns via `fieldToColumnName` and emits `CREATE UNIQUE INDEX IF NOT EXISTS`. Included in both the new-table and existing-table paths via a single append after the DDL block. `schemaHash` now includes the constraints so migration history invalidates correctly when they change.

## Docs
- `GRAMMAR.md`, `FEATURES.md`, `CHANGELOG.md`, `llms.txt`, `llms-full.txt`, `.cursor/rules/kilnx.mdc`.
- Docs site: `docs/content/guides/models.md`, `docs/content/reference/constraints.md` (grammar and changelog are synced from the root by `docs/build.sh`).

## Test plan
- [x] `go test -race ./...` green.
- [x] New parser tests cover the two-field, multi-group, single-field-rejection, unclosed-parens, and field-level-unique-still-works cases.
- [x] New database tests assert the emitted DDL shape, end-to-end UNIQUE violation against SQLite, migration idempotence (every statement uses `IF NOT EXISTS`), and `schemaHash` divergence when the directive is added.
- [x] New analyzer tests cover unknown field, repeat field inside a group, duplicate groups, and a valid baseline.
- [x] Manual smoke: `kilnx check` and `kilnx migrate` on a 3-model app with `unique (user, project)` produce the expected `CREATE UNIQUE INDEX`, and SQLite rejects a duplicate insert with `UNIQUE constraint failed: membership.user_id, membership.project_id`.