### PR TITLE
feat: non-unique index directive + LSP/MCP surfaces for composite directives

### DIFF
--- a/.cursor/rules/kilnx.mdc
+++ b/.cursor/rules/kilnx.mdc
@@ -68,7 +68,7 @@ Full references:
 
 `required` `unique` `default <val>` `auto` `min <n>` `max <n>`
 
-Composite UNIQUE: `unique (field_a, field_b, ...)` as a model-level line (two or more fields; references resolve to `_id` columns).
+Model-level directives: `unique (field_a, field_b, ...)` for composite UNIQUE (2+ fields); `index (field_a, field_b, ...)` for non-unique indexes (1+ fields). References resolve to `_id` columns.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versio
 ## [Unreleased]
 
 ### Added
+- Non-unique model-level `index (field_a, field_b, ...)` directive; emits idempotent `CREATE INDEX IF NOT EXISTS ix_<table>_<cols>` for query acceleration, validated by the analyzer the same way as composite UNIQUE
+- LSP and MCP surfaces advertise the composite `unique (...)` and `index (...)` directives; model hover lists declared groups
 - Composite UNIQUE via model-level `unique (field_a, field_b, ...)` directive; emits idempotent `CREATE UNIQUE INDEX IF NOT EXISTS` and is validated by the analyzer (unknown fields, duplicated fields within a group, or duplicate groups)
 - `tenant` modifier on `model` for multi-tenant scoping with fail-closed guards across every query path (refs [#48](https://github.com/kilnx-org/kilnx/issues/48), [#52](https://github.com/kilnx-org/kilnx/pull/52))
 - PostgreSQL support via `Dialect` abstraction; switch engines with `database: postgres://...` ([#46](https://github.com/kilnx-org/kilnx/pull/46))

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,6 +26,8 @@ Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `
 
 Composite uniqueness: declare `unique (field_a, field_b, ...)` at the model level for two or more fields. References resolve to their `_id` column automatically.
 
+Non-unique indexes: declare `index (field_a, field_b, ...)` at the model level for query acceleration. Single-column and multi-column are supported. Emits `CREATE INDEX IF NOT EXISTS ix_<table>_<cols>`.
+
 ## Auth
 
 Six lines. Registration, login, logout, bcrypt hashing, session cookies, and `current_user` available everywhere.

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -219,6 +219,26 @@ idempotent on both SQLite and PostgreSQL. Multiple `unique (...)` lines
 are allowed for independent groups. The analyzer rejects unknown field
 names, fields repeated within a group, and duplicate groups.
 
+#### non-unique indexes
+
+For query acceleration without a uniqueness requirement, declare an
+`index (...)` directive:
+
+```kilnx
+model order
+  customer: customer required
+  created: timestamp auto
+  status: option [pending, paid, shipped]
+  index (customer, created)
+  index (status)
+```
+
+Single-column and multi-column indexes are both supported. Migration
+emits `CREATE INDEX IF NOT EXISTS "ix_<table>_<cols>" ON "<table>"
+(...)`. The `ix_` prefix distinguishes non-unique indexes from the
+`uq_` prefix used by composite UNIQUE constraints. The same analyzer
+rules apply as for `unique (...)`.
+
 ### permissions
 
 Access rules by role.

--- a/docs/content/guides/models.md
+++ b/docs/content/guides/models.md
@@ -68,6 +68,21 @@ Rules:
 
 Migration emits `CREATE UNIQUE INDEX IF NOT EXISTS "uq_<table>_<col>_<col>" ON "<table>" (...)`, which is idempotent on SQLite and PostgreSQL. `kilnx check` rejects unknown field names, fields repeated within a group, and duplicated groups.
 
+## Non-unique indexes
+
+For query acceleration without uniqueness, declare an `index (...)` directive. Single-column and multi-column both work:
+
+```kilnx
+model order
+  customer: customer required
+  created: timestamp auto
+  status: option [pending, paid, shipped]
+  index (customer, created)
+  index (status)
+```
+
+Migration emits `CREATE INDEX IF NOT EXISTS "ix_<table>_<cols>" ON "<table>" (...)`. The `ix_` prefix keeps non-unique indexes separate from composite UNIQUE constraints (`uq_`). The analyzer applies the same validation rules as `unique (...)`.
+
 ## References (foreign keys)
 
 Use another model's name as the field type:

--- a/docs/content/reference/constraints.md
+++ b/docs/content/reference/constraints.md
@@ -109,6 +109,21 @@ Rules:
 
 Migration emits `CREATE UNIQUE INDEX IF NOT EXISTS "uq_&lt;table&gt;_&lt;col&gt;_&lt;col&gt;" ON "&lt;table&gt;" (...)`, safe to rerun on both SQLite and PostgreSQL.
 
+## Non-unique indexes
+
+For query acceleration without a uniqueness requirement, declare an `index (...)` directive inside the model. Single-column and multi-column are both valid:
+
+```kilnx
+model order
+  customer: customer required
+  created: timestamp auto
+  status: option [pending, paid, shipped]
+  index (customer, created)
+  index (status)
+```
+
+Migration emits `CREATE INDEX IF NOT EXISTS "ix_&lt;table&gt;_&lt;col&gt;_&lt;col&gt;" ON "&lt;table&gt;" (...)`. The `ix_` prefix keeps non-unique indexes distinguishable from composite UNIQUE indexes (`uq_`) in database tooling and migration history. `kilnx check` rejects unknown field names, fields repeated within a group, and duplicated groups.
+
 ## Combining constraints
 
 Constraints appear space-separated after the field type:
@@ -137,5 +152,6 @@ Order is not significant.
 | `min <n>` | Text (length) or numeric (value) | Lower bound |
 | `max <n>` | Text (length) or numeric (value) | Upper bound |
 | `unique (a, b, ...)` | Model-level, 2+ fields | Composite UNIQUE index |
+| `index (a, b, ...)` | Model-level, 1+ fields | Non-unique index |
 
-Total: 7 field constraints plus 1 model-level directive.
+Total: 7 field constraints plus 2 model-level directives.

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -125,6 +125,7 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkModelRefs(app, schema)...)
 	diags = append(diags, checkTenantRefs(app, schema)...)
 	diags = append(diags, checkUniqueConstraints(app)...)
+	diags = append(diags, checkIndexes(app)...)
 	diags = append(diags, checkAllSQL(app, schema)...)
 	diags = append(diags, checkSecurity(app, schema)...)
 	diags = append(diags, checkTemplateInterpolations(app, schema)...)
@@ -329,6 +330,54 @@ func checkUniqueConstraints(app *parser.App) []Diagnostic {
 				diags = append(diags, Diagnostic{
 					Level:   "error",
 					Message: fmt.Sprintf("duplicate unique constraint on model '%s': (%s)", m.Name, strings.Join(group, ", ")),
+					Context: "model " + m.Name,
+				})
+			}
+			seenGroups[key] = true
+		}
+	}
+	return diags
+}
+
+// checkIndexes validates each `index (a, b, ...)` directive the same way
+// as checkUniqueConstraints: declared field names exist on the model, no
+// repeats within a group, no duplicated groups.
+func checkIndexes(app *parser.App) []Diagnostic {
+	var diags []Diagnostic
+	for _, m := range app.Models {
+		if len(m.Indexes) == 0 {
+			continue
+		}
+		fieldSet := make(map[string]bool, len(m.Fields))
+		for _, f := range m.Fields {
+			fieldSet[f.Name] = true
+		}
+		seenGroups := make(map[string]bool)
+		for _, group := range m.Indexes {
+			seenInGroup := make(map[string]bool, len(group))
+			for _, name := range group {
+				if !fieldSet[name] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("index references unknown field '%s' on model '%s'", name, m.Name),
+						Context: "model " + m.Name,
+					})
+					continue
+				}
+				if seenInGroup[name] {
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("index on model '%s' repeats field '%s'", m.Name, name),
+						Context: "model " + m.Name,
+					})
+				}
+				seenInGroup[name] = true
+			}
+			key := strings.Join(group, "\x00")
+			if seenGroups[key] {
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("duplicate index on model '%s': (%s)", m.Name, strings.Join(group, ", ")),
 					Context: "model " + m.Name,
 				})
 			}

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -1954,3 +1954,48 @@ func TestAnalyze_UniqueConstraintValid(t *testing.T) {
 		}
 	}
 }
+
+func TestAnalyze_IndexUnknownField(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "m",
+			Fields: []parser.Field{
+				{Name: "a", Type: parser.FieldText},
+			},
+			Indexes: [][]string{{"a", "b"}},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "index references unknown field 'b'") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected unknown-field error for index, got: %+v", diags)
+	}
+}
+
+func TestAnalyze_IndexDuplicateGroup(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "m",
+			Fields: []parser.Field{
+				{Name: "a", Type: parser.FieldText},
+				{Name: "b", Type: parser.FieldText},
+			},
+			Indexes: [][]string{{"a", "b"}, {"a", "b"}},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "duplicate index") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected duplicate-index error, got: %+v", diags)
+	}
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -150,9 +150,59 @@ func (db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*pars
 		}
 
 		stmts = append(stmts, uniqueIndexDDLs(model)...)
+		stmts = append(stmts, indexDDLs(model)...)
 	}
 
 	return stmts, nil
+}
+
+// indexDDLs emits `CREATE INDEX IF NOT EXISTS` statements for each
+// non-unique `index (...)` group declared on the model. Index names
+// are prefixed with `ix_` to stay distinguishable from composite
+// UNIQUE indexes (`uq_`). Groups referencing unknown fields are
+// skipped; the analyzer surfaces the error.
+func indexDDLs(model parser.Model) []string {
+	if len(model.Indexes) == 0 {
+		return nil
+	}
+	byName := make(map[string]parser.Field, len(model.Fields))
+	for _, f := range model.Fields {
+		byName[f.Name] = f
+	}
+	var stmts []string
+	for _, group := range model.Indexes {
+		cols := make([]string, 0, len(group))
+		ok := true
+		for _, name := range group {
+			f, found := byName[name]
+			if !found {
+				ok = false
+				break
+			}
+			col := fieldToColumnName(f)
+			if !isValidIdentifier(col) {
+				ok = false
+				break
+			}
+			cols = append(cols, col)
+		}
+		if !ok || len(cols) == 0 {
+			continue
+		}
+		indexName := "ix_" + model.Name + "_" + strings.Join(cols, "_")
+		if !isValidIdentifier(indexName) {
+			continue
+		}
+		quoted := make([]string, len(cols))
+		for i, c := range cols {
+			quoted[i] = fmt.Sprintf("\"%s\"", c)
+		}
+		stmts = append(stmts, fmt.Sprintf(
+			"CREATE INDEX IF NOT EXISTS \"%s\" ON \"%s\" (%s)",
+			indexName, model.Name, strings.Join(quoted, ", "),
+		))
+	}
+	return stmts
 }
 
 // uniqueIndexDDLs emits `CREATE UNIQUE INDEX IF NOT EXISTS` statements for
@@ -292,6 +342,9 @@ func schemaHash(models []parser.Model) string {
 		}
 		for _, group := range m.UniqueConstraints {
 			fmt.Fprintf(&b, "  unique:%s\n", strings.Join(group, ","))
+		}
+		for _, group := range m.Indexes {
+			fmt.Fprintf(&b, "  index:%s\n", strings.Join(group, ","))
 		}
 	}
 	h := sha256.Sum256([]byte(b.String()))

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1136,3 +1136,87 @@ func TestSchemaHashIncludesUniqueConstraints(t *testing.T) {
 		t.Error("schemaHash must differ when composite UNIQUE groups differ")
 	}
 }
+
+// ---------- Non-unique indexes ----------
+
+func TestMigrateNonUniqueIndex(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{
+		{Name: "customer", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
+		{Name: "order", Fields: []parser.Field{
+			{Name: "customer", Type: parser.FieldReference, Reference: "customer", Required: true},
+			{Name: "created", Type: parser.FieldTimestamp},
+		}, Indexes: [][]string{{"customer", "created"}}},
+	}
+	stmts, err := db.Migrate(models)
+	if err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, `CREATE INDEX IF NOT EXISTS "ix_order_customer_id_created"`) &&
+			strings.Contains(s, `("customer_id", "created")`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected CREATE INDEX for ix_order_customer_id_created; got %v", stmts)
+	}
+	rows, err := db.QueryRows(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='order'`)
+	if err != nil {
+		t.Fatalf("sqlite_master query: %v", err)
+	}
+	var names []string
+	for _, r := range rows {
+		names = append(names, r["name"])
+	}
+	hasIx := false
+	for _, n := range names {
+		if n == "ix_order_customer_id_created" {
+			hasIx = true
+		}
+	}
+	if !hasIx {
+		t.Errorf("index not present in sqlite_master: %v", names)
+	}
+}
+
+func TestMigrateIndexIdempotent(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{{
+		Name:    "tag",
+		Fields:  []parser.Field{{Name: "scope", Type: parser.FieldText}, {Name: "name", Type: parser.FieldText}},
+		Indexes: [][]string{{"scope", "name"}},
+	}}
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("first Migrate: %v", err)
+	}
+	stmts, err := db.Migrate(models)
+	if err != nil {
+		t.Fatalf("second Migrate: %v", err)
+	}
+	for _, s := range stmts {
+		if strings.Contains(s, "CREATE INDEX") && !strings.Contains(s, "IF NOT EXISTS") {
+			t.Errorf("expected IF NOT EXISTS guard, got %q", s)
+		}
+	}
+}
+
+func TestSchemaHashIncludesIndexes(t *testing.T) {
+	a := []parser.Model{{
+		Name:    "m",
+		Fields:  []parser.Field{{Name: "x", Type: parser.FieldText}},
+		Indexes: [][]string{{"x"}},
+	}}
+	b := []parser.Model{{
+		Name:   "m",
+		Fields: []parser.Field{{Name: "x", Type: parser.FieldText}},
+	}}
+	if schemaHash(a) == schemaHash(b) {
+		t.Error("schemaHash must differ when index groups differ")
+	}
+}

--- a/internal/lsp/lsp.go
+++ b/internal/lsp/lsp.go
@@ -360,10 +360,21 @@ func getHover(content string, pos position) *hoverResult {
 				}
 				fields = append(fields, fmt.Sprintf("- **%s**: %s%s", f.Name, f.Type, constraint))
 			}
