### PR TITLE
feat: parent-scope syntax {^field} for nested {{each}} blocks

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -104,6 +104,21 @@ page /dashboard requires auth
     {{end}}
 ```
 
+Nested loops can reference outer scope fields with `{^field}`:
+
+```kilnx
+page /user/:id
+  query u: select id, name from user where id = :id
+  query posts: select id, title from post where user_id = :id
+  html
+    {{each u}}
+    <h1>{name}</h1>
+    {{each posts}}
+      <a href="/user/{^id}/posts/{id}/delete">delete {title}</a>
+    {{end}}
+    {{end}}
+```
+
 ## Actions
 
 POST/PUT/DELETE mutations with validation, branching, and redirects.

--- a/GRAMMAR.md
+++ b/GRAMMAR.md
@@ -327,6 +327,21 @@ page /users layout main title "Users"
     {{end}}
 ```
 
+Nested `{{each}}` blocks can reference fields from outer loops with `{^field}` (one level up), `{^^field}` (two levels), etc.:
+
+```kilnx
+page /user/:id
+  query u: select id, name from user where id = :id
+  query posts: select id, title from post where user_id = :id
+  html
+    {{each u}}
+    <h1>{name}</h1>
+    {{each posts}}
+      <a href="/user/{^id}/posts/{id}/delete">delete {title}</a>
+    {{end}}
+    {{end}}
+```
+
 With auth:
 
 ```kilnx

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -1711,6 +1711,138 @@ func TestCheckTemplateInterpolations_Fragment(t *testing.T) {
 	}
 }
 
+func TestCheckTemplateInterpolations_ParentScopeValid(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "id", Type: parser.FieldInt},
+				{Name: "name", Type: parser.FieldText},
+			},
+		}, {
+			Name: "post",
+			Fields: []parser.Field{
+				{Name: "id", Type: parser.FieldInt},
+				{Name: "title", Type: parser.FieldText},
+				{Name: "user_id", Type: parser.FieldInt},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "users", SQL: "SELECT id, name FROM user"},
+				{Type: parser.NodeQuery, Name: "posts", SQL: "SELECT id, title FROM post WHERE user_id = :id"},
+				{Type: parser.NodeHTML, HTMLContent: `{{each users}}<div>{{each posts}}<a href="/user/{^id}/posts/{id}">{title}</a>{{end}}</div>{{end}}`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "template reference") {
+			t.Errorf("unexpected template error: %s", d.Message)
+		}
+	}
+}
+
+func TestCheckTemplateInterpolations_ParentScopeInvalidField(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "id", Type: parser.FieldInt},
+			},
+		}, {
+			Name: "post",
+			Fields: []parser.Field{
+				{Name: "id", Type: parser.FieldInt},
+				{Name: "title", Type: parser.FieldText},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "users", SQL: "SELECT id FROM user"},
+				{Type: parser.NodeQuery, Name: "posts", SQL: "SELECT id, title FROM post"},
+				{Type: parser.NodeHTML, HTMLContent: `{{each users}}{{each posts}}<span>{^nonexistent}</span>{{end}}{{end}}`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "{^nonexistent}") && strings.Contains(d.Message, "does not exist") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error for invalid parent-scope field, got: %v", diags)
+	}
+}
+
+func TestCheckTemplateInterpolations_ParentScopeTooDeep(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "id", Type: parser.FieldInt},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/users",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "users", SQL: "SELECT id FROM user"},
+				{Type: parser.NodeHTML, HTMLContent: `{{each users}}<span>{^^id}</span>{{end}}`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "{^^id}") && strings.Contains(d.Message, "exceeds") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error for too-deep parent scope, got: %v", diags)
+	}
+}
+
+func TestCheckTemplateInterpolations_ParentScopeMultiLevel(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "a",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			},
+		}, {
+			Name: "b",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			},
+		}, {
+			Name: "c",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/test",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, Name: "a", SQL: "SELECT name FROM a"},
+				{Type: parser.NodeQuery, Name: "b", SQL: "SELECT name FROM b"},
+				{Type: parser.NodeQuery, Name: "c", SQL: "SELECT name FROM c"},
+				{Type: parser.NodeHTML, HTMLContent: `{{each a}}<a>{name}</a>{{each b}}<b>{name}</b>{{each c}}<c>{^^name}</c>{{end}}{{end}}</a>{{end}}`},
+			},
+		}},
+	}
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Level == "error" && strings.Contains(d.Message, "template reference") {
+			t.Errorf("unexpected template error: %s", d.Message)
+		}
+	}
+}
+
 func TestQueryModelMap(t *testing.T) {
 	pages := []parser.Page{{
 		Path: "/users",

--- a/internal/analyzer/types.go
+++ b/internal/analyzer/types.go
@@ -9,8 +9,8 @@ import (
 	"github.com/kilnx-org/kilnx/internal/parser"
 )
 
-// templateInterpolationRe matches {queryName.field} patterns in HTML content.
-var templateInterpolationRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)\}`)
+// templateInterpolationRe matches {queryName.field}, {field}, {^field}, {^^field}, etc. patterns in HTML content.
+var templateInterpolationRe = regexp.MustCompile(`\{(\^*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\}`)
 
 // ColumnInfo holds the inferred type for a single database column.
 type ColumnInfo struct {
@@ -505,6 +505,115 @@ var reservedInterpolations = map[string]bool{
 
 // checkTemplateInterpolations validates {queryName.field} references inside
 // HTML content of pages, fragments, and layouts against the schema.
+// findMatchingEnd finds the body, else body, and position after {{end}} for a block,
+// accounting for nested {{each}}/{{if}} blocks.
+func findMatchingEnd(content string) (body, elseBody string, endPos int) {
+	depth := 1
+	pos := 0
+	bodyEnd := -1
+	elseStart := -1
+
+	for pos < len(content) {
+		nextTag := strings.Index(content[pos:], "{{")
+		if nextTag < 0 {
+			return "", "", -1
+		}
+		nextTag += pos
+
+		closeTag := strings.Index(content[nextTag:], "}}")
+		if closeTag < 0 {
+			return "", "", -1
+		}
+		closeTag += nextTag + 2
+
+		tagInner := strings.TrimSpace(content[nextTag+2 : closeTag-2])
+
+		if strings.HasPrefix(tagInner, "each ") || strings.HasPrefix(tagInner, "if ") {
+			depth++
+		} else if tagInner == "end" {
+			depth--
+			if depth == 0 {
+				if elseStart >= 0 {
+					body = content[:bodyEnd]
+					elseBody = content[elseStart:nextTag]
+				} else {
+					body = content[:nextTag]
+				}
+				return body, elseBody, closeTag
+			}
+		} else if tagInner == "else" && depth == 1 {
+			bodyEnd = nextTag
+			elseStart = closeTag
+		}
+
+		pos = closeTag
+	}
+
+	return "", "", -1
+}
+
+// eachBlock represents a single {{each queryName}}...{{end}} span in HTML.
+type eachBlock struct {
+	start     int
+	end       int
+	queryName string
+}
+
+// findEachBlocks returns all {{each}} blocks in the given text, including nested ones.
+func findEachBlocks(text string) []eachBlock {
+	var blocks []eachBlock
+	remaining := text
+	offset := 0
+	for {
+		idx := strings.Index(remaining, "{{each ")
+		if idx < 0 {
+			break
+		}
+		tagEnd := strings.Index(remaining[idx:], "}}")
+		if tagEnd < 0 {
+			break
+		}
+		tagEnd += idx + 2
+		queryName := strings.TrimSpace(remaining[idx+7 : tagEnd-2])
+		bodyStart := tagEnd
+		body, _, endPos := findMatchingEnd(remaining[bodyStart:])
+		if endPos < 0 {
+			break
+		}
+		absStart := offset + idx
+		absEnd := offset + bodyStart + endPos
+		blocks = append(blocks, eachBlock{
+			start:     absStart,
+			end:       absEnd,
+			queryName: queryName,
+		})
+		if body != "" {
+			nested := findEachBlocks(body)
+			for i := range nested {
+				nested[i].start += absStart + (tagEnd - idx)
+				nested[i].end += absStart + (tagEnd - idx)
+			}
+			blocks = append(blocks, nested...)
+		}
+		remaining = remaining[bodyStart+endPos:]
+		offset += bodyStart + endPos
+	}
+	return blocks
+}
+
+// countEachEnclosing returns the names of {{each}} blocks that enclose the given position.
+func countEachEnclosing(pos int, blocks []eachBlock) []string {
+	var names []string
+	for _, b := range blocks {
+		if pos >= b.start && pos < b.end {
+			names = append(names, b.queryName)
+		}
+	}
+	return names
+}
+
+// checkTemplateInterpolations validates {queryName.field}, {^field}, and bare {field}
+// references inside HTML content of pages, fragments, and layouts against the schema.
 func checkTemplateInterpolations(app *parser.App, schema *Schema) []Diagnostic {
 	qMap := queryModelMap(app.Pages, app.Fragments, app.APIs)
 
@@ -560,10 +669,64 @@ func checkTemplateInterpolations(app *parser.App, schema *Schema) []Diagnostic {
 			if html == "" {
 				continue
 			}
-			matches := templateInterpolationRe.FindAllStringSubmatch(html, -1)
+			blocks := findEachBlocks(html)
+			matches := templateInterpolationRe.FindAllStringSubmatchIndex(html, -1)
 			for _, m := range matches {
-				queryName := m[1]
-				fieldName := m[2]
+				expr := html[m[2]:m[3]]
+				pos := m[0]
+
+				// Parent-scope reference: {^field}, {^^field}, etc.
+				if strings.HasPrefix(expr, "^") {
+					depth := 0
+					for depth < len(expr) && expr[depth] == '^' {
+						depth++
+					}
+					field := expr[depth:]
+					eachNames := countEachEnclosing(pos, blocks)
+					eachDepth := len(eachNames)
+					if depth >= eachDepth {
+						diags = append(diags, Diagnostic{
+							Level:   "error",
+							Message: fmt.Sprintf("template reference '{%s}': parent scope level %d exceeds available {{each}} nesting depth %d", expr, depth, eachDepth),
+							Context: context,
+						})
+						continue
+					}
+					// The target query is the one at the appropriate nesting level
+					targetQuery := eachNames[eachDepth-depth-1]
+					// Validate the field exists in the target query
+					modelName := ""
+					if mn, ok := localQueries[targetQuery]; ok {
+						modelName = mn
+					} else if mn, ok := qMap[targetQuery]; ok {
+						modelName = mn
+					}
+					if aliases, ok := localAliases[targetQuery]; ok && (aliases[field] || aliases["*"]) {
+						continue
+					}
+					if modelName != "" && modelName != "_fetch" {
+						if info, ok := schema.Tables[modelName]; ok {
+							if _, colExists := info.Columns[field]; !colExists {
+								diags = append(diags, Diagnostic{
+									Level:   "error",
+									Message: fmt.Sprintf("template reference '{%s}': field '%s' does not exist in query '%s' (model '%s')", expr, field, targetQuery, modelName),
+									Context: context,
+								})
+							}
+						}
+					}
+					continue
+				}
+
+				// Bare field: {field} — not statically validated (may be SQL alias, row field, etc.)
+				if !strings.Contains(expr, ".") {
+					continue
+				}
+
+				// queryName.field or queryName.count
+				parts := strings.SplitN(expr, ".", 2)
+				queryName := parts[0]
+				fieldName := parts[1]
 
 				if reservedInterpolations[queryName] {
 					continue
@@ -583,7 +746,7 @@ func checkTemplateInterpolations(app *parser.App, schema *Schema) []Diagnostic {
 				if modelName == "" {
 					diags = append(diags, Diagnostic{
 						Level:   "error",
-						Message: fmt.Sprintf("template reference '{%s.%s}' uses unknown query '%s'", queryName, fieldName, queryName),
+						Message: fmt.Sprintf("template reference '{%s}' uses unknown query '%s'", expr, queryName),
 						Context: context,
 					})
 					continue
@@ -601,7 +764,7 @@ func checkTemplateInterpolations(app *parser.App, schema *Schema) []Diagnostic {
 				if _, colExists := info.Columns[fieldName]; !colExists {
 					diags = append(diags, Diagnostic{
 						Level:   "error",
-						Message: fmt.Sprintf("template reference '{%s.%s}': field '%s' does not exist in model '%s'", queryName, fieldName, fieldName, modelName),
+						Message: fmt.Sprintf("template reference '{%s}': field '%s' does not exist in model '%s'", expr, fieldName, modelName),
 						Context: context,
 					})
 				}
@@ -622,10 +785,24 @@ func checkTemplateInterpolations(app *parser.App, schema *Schema) []Diagnostic {
 		if l.HTMLContent == "" {
 			continue
 		}
-		matches := templateInterpolationRe.FindAllStringSubmatch(l.HTMLContent, -1)
+		matches := templateInterpolationRe.FindAllStringSubmatchIndex(l.HTMLContent, -1)
 		for _, m := range matches {
-			queryName := m[1]
-			fieldName := m[2]
+			expr := l.HTMLContent[m[2]:m[3]]
+			if strings.HasPrefix(expr, "^") {
+				// Parent scope in layout makes no sense (no {{each}})
+				diags = append(diags, Diagnostic{
+					Level:   "error",
+					Message: fmt.Sprintf("template reference '{%s}': parent scope syntax is not valid in layouts", expr),
+					Context: fmt.Sprintf("layout %s", l.Name),
+				})
+				continue
+			}
+			if !strings.Contains(expr, ".") {
+				continue
+			}
+			parts := strings.SplitN(expr, ".", 2)
+			queryName := parts[0]
+			fieldName := parts[1]
 
 			if reservedInterpolations[queryName] {
 				continue
@@ -637,7 +814,7 @@ func checkTemplateInterpolations(app *parser.App, schema *Schema) []Diagnostic {
 			if _, ok := qMap[queryName]; !ok {
 				diags = append(diags, Diagnostic{
 					Level:   "error",
-					Message: fmt.Sprintf("template reference '{%s.%s}' uses unknown query '%s'", queryName, fieldName, queryName),
+					Message: fmt.Sprintf("template reference '{%s}' uses unknown query '%s'", expr, queryName),
 					Context: fmt.Sprintf("layout %s", l.Name),
 				})
 			}

--- a/internal/optimizer/optimizer.go
+++ b/internal/optimizer/optimizer.go
@@ -7,8 +7,8 @@ import (
 	"github.com/kilnx-org/kilnx/internal/parser"
 )
 
-// interpolateRe matches {queryName.field} patterns used in text/html interpolation.
-var interpolateRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)\}`)
+// interpolateRe matches {queryName.field}, {^field}, {^^field}, and bare {field} patterns.
+var interpolateRe = regexp.MustCompile(`\{(\^*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\}`)
 
 // selectStarRe matches SELECT * or SELECT DISTINCT * at the start of a SQL query (case-insensitive).
 var selectStarRe = regexp.MustCompile(`(?i)^(SELECT\s+(?:DISTINCT\s+)?)\*(\s+FROM\s+)`)
@@ -109,13 +109,52 @@ func collectUsedFields(nodes []parser.Node) map[string]*fieldSet {
 	return result
 }
 
-// addInterpolatedFields extracts {queryName.field} references from text
+// addInterpolatedFields extracts {queryName.field} and {^field} references from text
 // and adds the fields to the appropriate query's field set.
 func addInterpolatedFields(result map[string]*fieldSet, text string) {
-	matches := interpolateRe.FindAllStringSubmatch(text, -1)
+	blocks := findEachBlocks(text)
+	matches := interpolateRe.FindAllStringSubmatchIndex(text, -1)
 	for _, m := range matches {
-		queryName := m[1]
-		field := m[2]
+		expr := text[m[2]:m[3]]
+
+		// Parent-scope reference: {^field}, {^^field}, etc.
+		if strings.HasPrefix(expr, "^") {
+			depth := 0
+			for depth < len(expr) && expr[depth] == '^' {
+				depth++
+			}
+			field := expr[depth:]
+			if field == "" {
+				continue
+			}
+			eachNames := countEachEnclosing(m[0], blocks)
+			if depth > len(eachNames) {
+				continue
+			}
+			targetQuery := eachNames[len(eachNames)-depth-1]
+			if targetQuery == "" {
+				continue
+			}
+			if result[targetQuery] == nil && !hasKey(result, targetQuery) {
+				result[targetQuery] = newFieldSet()
+			}
+			fs := result[targetQuery]
+			if fs == nil {
+				continue
+			}
+			fs.add(field)
+			continue
+		}
+
+		// Bare field: {field} — cannot determine which query it belongs to
+		if !strings.Contains(expr, ".") {
+			continue
+		}
+
+		// queryName.field or queryName.count
+		parts := strings.SplitN(expr, ".", 2)
+		queryName := parts[0]
+		field := parts[1]
 		if field == "count" {
 			continue // built-in, not a real column
 		}
@@ -128,6 +167,113 @@ func addInterpolatedFields(result map[string]*fieldSet, text string) {
 		}
 		fs.add(field)
 	}
+}
+
+// eachBlock represents a single {{each queryName}}...{{end}} span.
+type eachBlock struct {
+	start     int
+	end       int
+	queryName string
+}
+
+// findMatchingEnd finds the body, else body, and position after {{end}} for a block,
+// accounting for nested {{each}}/{{if}} blocks.
+func findMatchingEnd(content string) (body, elseBody string, endPos int) {
+	depth := 1
+	pos := 0
+	bodyEnd := -1
+	elseStart := -1
+
+	for pos < len(content) {
+		nextTag := strings.Index(content[pos:], "{{")
+		if nextTag < 0 {
+			return "", "", -1
+		}
+		nextTag += pos
+
+		closeTag := strings.Index(content[nextTag:], "}}")
+		if closeTag < 0 {
+			return "", "", -1
+		}
+		closeTag += nextTag + 2
+
+		tagInner := strings.TrimSpace(content[nextTag+2 : closeTag-2])
+
+		if strings.HasPrefix(tagInner, "each ") || strings.HasPrefix(tagInner, "if ") {
+			depth++
+		} else if tagInner == "end" {
+			depth--
+			if depth == 0 {
+				if elseStart >= 0 {
+					body = content[:bodyEnd]
+					elseBody = content[elseStart:nextTag]
+				} else {
+					body = content[:nextTag]
+				}
+				return body, elseBody, closeTag
+			}
+		} else if tagInner == "else" && depth == 1 {
+			bodyEnd = nextTag
+			elseStart = closeTag
+		}
+
+		pos = closeTag
+	}
+
+	return "", "", -1
+}
+
+// findEachBlocks returns all {{each}} blocks in the given text, including nested ones.
+func findEachBlocks(text string) []eachBlock {
+	var blocks []eachBlock
+	remaining := text
+	offset := 0
+	for {
+		idx := strings.Index(remaining, "{{each ")
+		if idx < 0 {
+			break
+		}
+		tagEnd := strings.Index(remaining[idx:], "}}")
+		if tagEnd < 0 {
+			break
+		}
+		tagEnd += idx + 2
+		queryName := strings.TrimSpace(remaining[idx+7 : tagEnd-2])
+		bodyStart := tagEnd
+		body, _, endPos := findMatchingEnd(remaining[bodyStart:])
+		if endPos < 0 {
+			break
+		}
+		absStart := offset + idx
+		absEnd := offset + bodyStart + endPos
+		blocks = append(blocks, eachBlock{
+			start:     absStart,
+			end:       absEnd,
+			queryName: queryName,
+		})
+		if body != "" {
+			nested := findEachBlocks(body)
+			for i := range nested {
+				nested[i].start += absStart + (tagEnd - idx)
+				nested[i].end += absStart + (tagEnd - idx)
+			}
+			blocks = append(blocks, nested...)
+		}
+		remaining = remaining[bodyStart+endPos:]
+		offset += bodyStart + endPos
+	}
+	return blocks
+}
+
+// countEachEnclosing returns the names of {{each}} blocks that enclose the given position.
+func countEachEnclosing(pos int, blocks []eachBlock) []string {
+	var names []string
+	for _, b := range blocks {
+		if pos >= b.start && pos < b.end {
+			names = append(names, b.queryName)
+		}
+	}
+	return names
 }
 
 // extractPathParams pulls :param names from a URL path like /users/:id/edit.

--- a/internal/optimizer/optimizer_test.go
+++ b/internal/optimizer/optimizer_test.go
@@ -305,6 +305,100 @@ func TestRewrite_CaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestRewrite_ParentScopeField(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "id", Type: parser.FieldInt},
+				{Name: "name", Type: parser.FieldText},
+			},
+		}, {
+			Name: "post",
+			Fields: []parser.Field{
+				{Name: "id", Type: parser.FieldInt},
+				{Name: "title", Type: parser.FieldText},
+				{Name: "user_id", Type: parser.FieldInt},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/user/:id",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "u",
+					SQL:  "SELECT * FROM user WHERE id = :id",
+				},
+				{
+					Type: parser.NodeQuery,
+					Name: "posts",
+					SQL:  "SELECT * FROM post WHERE user_id = :id",
+				},
+				{
+					Type:        parser.NodeHTML,
+					HTMLContent: `{{each u}}<h1>{u.name}</h1>{{each posts}}<a href="/user/{^id}/posts/{id}">{title}</a>{{end}}{{end}}`,
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	// The {^id} reference inside {{each u}} should cause 'id' to be collected for query 'u'
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT id, name FROM user WHERE id = :id"
+	wantAlt := "SELECT name, id FROM user WHERE id = :id"
+	if got != want && got != wantAlt {
+		t.Errorf("parent-scope field not collected for outer query, got %q, want %q or %q", got, want, wantAlt)
+	}
+}
+
+func TestRewrite_ParentScopeFieldOnly(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name: "user",
+			Fields: []parser.Field{
+				{Name: "id", Type: parser.FieldInt},
+				{Name: "name", Type: parser.FieldText},
+			},
+		}, {
+			Name: "post",
+			Fields: []parser.Field{
+				{Name: "id", Type: parser.FieldInt},
+				{Name: "title", Type: parser.FieldText},
+			},
+		}},
+		Pages: []parser.Page{{
+			Path: "/user/:id",
+			Body: []parser.Node{
+				{
+					Type: parser.NodeQuery,
+					Name: "u",
+					SQL:  "SELECT * FROM user WHERE id = :id",
+				},
+				{
+					Type: parser.NodeQuery,
+					Name: "posts",
+					SQL:  "SELECT * FROM post WHERE user_id = :id",
+				},
+				{
+					Type:        parser.NodeHTML,
+					HTMLContent: `{{each u}}<h1>{name}</h1>{{each posts}}<a href="/user/{^id}/posts/{id}">{title}</a>{{end}}{{end}}`,
+				},
+			},
+		}},
+	}
+
+	Optimize(app)
+
+	// Bare {name} is not detected, but {^id} should be — so id must be in the rewritten query
+	got := app.Pages[0].Body[0].SQL
+	want := "SELECT id FROM user WHERE id = :id"
+	if got != want {
+		t.Errorf("parent-scope-only field not collected, got %q, want %q", got, want)
+	}
+}
+
 func TestRewrite_DedupFields(t *testing.T) {
 	app := &parser.App{
 		Pages: []parser.Page{{

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -26,10 +26,10 @@ import (
 //   {paginate.queryName.field}               - pagination metadata
 //   {params.key}                             - URL query parameter
 
-var rawFilterRe = regexp.MustCompile(`\{([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\|\s*raw\}`)
+var rawFilterRe = regexp.MustCompile(`\{(\^*[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\|\s*raw\}`)
 
 // filterRe matches {expr | filter} or {expr | filter1 | filter2: arg}
-var filterRe = regexp.MustCompile(`\{([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\|([^}]+)\}`)
+var filterRe = regexp.MustCompile(`\{(\^*[a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\|([^}]+)\}`)
 
 // parsedFilter represents a single filter in a chain
 type parsedFilter struct {
@@ -423,6 +423,8 @@ func expandEachBlocks(content string, ctx *renderContext, nonce string) string {
 			}
 		} else {
 			for _, row := range rows {
+				// Push current row onto eachStack for parent-scope resolution
+				ctx.eachStack = append(ctx.eachStack, row)
 				// Rebind q.custom per row so {{each q.custom}} works on list pages (#66)
 				if sourceModel, ok := ctx.querySourceModels[queryName]; ok {
 					if manifest, ok := ctx.customManifests[sourceModel]; ok {
@@ -438,6 +440,8 @@ func expandEachBlocks(content string, ctx *renderContext, nonce string) string {
 				// Interpolate row fields
 				expanded = interpolateRow(expanded, row, ctx)
 				result.WriteString(expanded)
+				// Pop row from eachStack
+				ctx.eachStack = ctx.eachStack[:len(ctx.eachStack)-1]
 			}
 		}
 
@@ -447,10 +451,12 @@ func expandEachBlocks(content string, ctx *renderContext, nonce string) string {
 	return result.String()
 }
 
-// processRawInRow handles {field | filters} inside {{each}} blocks where field comes from the current row
+// processRawInRow handles {field | filters} inside {{each}} blocks where field comes from the current row.
+// Skips expressions that are inside nested {{each}} blocks so the inner loop processes them.
 func processRawInRow(content string, row database.Row, ctx *renderContext, nonce string) string {
 	counter := 0
 	placeholders := make(map[string]string)
+	insideEach := isInsideEachBlock(content)
 
 	result := filterRe.ReplaceAllStringFunc(content, func(match string) string {
 		parts := filterRe.FindStringSubmatch(match)
@@ -459,6 +465,11 @@ func processRawInRow(content string, row database.Row, ctx *renderContext, nonce
 		}
 		expr := parts[1]
 		chain := strings.TrimSpace(parts[2])
+		// Skip if this expression is inside a nested {{each}} block
+		matchIdx := strings.Index(content, match)
+		if matchIdx >= 0 && insideEach(matchIdx) {
+			return match
+		}
 		val := resolveValue(expr, ctx, row)
 		if val == "{"+expr+"}" {
 			return match
@@ -747,9 +758,26 @@ func compareNumeric(a, b string) int {
 }
 
 // resolveValue resolves a template expression to its value.
-// Handles: "paginate.query.field", "params.key", "queryName.field", "queryName.count", bare "field"
+// Handles: "paginate.query.field", "params.key", "queryName.field", "queryName.count",
+// bare "field", and parent-scope "^field", "^^field", etc.
 // Returns the original "{expr}" string if not found.
 func resolveValue(expr string, ctx *renderContext, currentRow database.Row) string {
+	// Parent-scope reference: count leading ^ to walk up the eachStack
+	if strings.HasPrefix(expr, "^") {
+		depth := 0
+		for depth < len(expr) && expr[depth] == '^' {
+			depth++
+		}
+		field := expr[depth:]
+		if len(ctx.eachStack) > depth {
+			idx := len(ctx.eachStack) - depth - 1
+			if val, ok := ctx.eachStack[idx][field]; ok {
+				return val
+			}
+		}
+		return "{" + expr + "}"
+	}
+
 	allParts := strings.Split(expr, ".")
 
 	// paginate.queryName.field (3 parts)

--- a/internal/runtime/render_test.go
+++ b/internal/runtime/render_test.go
@@ -403,6 +403,67 @@ func TestRenderHTML_NestedEachBlocks(t *testing.T) {
 	}
 }
 
+func TestRenderHTML_NestedEachParentScope(t *testing.T) {
+	ctx := newTestContext()
+	ctx.queries["companies"] = []database.Row{{"id": "1", "name": "Acme"}, {"id": "2", "name": "Corp"}}
+	ctx.queries["people"] = []database.Row{{"id": "10", "name": "Alice"}, {"id": "11", "name": "Bob"}}
+
+	result := renderHTML(`{{each companies}}<div id="c{id}"><h2>{name}</h2>{{each people}}<li data-cid="{^id}" data-pid="{id}">{name}</li>{{end}}</div>{{end}}`, ctx)
+	if !strings.Contains(result, `<div id="c1">`) {
+		t.Errorf("expected outer id c1, got: %s", result)
+	}
+	if !strings.Contains(result, `<li data-cid="1" data-pid="10">`) {
+		t.Errorf("expected parent scope ^id=1 and inner id=10, got: %s", result)
+	}
+	if !strings.Contains(result, `<li data-cid="2" data-pid="11">`) {
+		t.Errorf("expected parent scope ^id=2 and inner id=11, got: %s", result)
+	}
+	if strings.Contains(result, "{^id}") {
+		t.Errorf("unresolved parent scope ref leaked: %s", result)
+	}
+}
+
+func TestRenderHTML_NestedEachParentScopeMultiLevel(t *testing.T) {
+	ctx := newTestContext()
+	ctx.queries["a"] = []database.Row{{"name": "A1"}}
+	ctx.queries["b"] = []database.Row{{"name": "B1"}}
+	ctx.queries["c"] = []database.Row{{"name": "C1"}}
+
+	result := renderHTML(`{{each a}}<a>{name}</a>{{each b}}<b>{name}</b>{{each c}}<c>{name}|{^^name}|{^name}</c>{{end}}{{end}}{{end}}`, ctx)
+	expected := "<c>C1|A1|B1</c>"
+	if !strings.Contains(result, expected) {
+		t.Errorf("expected multi-level parent scope %s, got: %s", expected, result)
+	}
+}
+
+func TestRenderHTML_NestedEachParentScopeNotFound(t *testing.T) {
+	ctx := newTestContext()
+	ctx.queries["outer"] = []database.Row{{"id": "1"}}
+	ctx.queries["inner"] = []database.Row{{"id": "10"}}
+
+	result := renderHTML(`{{each outer}}<o>{id}</o>{{each inner}}<i>{^id}</i><x>{^nonexistent}</x>{{end}}{{end}}`, ctx)
+	if !strings.Contains(result, "<o>1</o>") {
+		t.Errorf("expected outer id, got: %s", result)
+	}
+	if !strings.Contains(result, "<i>1</i>") {
+		t.Errorf("expected parent scope ^id=1, got: %s", result)
+	}
+	if !strings.Contains(result, "{^nonexistent}") {
+		t.Errorf("expected unresolved parent ref to stay literal, got: %s", result)
+	}
+}
+
+func TestRenderHTML_NestedEachParentScopeWithFilter(t *testing.T) {
+	ctx := newTestContext()
+	ctx.queries["companies"] = []database.Row{{"id": "1", "name": "Acme"}}
+	ctx.queries["people"] = []database.Row{{"id": "10", "name": "Alice"}}
+
+	result := renderHTML(`{{each companies}}{{each people}}<span>{^name | upcase} {name | upcase}</span>{{end}}{{end}}`, ctx)
+	if !strings.Contains(result, "<span>ACME ALICE</span>") {
+		t.Errorf("expected filtered parent scope ACME ALICE, got: %s", result)
+	}
+}
+
 func TestRenderHTML_IfWithNotEquals(t *testing.T) {
 	ctx := newTestContext()
 	ctx.queries["user"] = []database.Row{{"role": "admin"}}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -21,7 +21,7 @@ import (
 //go:embed static/htmx.min.js static/sse.js
 var staticFS embed.FS
 
-var interpolateRe = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\}`)
+var interpolateRe = regexp.MustCompile(`\{(\^*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\}`)
 
 type Server struct {
 	app               *parser.App
@@ -336,6 +336,7 @@ type renderContext struct {
 	queryParams       map[string]string                      // URL query parameters (?key=value)
 	querySourceModels map[string]string                      // query name -> primary model name (set by analyzer)
 	customManifests   map[string]*parser.CustomFieldManifest // model name -> manifest (for list-page rebinding)
+	eachStack         []database.Row                         // stack of active {{each}} rows for parent-scope resolution
 }
 
 func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Request) string {


### PR DESCRIPTION
## Problem

Inside nested `{{each}}` blocks, there was no documented syntax to reference a field from the parent scope. The workaround `{outerQuery.field}` resolved `rows[0]`, breaking silently when the outer query returned multiple rows.

## Solution

Introduce `{^field}` (one level up), `{^^field}` (two levels), etc.:

- **Runtime**: `eachStack` on `renderContext`; `resolveValue` walks the stack
- **Analyzer**: validates `{^field}` against parent queries; errors for unknown fields or excessive depth
- **Optimizer**: collects parent-scope fields so `SELECT *` rewriting includes columns referenced via `{^field}`

## Checklist

- [x] `go test -race ./...` passes
- [x] Documentation updated (GRAMMAR.md, FEATURES.md)

Fixes #95