### PR TITLE
feat(docs): center nav menu

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -50,9 +50,10 @@ nav {
 }
 .nav-inner {
   margin: 0 auto; padding: 0 2rem;
-  height: var(--nav-height); display: flex; align-items: center; justify-content: space-between;
+  height: var(--nav-height); display: flex; align-items: center; gap: 2rem;
 }
 .nav-left, .nav-right { display: flex; align-items: center; gap: 1.5rem; }
+.nav-links { flex: 1; justify-content: center; }
 .nav-logo { display: flex; align-items: center; gap: 0.75rem; }
 .nav-logo img:first-child { width: 28px; height: 28px; filter: invert(1); }
 .nav-logo img:last-child { width: 80px; height: 18px; filter: invert(1); }

--- a/docs/template.html
+++ b/docs/template.html
@@ -20,16 +20,16 @@
         <img src="$root$assets/logos/kilnx-icon.svg" alt="">
         <img src="$root$assets/logos/kilnx-text.svg" alt="Kilnx">
       </a>
-      <div class="nav-links">
-        <a href="https://kilnx.org/#features">Features</a>
-        <a href="https://kilnx.org/#examples">Examples</a>
-        <a href="https://kilnx.org/#keywords">Language</a>
-        <a href="https://kilnx.org/#philosophy">Philosophy</a>
-        <a href="https://kilnx.org/#deploy">Deploy</a>
-        <a href="https://kilnx.org/playground.html">Playground</a>
-        <a href="$root$" class="active">Docs</a>
-        <a href="https://github.com/kilnx-org">GitHub</a>
-      </div>
+    </div>
+    <div class="nav-links">
+      <a href="https://kilnx.org/#features">Features</a>
+      <a href="https://kilnx.org/#examples">Examples</a>
+      <a href="https://kilnx.org/#keywords">Language</a>
+      <a href="https://kilnx.org/#philosophy">Philosophy</a>
+      <a href="https://kilnx.org/#deploy">Deploy</a>
+      <a href="https://kilnx.org/playground.html">Playground</a>
+      <a href="$root$" class="active">Docs</a>
+      <a href="https://github.com/kilnx-org">GitHub</a>
     </div>
     <div class="nav-right">
       <a href="https://discord.gg/AJcw5eee54" class="nav-icon-link" aria-label="Discord">


### PR DESCRIPTION
Mirror the landing nav restructure: lift nav-links out of nav-left so the menu centers via flex:1.