+			var extras []string
+			for _, g := range m.UniqueConstraints {
+				extras = append(extras, fmt.Sprintf("- unique (%s)", strings.Join(g, ", ")))
+			}
+			for _, g := range m.Indexes {
+				extras = append(extras, fmt.Sprintf("- index (%s)", strings.Join(g, ", ")))
+			}
+			body := strings.Join(fields, "\n")
+			if len(extras) > 0 {
+				body += "\n\n**Indexes**\n" + strings.Join(extras, "\n")
+			}
 			return &hoverResult{
 				Contents: markupContent{
 					Kind:  "markdown",
-					Value: fmt.Sprintf("**model %s**\n\n%s", m.Name, strings.Join(fields, "\n")),
+					Value: fmt.Sprintf("**model %s**\n\n%s", m.Name, body),
 				},
 			}
 		}
@@ -928,6 +939,8 @@ var fieldTypes = []keywordInfo{
 	{"auto", "Field constraint: auto-generated"},
 	{"min", "Field constraint: minimum value"},
 	{"max", "Field constraint: maximum value"},
+	{"unique (...)", "Composite UNIQUE: unique (field_a, field_b, ...)"},
+	{"index (...)", "Non-unique index: index (field_a, field_b, ...)"},
 }
 
 var keywordDocs = map[string]string{
@@ -962,7 +975,8 @@ var keywordDocs = map[string]string{
 	"float":        "Floating point type. Maps to SQLite REAL.",
 	"password":     "Password type. Automatically hashed with bcrypt on INSERT.",
 	"required":     "Field constraint: value must be non-null.",
-	"unique":       "Field constraint: value must be unique across all rows.",
+	"unique":       "Field constraint: value must be unique across all rows. For multi-column uniqueness, declare a model-level `unique (field_a, field_b, ...)` directive instead.",
+	"index":        "Model-level directive: `index (field_a, field_b, ...)` creates a non-unique index (`CREATE INDEX IF NOT EXISTS ix_<table>_<cols>`). Use for query acceleration.",
 	"optional":     "Field constraint: value can be null.",
 	"default":      "Field constraint: provides a default value if none specified.",
 	"retry":        "Job retry count. Syntax: `retry N`. Failed jobs retry with exponential backoff.",

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -376,6 +376,7 @@ func buildKeywordRef() string {
 	}
 
 	sb.WriteString("\n## Constraints\n\nrequired, unique, default, auto, min, max\n")
+	sb.WriteString("\n## Model-level directives\n\n`unique (field_a, field_b, ...)` — composite UNIQUE (2+ fields).\n`index (field_a, field_b, ...)` — non-unique index.\nReference fields resolve to their `<name>_id` column.\n")
 	return sb.String()
 }
 
@@ -469,7 +470,8 @@ var keywordDocs = map[string]string{
 	"uuid":        "UUID v4. Use `auto` to generate on INSERT. Maps to TEXT/UUID.",
 	"bigint":      "64-bit integer. Maps to INTEGER/BIGINT.",
 	"required":    "Field constraint: value must be non-null.",
-	"unique":      "Field constraint: value must be unique across all rows.",
+	"unique":      "Field constraint: value must be unique across all rows. For multi-column uniqueness, use a model-level `unique (field_a, field_b, ...)` directive instead.",
+	"index":       "Model-level directive inside a model block: `index (field_a, field_b, ...)` creates a non-unique database index prefixed `ix_<table>_<cols>`. Reference fields resolve to their `<name>_id` column.",
 	"default":     "Field constraint: provides a default value if none specified. Example: `status: text default \"active\"`.",
 	"auto":        "Field constraint: auto-generated value. On timestamp fields: current time on INSERT. On uuid fields: UUID v4 on INSERT.",
 	"auto_update": "Field constraint: auto-set field to current timestamp on every UPDATE. Creates a DB trigger. Use on timestamp fields for updated_at pattern.",
@@ -488,6 +490,8 @@ Top-level blocks: config, model, auth, permissions, layout, page, action, fragme
 Field types: text, email, int, float, bool, timestamp, date, richtext, option, password, image, phone, reference, url, decimal, file, tags, json, uuid, bigint
 
 Constraints: required, unique, default, auto, auto_update, min, max
+
+Model-level directives (separate lines inside a model block): unique (a, b, ...) for composite UNIQUE (2+ fields), index (a, b, ...) for non-unique indexes. Reference fields resolve to <name>_id.
 
 Body keywords: query, validate, redirect, html, send, enqueue, broadcast, on, requires, fetch, respond
 
@@ -531,6 +535,10 @@ const grammarSummary = `# Kilnx Grammar Summary
 
   Field types: text, email, int, float, bool, timestamp, richtext, option, password, image, phone
   Constraints: required, unique, default <val>, auto, min <n>, max <n>
+
+  Model-level directives:
+    unique (a, b, ...)   — composite UNIQUE (requires 2+ fields)
+    index (a, b, ...)    — non-unique index (query acceleration)
 
 ## auth block
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -175,6 +175,9 @@ type Model struct {
 	// names as written; references resolve to their `<name>_id` column
 	// at DDL generation time.
 	UniqueConstraints [][]string
+	// Indexes lists non-unique indexes declared with `index (a, b, ...)`
+	// directives. Same field-name resolution as UniqueConstraints.
+	Indexes [][]string
 }
 
 // CustomFieldKind is the type of a runtime-extensible custom field.
@@ -661,6 +664,17 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 			continue
 		}
 
+		// index (a, b, ...) is a non-unique index directive.
+		if (tok.Type == lexer.TokenIdentifier || tok.Type == lexer.TokenKeyword) &&
+			tok.Value == "index" && p.peekIsIndexDirective() {
+			group, err := p.parseIndexDirective()
+			if err != nil {
+				return model, err
+			}
+			model.Indexes = append(model.Indexes, group)
+			continue
+		}
+
 		// unique (a, b, ...) is a composite UNIQUE constraint directive.
 		// Distinguished from the field-level `unique` constraint by the
 		// presence of '(' immediately after.
@@ -714,6 +728,55 @@ func (p *parserState) parseModel(app *App) (Model, error) {
 	}
 
 	return model, nil
+}
+
+// peekIsIndexDirective reports whether the tokens at the current position
+// match `index (` (a non-unique index directive).
+func (p *parserState) peekIsIndexDirective() bool {
+	if p.pos+1 >= len(p.tokens) {
+		return false
+	}
+	return p.tokens[p.pos+1].Type == lexer.TokenParenOpen
+}
+
+// parseIndexDirective consumes `index ( ident (, ident)* )` and returns
+// the list of field names. Single-column indexes are allowed (they
+// accelerate non-equality predicates and sorts in ways that a UNIQUE
+// index would not).
+func (p *parserState) parseIndexDirective() ([]string, error) {
+	line := p.current().Line
+	p.advance() // consume 'index'
+	if p.current().Type != lexer.TokenParenOpen {
+		return nil, fmt.Errorf("line %d: expected '(' after 'index'", line)
+	}
+	p.advance() // consume '('
+
+	var names []string
+	for !p.isEOF() && p.current().Type != lexer.TokenParenClose {
+		tok := p.current()
+		if tok.Type == lexer.TokenComma {
+			p.advance()
+			continue
+		}
+		if tok.Type != lexer.TokenIdentifier && tok.Type != lexer.TokenKeyword {
+			return nil, fmt.Errorf("line %d: expected field name in index(), got %q", tok.Line, tok.Value)
+		}
+		names = append(names, tok.Value)
+		p.advance()
+	}
+	if p.isEOF() || p.current().Type != lexer.TokenParenClose {
+		return nil, fmt.Errorf("line %d: unclosed index(...) directive", line)
+	}
+	p.advance() // consume ')'
+
+	if len(names) == 0 {
+		return nil, fmt.Errorf("line %d: index() requires at least one field", line)
+	}
+
+	for !p.isEOF() && p.current().Type != lexer.TokenNewline && p.current().Type != lexer.TokenDedent {
+		p.advance()
+	}
+	return names, nil
 }
 
 // peekIsUniqueDirective reports whether the tokens at the current position

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1245,3 +1245,71 @@ func TestParseFieldLevelUniqueStillWorks(t *testing.T) {
 		t.Error("composite constraints should be empty for field-level unique")
 	}
 }
+
+func TestParseIndexDirective_Simple(t *testing.T) {
+	src := `model order
+  customer: user required
+  created: timestamp auto
+  index (customer, created)
+`
+	app := parse(t, src)
+	m := app.Models[0]
+	if len(m.Indexes) != 1 {
+		t.Fatalf("expected 1 index group, got %d", len(m.Indexes))
+	}
+	g := m.Indexes[0]
+	if len(g) != 2 || g[0] != "customer" || g[1] != "created" {
+		t.Errorf("unexpected index group: %#v", g)
+	}
+}
+
+func TestParseIndexDirective_SingleFieldAllowed(t *testing.T) {
+	src := `model order
+  status: text
+  index (status)
+`
+	app := parse(t, src)
+	if len(app.Models[0].Indexes) != 1 || len(app.Models[0].Indexes[0]) != 1 {
+		t.Errorf("single-field index should be accepted: %+v", app.Models[0].Indexes)
+	}
+}
+
+func TestParseIndexDirective_MultipleGroups(t *testing.T) {
+	src := `model order
+  a: text
+  b: text
+  c: text
+  index (a, b)
+  index (c)
+`
+	app := parse(t, src)
+	if len(app.Models[0].Indexes) != 2 {
+		t.Fatalf("expected 2 index groups, got %d", len(app.Models[0].Indexes))
+	}
+}
+
+func TestParseIndexDirective_EmptyRejected(t *testing.T) {
+	src := `model m
+  a: text
+  index ()
+`
+	_, err := parseAllowErrors(t, src)
+	if err == nil {
+		t.Fatal("expected error for empty index()")
+	}
+}
+
+func TestParseIndexAndUniqueCoexist(t *testing.T) {
+	src := `model m
+  a: text
+  b: text
+  c: text
+  unique (a, b)
+  index (b, c)
+`
+	app := parse(t, src)
+	m := app.Models[0]
+	if len(m.UniqueConstraints) != 1 || len(m.Indexes) != 1 {
+		t.Errorf("expected 1 unique and 1 index, got %d/%d", len(m.UniqueConstraints), len(m.Indexes))
+	}
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -677,6 +677,8 @@ Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `
 
 Composite uniqueness: add a `unique (field_a, field_b, ...)` line at the model level for two or more fields. References resolve to their `_id` column. The migration emits an idempotent `CREATE UNIQUE INDEX IF NOT EXISTS`.
 
+Non-unique indexes: add an `index (field_a, field_b, ...)` line at the model level for query acceleration. Single-column and multi-column indexes are both supported. The migration emits an idempotent `CREATE INDEX IF NOT EXISTS ix_<table>_<cols>`.
+
 ## Auth
 
 Six lines. Registration, login, logout, bcrypt hashing, session cookies, and `current_user` available everywhere.

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@ Top-level blocks: `config`, `model`, `auth`, `permissions`, `layout`, `page`, `a
 
 Field types: `text`, `email`, `int`, `float`, `bool`, `timestamp`, `richtext`, `option`, `password`, `image`, `phone`.
 
-Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`. Composite UNIQUE on a model: `unique (field_a, field_b, ...)` as a separate line (two or more fields; references resolve to their `_id` column).
+Constraints: `required`, `unique`, `default`, `auto`, `min`, `max`. Model-level directives: `unique (field_a, field_b, ...)` for composite UNIQUE (2+ fields), `index (field_a, field_b, ...)` for non-unique indexes (1+ fields). References resolve to `_id` columns.
 
 ## CLI
 


### PR DESCRIPTION
## Summary
- Adds a model-level `index (field_a, field_b, ...)` directive for non-unique indexes. Single-column and multi-column both work; emits `CREATE INDEX IF NOT EXISTS "ix_<table>_<cols>" ON "<table>" (...)`. The `ix_` prefix keeps these distinguishable from composite UNIQUE (`uq_`) in database tooling and migration history.
- Exposes both the existing `unique (...)` (shipped in [#88](https://github.com/kilnx-org/kilnx/pull/88)) and the new `index (...)` through LSP and MCP: hover on a model name lists the declared groups, completion advertises the directives, and the quick-reference strings that the MCP server sends to agents mention them.
- Same analyzer rules as composite UNIQUE: unknown fields, fields repeated within a group, and duplicated groups are compile-time errors.

## Syntax

```kilnx
model order
  customer: customer required
  created: timestamp auto
  status: option [pending, paid, shipped]
  index (customer, created)
  index (status)
```

## Why
`unique (...)` closed the declarative gap for composite UNIQUE but the non-unique case, indexing for query acceleration, still forced raw SQL migrations. This finishes the pair without introducing a second spelling for UNIQUE (it stays `unique (...)` only).

## Implementation notes
- Parser: `Model.Indexes [][]string`; `parseModel` peeks for `index (` and dispatches to `parseIndexDirective`. Rejects empty groups and unclosed parens.
- Analyzer: `checkIndexes` mirrors `checkUniqueConstraints`.
- Database: `indexDDLs(model)` resolves field names to columns via `fieldToColumnName` and emits idempotent `CREATE INDEX IF NOT EXISTS`. `schemaHash` includes the groups.
- LSP: hover on a model name appends an `Indexes` section listing `unique (...)` and `index (...)` groups. Completion exposes `unique (...)` and `index (...)` inside model blocks. `keywordDocs` updated.
- MCP: grammar summary and quick-ref strings updated.

## Docs
- `GRAMMAR.md`, `FEATURES.md`, `CHANGELOG.md`, `llms.txt`, `llms-full.txt`, `.cursor/rules/kilnx.mdc`.
- Docs site: `docs/content/guides/models.md` and `docs/content/reference/constraints.md` (grammar/changelog are synced from the repo root by `docs/build.sh`).

## Test plan
- [x] `go test -race ./...` green.
- [x] New parser tests: single-field index, multi-field, multiple groups, empty rejected, coexistence with `unique (...)`.
- [x] New database tests: DDL shape, sqlite_master verification, idempotence, `schemaHash` divergence.
- [x] New analyzer tests: unknown field, duplicate groups.
- [x] Manual smoke: `kilnx migrate` on a 2-model app with `index (customer, created)` and `index (status)` produces the expected statements; `sqlite_master` lists both indexes.