### PR TITLE
feat(dev): disable static asset cache during kilnx run

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -184,6 +184,9 @@ func cmdRun(filename string) error {
 		}
 	}
 
+	// Dev mode: disable static asset caching for hot-reload
+	os.Setenv("KILNX_DEV", "1")
+
 	return runtime.WatchAndServe(filename, db, port)
 }
 

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -133,7 +133,11 @@ func (s *Server) Start() error {
 			if info, err := os.Stat(absStatic); err == nil && info.IsDir() {
 				fileServer := http.FileServer(http.Dir(absStatic))
 				mux.Handle("/_static/", http.StripPrefix("/_static/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Set("Cache-Control", "public, max-age=3600")
+					if os.Getenv("KILNX_DEV") == "1" {
+						w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
+					} else {
+						w.Header().Set("Cache-Control", "public, max-age=3600")
+					}
 					fileServer.ServeHTTP(w, r)
 				})))
 				fmt.Printf("Serving static files from %s at /_static/\n", staticDir)


### PR DESCRIPTION
`kilnx run` now defaults `KILNX_DEV=1` and the `/_static/` handler emits `Cache-Control: no-store, no-cache, must-revalidate` when that flag is set.

Motivation: during development the CSS/JS hot-reload loop is broken by the default 1h public cache — any edit requires manual hard-reload or a `?v=N` query-string bump. With this change, `kilnx run` gives fresh bytes on every request; `kilnx build` artefacts keep the existing 1h cache header.

Behaviour outside `kilnx run` is unchanged: `KILNX_DEV` must be explicitly set to `1` to opt into the no-cache path, so production deploys are not affected unless the env var is set deliberately.

Closes #96