### PR TITLE
feat(dev): serve /_static/ with no-cache headers under `kilnx run`

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -127,6 +127,9 @@ func cmdCheck(filename, dbURL string) error {
 }
 
 func cmdRun(filename string) error {
+	if os.Getenv("KILNX_DEV") == "" {
+		os.Setenv("KILNX_DEV", "1")
+	}
 	app, err := loadApp(filename)
 	if err != nil {
 		return err

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -133,7 +133,13 @@ func (s *Server) Start() error {
 			if info, err := os.Stat(absStatic); err == nil && info.IsDir() {
 				fileServer := http.FileServer(http.Dir(absStatic))
 				mux.Handle("/_static/", http.StripPrefix("/_static/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Set("Cache-Control", "public, max-age=3600")
+					if os.Getenv("KILNX_DEV") == "1" {
+						w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
+						w.Header().Set("Pragma", "no-cache")
+						w.Header().Set("Expires", "0")
+					} else {
+						w.Header().Set("Cache-Control", "public, max-age=3600")
+					}
 					fileServer.ServeHTTP(w, r)
 				})))
 				fmt.Printf("Serving static files from %s at /_static/\n", staticDir)


### PR DESCRIPTION
## Summary

Makes `kilnx run` emit `Cache-Control: no-store, no-cache, must-revalidate` on `/_static/` responses so CSS/JS edits are picked up immediately without a hard-reload or `?v=N` busting.

## Why

Default handler sets `Cache-Control: public, max-age=3600`, which is right for production but broken for the dev loop: edit `static/app.css`, refresh, still serves the stale bytes for an hour unless you bust the URL manually or clear the cache. The hot-reload story for `.kilnx` changes is already great — this plugs the gap for static assets.

## Change

- `cmd/kilnx/main.go`: `cmdRun` now defaults `KILNX_DEV=1` if unset.
- `internal/runtime/server.go`: `/_static/` handler switches on `KILNX_DEV==\"1\"`. When set, emits the no-cache triple; otherwise keeps the existing 1h public cache.

## Behaviour

| Invocation                  | `KILNX_DEV` | `/_static/` Cache-Control                             |
|-----------------------------|-------------|--------------------------------------------------------|
| `kilnx run app.kilnx`       | `1` (auto)  | `no-store, no-cache, must-revalidate`                 |
| `kilnx build` binary        | unset       | `public, max-age=3600` (unchanged)                    |
| Any invocation + `KILNX_DEV=1` | `1`      | `no-store, no-cache, must-revalidate`                 |
| Any invocation + `KILNX_DEV=0` | `0`      | `public, max-age=3600`                                |

User can always override by exporting `KILNX_DEV` explicitly.

## Test plan

- [x] `go build ./...` from repo root
- [x] `kilnx run` an app, `curl -I /_static/foo.css` → returns `Cache-Control: no-store, no-cache, must-revalidate`
- [x] Binary built with `go build -o kilnx ./cmd/kilnx`, run via compiled artefact, same response
- [ ] `KILNX_DEV=0 kilnx run` → falls back to `public, max-age=3600`
- [ ] Production binary (no env var) → unchanged behaviour