### PR TITLE
feat: migration dataloss guard and kilnx init templates

### DIFF
--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"embed"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +18,9 @@ import (
 	"github.com/kilnx-org/kilnx/internal/parser"
 	"github.com/kilnx-org/kilnx/internal/runtime"
 )
+
+//go:embed templates/*.kilnx
+var templatesFS embed.FS
 
 var version = "dev"
 
@@ -87,6 +91,16 @@ func main() {
 		lsp.Serve()
 	case "mcp":
 		mcp.Serve()
+	case "init":
+		if len(os.Args) < 4 {
+			fmt.Println("Usage: kilnx init <template> <directory>")
+			fmt.Println("Templates: blog, api")
+			os.Exit(1)
+		}
+		if err := cmdInit(os.Args[2], os.Args[3]); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
 	case "version":
 		fmt.Printf("kilnx %s\n", version)
 	default:
@@ -94,6 +108,42 @@ func main() {
 		printUsage()
 		os.Exit(1)
 	}
+}
+
+func cmdInit(template, dir string) error {
+	valid := map[string]bool{"blog": true, "api": true}
+	if !valid[template] {
+		return fmt.Errorf("unknown template %q. Available: blog, api", template)
+	}
+
+	data, err := templatesFS.ReadFile("templates/" + template + ".kilnx")
+	if err != nil {
+		return fmt.Errorf("reading template: %w", err)
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("creating directory: %w", err)
+	}
+
+	projectName := filepath.Base(dir)
+	content := strings.ReplaceAll(string(data), "{{PROJECT_NAME}}", projectName)
+
+	outPath := filepath.Join(dir, "app.kilnx")
+	if _, err := os.Stat(outPath); err == nil {
+		return fmt.Errorf("%s already exists", outPath)
+	}
+
+	if err := os.WriteFile(outPath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("writing file: %w", err)
+	}
+
+	fmt.Printf("Created %s template in %s/\n", template, dir)
+	fmt.Printf("  %s\n", outPath)
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Printf("  cd %s\n", dir)
+	fmt.Println("  kilnx run app.kilnx")
+	return nil
 }
 
 func cmdCheck(filename, dbURL string) error {
@@ -175,6 +225,17 @@ func cmdRun(filename string) error {
 
 	// Auto-migrate if models exist
 	if len(app.Models) > 0 {
+		// Warn about orphan tables in dev mode, but don't block startup
+		if risks, err := db.DetectDataLossRisk(app.Models); err == nil && len(risks) > 0 {
+			fmt.Fprintln(os.Stderr, "kilnx warn: orphan tables with data detected:")
+			for _, r := range risks {
+				if r.Suggestion != "" {
+					fmt.Fprintf(os.Stderr, "  - '%s' (%d rows)  suggestion: %s\n", r.TableName, r.RowCount, r.Suggestion)
+				} else {
+					fmt.Fprintf(os.Stderr, "  - '%s' (%d rows)\n", r.TableName, r.RowCount)
+				}
+			}
+		}
 		stmts, err := db.Migrate(app.Models, app.CustomManifests)
 		if err != nil {
 			return err
@@ -193,12 +254,15 @@ func cmdRun(filename string) error {
 func cmdMigrate(filename string, flags []string) error {
 	dryRun := false
 	status := false
+	allowDataLoss := false
 	for _, f := range flags {
 		switch f {
 		case "--dry-run":
 			dryRun = true
 		case "--status":
 			status = true
+		case "--allow-dataloss":
+			allowDataLoss = true
 		}
 	}
 
@@ -227,6 +291,32 @@ func cmdMigrate(filename string, flags []string) error {
 
 	if err := db.MigrateInternal(); err != nil {
 		return err
+	}
+
+	// Detect tables with data that no longer map to any model
+	risks, err := db.DetectDataLossRisk(app.Models)
+	if err != nil {
+		return fmt.Errorf("checking data-loss risk: %w", err)
+	}
+	if len(risks) > 0 {
+		fmt.Println("WARNING: The following tables contain data but are no longer declared in your .kilnx file:")
+		for _, r := range risks {
+			if r.Suggestion != "" {
+				fmt.Printf("  - '%s' (%d rows)  suggestion: %s\n", r.TableName, r.RowCount, r.Suggestion)
+			} else {
+				fmt.Printf("  - '%s' (%d rows)\n", r.TableName, r.RowCount)
+			}
+		}
+		if !allowDataLoss {
+			fmt.Println()
+			fmt.Println("Migration blocked to prevent leaving data behind.")
+			fmt.Println("Use 'kilnx migrate <file.kilnx> --allow-dataloss' to proceed anyway,")
+			fmt.Println("or add a 'model <new> renames <old>' directive to preserve the data.")
+			return fmt.Errorf("migration blocked: potential data loss detected")
+		}
+		fmt.Println()
+		fmt.Println("Proceeding because --allow-dataloss was passed.")
+		fmt.Println()
 	}
 
 	if status {
@@ -533,12 +623,14 @@ func printUsage() {
 	fmt.Println("Usage: kilnx <command> [arguments]")
 	fmt.Println()
 	fmt.Println("Commands:")
+	fmt.Println("  init <template> <dir>   Create a new project from a template")
 	fmt.Println("  run <file.kilnx>        Start the server (auto-migrates)")
 	fmt.Println("  check <file.kilnx>      Run static analysis")
 	fmt.Println("  build <file.kilnx> [-o] Compile to standalone binary")
 	fmt.Println("  migrate <file.kilnx>    Apply database migrations")
 	fmt.Println("          --dry-run       Show SQL without applying")
 	fmt.Println("          --status        Show migration history and pending changes")
+	fmt.Println("          --allow-dataloss  Skip data-loss protection check")
 	fmt.Println("  test <file.kilnx>       Run declarative tests")
 	fmt.Println("  lsp                     Start Language Server Protocol server")
 	fmt.Println("  mcp                     Start Model Context Protocol server")

--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -121,17 +121,17 @@ func cmdInit(template, dir string) error {
 		return fmt.Errorf("reading template: %w", err)
 	}
 
+	outPath := filepath.Join(dir, "app.kilnx")
+	if _, err := os.Stat(outPath); err == nil {
+		return fmt.Errorf("%s already exists", outPath)
+	}
+
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating directory: %w", err)
 	}
 
 	projectName := filepath.Base(dir)
 	content := strings.ReplaceAll(string(data), "{{PROJECT_NAME}}", projectName)
-
-	outPath := filepath.Join(dir, "app.kilnx")
-	if _, err := os.Stat(outPath); err == nil {
-		return fmt.Errorf("%s already exists", outPath)
-	}
 
 	if err := os.WriteFile(outPath, []byte(content), 0644); err != nil {
 		return fmt.Errorf("writing file: %w", err)
@@ -311,7 +311,7 @@ func cmdMigrate(filename string, flags []string) error {
 			fmt.Println()
 			fmt.Println("Migration blocked to prevent leaving data behind.")
 			fmt.Println("Use 'kilnx migrate <file.kilnx> --allow-dataloss' to proceed anyway,")
-			fmt.Println("or add a 'model <new> renames <old>' directive to preserve the data.")
+			fmt.Println("or run an ALTER TABLE ... RENAME TO ... statement to preserve the data before migrating.")
 			return fmt.Errorf("migration blocked: potential data loss detected")
 		}
 		fmt.Println()

--- a/cmd/kilnx/main_test.go
+++ b/cmd/kilnx/main_test.go
@@ -68,3 +68,88 @@ func TestCLI_Check(t *testing.T) {
 		t.Logf("check output: %s", out)
 	}
 }
+
+func TestCLI_Init_Blog(t *testing.T) {
+	bin := buildKilnx(t)
+	tmpDir := t.TempDir()
+	projDir := filepath.Join(tmpDir, "myblog")
+
+	cmd := exec.Command(bin, "init", "blog", projDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kilnx init failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Created blog template") {
+		t.Errorf("expected success message, got: %s", out)
+	}
+
+	appFile := filepath.Join(projDir, "app.kilnx")
+	if _, err := os.Stat(appFile); err != nil {
+		t.Fatalf("app.kilnx not created: %v", err)
+	}
+
+	content, err := os.ReadFile(appFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "myblog") {
+		t.Errorf("expected project name substitution, got: %s", content)
+	}
+}
+
+func TestCLI_Init_Api(t *testing.T) {
+	bin := buildKilnx(t)
+	tmpDir := t.TempDir()
+	projDir := filepath.Join(tmpDir, "myapi")
+
+	cmd := exec.Command(bin, "init", "api", projDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kilnx init failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Created api template") {
+		t.Errorf("expected success message, got: %s", out)
+	}
+
+	appFile := filepath.Join(projDir, "app.kilnx")
+	if _, err := os.Stat(appFile); err != nil {
+		t.Fatalf("app.kilnx not created: %v", err)
+	}
+}
+
+func TestCLI_Init_UnknownTemplate(t *testing.T) {
+	bin := buildKilnx(t)
+	tmpDir := t.TempDir()
+	projDir := filepath.Join(tmpDir, "x")
+
+	cmd := exec.Command(bin, "init", "unknown", projDir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error for unknown template")
+	}
+	if !strings.Contains(string(out), "unknown template") {
+		t.Errorf("expected unknown template error, got: %s", out)
+	}
+}
+
+func TestCLI_Init_Duplicate(t *testing.T) {
+	bin := buildKilnx(t)
+	tmpDir := t.TempDir()
+	projDir := filepath.Join(tmpDir, "dup")
+
+	// First init succeeds
+	cmd1 := exec.Command(bin, "init", "blog", projDir)
+	if out, err := cmd1.CombinedOutput(); err != nil {
+		t.Fatalf("first init failed: %v\n%s", err, out)
+	}
+
+	// Second init fails because app.kilnx exists
+	cmd2 := exec.Command(bin, "init", "api", projDir)
+	out, err := cmd2.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error when target exists")
+	}
+	if !strings.Contains(string(out), "already exists") {
+		t.Errorf("expected already exists error, got: %s", out)
+	}
+}

--- a/cmd/kilnx/main_test.go
+++ b/cmd/kilnx/main_test.go
@@ -95,6 +95,15 @@ func TestCLI_Init_Blog(t *testing.T) {
 	if !strings.Contains(string(content), "myblog") {
 		t.Errorf("expected project name substitution, got: %s", content)
 	}
+
+	checkCmd := exec.Command(bin, "check", appFile)
+	checkOut, checkErr := checkCmd.CombinedOutput()
+	if checkErr != nil {
+		t.Fatalf("kilnx check failed on generated blog template: %v\n%s", checkErr, checkOut)
+	}
+	if !strings.Contains(string(checkOut), "No issues found") {
+		t.Errorf("kilnx check did not report clean template: %s", checkOut)
+	}
 }
 
 func TestCLI_Init_Api(t *testing.T) {
@@ -114,6 +123,32 @@ func TestCLI_Init_Api(t *testing.T) {
 	appFile := filepath.Join(projDir, "app.kilnx")
 	if _, err := os.Stat(appFile); err != nil {
 		t.Fatalf("app.kilnx not created: %v", err)
+	}
+
+	content, err := os.ReadFile(appFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(content)
+	// Guard against regression to unsupported `return` / `last_insert_id` syntax
+	// that the parser silently drops (see PR #100 review). Only `respond` is valid.
+	if strings.Contains(body, "last_insert_id") {
+		t.Error("api template references last_insert_id which is not a runtime binding")
+	}
+	if strings.Contains(body, "  return ") {
+		t.Error("api template uses `return` which the parser silently drops; use `respond` instead")
+	}
+	if !strings.Contains(body, "respond status") {
+		t.Error("api template should declare `respond status N` for mutations")
+	}
+
+	checkCmd := exec.Command(bin, "check", appFile)
+	checkOut, checkErr := checkCmd.CombinedOutput()
+	if checkErr != nil {
+		t.Fatalf("kilnx check failed on generated api template: %v\n%s", checkErr, checkOut)
+	}
+	if !strings.Contains(string(checkOut), "No issues found") {
+		t.Errorf("kilnx check did not report clean template: %s", checkOut)
 	}
 }
 
@@ -151,5 +186,27 @@ func TestCLI_Init_Duplicate(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "already exists") {
 		t.Errorf("expected already exists error, got: %s", out)
+	}
+}
+
+func TestCLI_Init_MissingArgs(t *testing.T) {
+	bin := buildKilnx(t)
+
+	cmd := exec.Command(bin, "init")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error when no template/dir provided")
+	}
+	if !strings.Contains(string(out), "Usage: kilnx init") {
+		t.Errorf("expected usage hint, got: %s", out)
+	}
+
+	cmd = exec.Command(bin, "init", "blog")
+	out, err = cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected error when dir omitted")
+	}
+	if !strings.Contains(string(out), "Usage: kilnx init") {
+		t.Errorf("expected usage hint, got: %s", out)
 	}
 }

--- a/cmd/kilnx/templates/api.kilnx
+++ b/cmd/kilnx/templates/api.kilnx
@@ -1,0 +1,68 @@
+config
+  port: 3000
+
+model user
+  email: email required unique
+  password: password required
+  name: text required
+  api_token: text unique
+
+model item
+  user_id: reference user
+  name: text required
+  done: bool default false
+  created_at: timestamp auto
+
+auth
+  identity: email
+  password: password
+
+permissions
+  default: auth
+
+api /items requires auth
+  query items: SELECT id, name, done, created_at FROM item WHERE user_id = :current_user.id ORDER BY created_at DESC
+  return items
+
+api /items method POST requires auth
+  validate item
+    name: required min 1
+  query: INSERT INTO item (user_id, name) VALUES (:current_user.id, :name)
+  on success
+    return {"id": :last_insert_id, "name": :name, "done": false}
+
+api /items/:id method PUT requires auth
+  query: UPDATE item SET done = :done WHERE id = :id AND user_id = :current_user.id
+  on success
+    return {"updated": true}
+
+api /items/:id method DELETE requires auth
+  query: DELETE FROM item WHERE id = :id AND user_id = :current_user.id
+  on success
+    return {"deleted": true}
+
+test "CRUD item"
+  step "register"
+    POST /register
+      email: "api@example.com"
+      password: "secret123"
+      name: "API User"
+    assert status 302
+  step "create item"
+    POST /items
+      name: "Buy milk"
+    assert status 200
+    assert json path "$.name" equals "Buy milk"
+  step "list items"
+    GET /items
+    assert status 200
+    assert json path "$[0].name" equals "Buy milk"
+  step "update item"
+    PUT /items/1
+      done: true
+    assert status 200
+    assert json path "$.updated" equals true
+  step "delete item"
+    DELETE /items/1
+    assert status 200
+    assert json path "$.deleted" equals true

--- a/cmd/kilnx/templates/api.kilnx
+++ b/cmd/kilnx/templates/api.kilnx
@@ -1,5 +1,5 @@
 config
-  port: 3000
+  port: 8080
 
 model user
   email: email required unique
@@ -57,47 +57,17 @@ page /reset-password
 
 api /items requires auth
   query items: SELECT id, name, done, created_at FROM item WHERE user_id = :current_user.id ORDER BY created_at DESC
-  return items
 
 api /items method POST requires auth
   validate item
     name: required min 1
   query: INSERT INTO item (user_id, name) VALUES (:current_user.id, :name)
-  on success
-    return {"id": :last_insert_id, "name": :name, "done": false}
+  respond status 201
 
 api /items/:id method PUT requires auth
   query: UPDATE item SET done = :done WHERE id = :id AND user_id = :current_user.id
-  on success
-    return {"updated": true}
+  respond status 200
 
 api /items/:id method DELETE requires auth
   query: DELETE FROM item WHERE id = :id AND user_id = :current_user.id
-  on success
-    return {"deleted": true}
-
-test "CRUD item"
-  step "register"
-    POST /register
-      email: "api@example.com"
-      password: "secret123"
-      name: "API User"
-    assert status 302
-  step "create item"
-    POST /items
-      name: "Buy milk"
-    assert status 200
-    assert json path "$.name" equals "Buy milk"
-  step "list items"
-    GET /items
-    assert status 200
-    assert json path "$[0].name" equals "Buy milk"
-  step "update item"
-    PUT /items/1
-      done: true
-    assert status 200
-    assert json path "$.updated" equals true
-  step "delete item"
-    DELETE /items/1
-    assert status 200
-    assert json path "$.deleted" equals true
+  respond status 200

--- a/cmd/kilnx/templates/api.kilnx
+++ b/cmd/kilnx/templates/api.kilnx
@@ -8,7 +8,7 @@ model user
   api_token: text unique
 
 model item
-  user_id: reference user
+  user: user
   name: text required
   done: bool default false
   created_at: timestamp auto
@@ -19,6 +19,41 @@ auth
 
 permissions
   default: auth
+
+page /login
+  html
+    <h1>Login</h1>
+    <form action="/login" method="POST">
+      <input name="email" type="email" placeholder="Email" required>
+      <input name="password" type="password" placeholder="Password" required>
+      <button type="submit">Login</button>
+    </form>
+
+page /register
+  html
+    <h1>Register</h1>
+    <form action="/register" method="POST">
+      <input name="email" type="email" placeholder="Email" required>
+      <input name="password" type="password" placeholder="Password" required>
+      <input name="name" placeholder="Name" required>
+      <button type="submit">Register</button>
+    </form>
+
+page /forgot-password
+  html
+    <h1>Forgot Password</h1>
+    <form action="/forgot-password" method="POST">
+      <input name="email" type="email" placeholder="Email" required>
+      <button type="submit">Send Reset Link</button>
+    </form>
+
+page /reset-password
+  html
+    <h1>Reset Password</h1>
+    <form action="/reset-password" method="POST">
+      <input name="password" type="password" placeholder="New Password" required>
+      <button type="submit">Reset</button>
+    </form>
 
 api /items requires auth
   query items: SELECT id, name, done, created_at FROM item WHERE user_id = :current_user.id ORDER BY created_at DESC

--- a/cmd/kilnx/templates/blog.kilnx
+++ b/cmd/kilnx/templates/blog.kilnx
@@ -1,0 +1,77 @@
+config
+  port: 3000
+
+model user
+  email: email required unique
+  password: password required
+  name: text required
+
+model post
+  user_id: reference user
+  title: text required
+  content: richtext
+  created_at: timestamp auto
+
+auth
+  identity: email
+  password: password
+
+permissions
+  default: auth
+
+page / requires auth
+  query posts: SELECT p.id, p.title, p.content, p.created_at, u.name as author
+                 FROM post p JOIN user u ON p.user_id = u.id
+                 ORDER BY p.created_at DESC
+  html
+    <h1>{{PROJECT_NAME}}</h1>
+    <a href="/new">New post</a>
+    <hr>
+    {{each posts}}
+      <article>
+        <h2><a href="/posts/{id}">{title}</a></h2>
+        <p>By {author} on {created_at|date:"Jan 02, 2006"}</p>
+        <p>{content|truncate:200}</p>
+      </article>
+    {{end}}
+
+page /posts/:id
+  query post: SELECT p.*, u.name as author FROM post p JOIN user u ON p.user_id = u.id WHERE p.id = :id
+  html
+    <h1>{post.title}</h1>
+    <p>By {post.author} on {post.created_at|date:"Jan 02, 2006"}</p>
+    <div>{post.content|raw}</div>
+    <a href="/">Back</a>
+
+page /new requires auth
+  html
+    <h1>New post</h1>
+    <form action="/posts" method="POST">
+      <input name="title" placeholder="Title" required>
+      <textarea name="content" placeholder="Content"></textarea>
+      <button type="submit">Publish</button>
+    </form>
+
+action /posts method POST requires auth
+  validate post
+    title: required min 3
+    content: required
+  query: INSERT INTO post (user_id, title, content) VALUES (:current_user.id, :title, :content)
+  on success
+    redirect /
+
+test "create and list post"
+  step "register"
+    POST /register
+      email: "writer@example.com"
+      password: "secret123"
+      name: "Writer"
+    assert status 302
+  step "create post"
+    POST /posts
+      title: "Hello Kilnx"
+      content: "My first post."
+    assert status 302
+  step "list posts"
+    GET /
+    assert body contains "Hello Kilnx"

--- a/cmd/kilnx/templates/blog.kilnx
+++ b/cmd/kilnx/templates/blog.kilnx
@@ -1,5 +1,5 @@
 config
-  port: 3000
+  port: 8080
 
 model user
   email: email required unique
@@ -96,17 +96,14 @@ action /posts method POST requires auth
     redirect /
 
 test "create and list post"
-  step "register"
-    POST /register
-      email: "writer@example.com"
-      password: "secret123"
-      name: "Writer"
-    assert status 302
-  step "create post"
-    POST /posts
-      title: "Hello Kilnx"
-      content: "My first post."
-    assert status 302
-  step "list posts"
-    GET /
-    assert body contains "Hello Kilnx"
+  visit /register
+  fill email "writer@example.com"
+  fill password "secret123"
+  fill name "Writer"
+  submit
+  visit /new
+  fill title "Hello Kilnx"
+  fill content "My first post."
+  submit
+  visit /
+  expect page / contains "Hello Kilnx"

--- a/cmd/kilnx/templates/blog.kilnx
+++ b/cmd/kilnx/templates/blog.kilnx
@@ -7,7 +7,7 @@ model user
   name: text required
 
 model post
-  user_id: reference user
+  user: user
   title: text required
   content: richtext
   created_at: timestamp auto
@@ -36,7 +36,7 @@ page / requires auth
     {{end}}
 
 page /posts/:id
-  query post: SELECT p.*, u.name as author FROM post p JOIN user u ON p.user_id = u.id WHERE p.id = :id
+  query post: SELECT p.id, p.title, p.content, p.created_at, u.name as author FROM post p JOIN user u ON p.user_id = u.id WHERE p.id = :id
   html
     <h1>{post.title}</h1>
     <p>By {post.author} on {post.created_at|date:"Jan 02, 2006"}</p>
@@ -50,6 +50,41 @@ page /new requires auth
       <input name="title" placeholder="Title" required>
       <textarea name="content" placeholder="Content"></textarea>
       <button type="submit">Publish</button>
+    </form>
+
+page /login
+  html
+    <h1>Login</h1>
+    <form action="/login" method="POST">
+      <input name="email" type="email" placeholder="Email" required>
+      <input name="password" type="password" placeholder="Password" required>
+      <button type="submit">Login</button>
+    </form>
+
+page /register
+  html
+    <h1>Register</h1>
+    <form action="/register" method="POST">
+      <input name="email" type="email" placeholder="Email" required>
+      <input name="password" type="password" placeholder="Password" required>
+      <input name="name" placeholder="Name" required>
+      <button type="submit">Register</button>
+    </form>
+
+page /forgot-password
+  html
+    <h1>Forgot Password</h1>
+    <form action="/forgot-password" method="POST">
+      <input name="email" type="email" placeholder="Email" required>
+      <button type="submit">Send Reset Link</button>
+    </form>
+
+page /reset-password
+  html
+    <h1>Reset Password</h1>
+    <form action="/reset-password" method="POST">
+      <input name="password" type="password" placeholder="New Password" required>
+      <button type="submit">Reset</button>
     </form>
 
 action /posts method POST requires auth

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -1325,6 +1325,12 @@ func checkFragmentComponents(app *parser.App) []Diagnostic {
 	// Regex to find {{name arg=expr}} calls (args optional)
 	callRe := regexp.MustCompile(`\{\{(\w+)(?:\s+([^}]+))?\}\}`)
 
+	// Built-in template directives that look like fragment calls but are not.
+	builtins := map[string]bool{
+		"each": true, "end": true, "if": true, "else": true,
+		"t": true, "plural": true,
+	}
+
 	// Scan all NodeHTML bodies across pages, fragments, actions, apis
 	var scanNodes func([]parser.Node, string)
 	scanNodes = func(nodes []parser.Node, ctx string) {
@@ -1332,6 +1338,9 @@ func checkFragmentComponents(app *parser.App) []Diagnostic {
 			if node.Type == parser.NodeHTML {
 				for _, match := range callRe.FindAllStringSubmatch(node.HTMLContent, -1) {
 					name := match[1]
+					if builtins[name] {
+						continue
+					}
 					argStr := ""
 					if len(match) > 2 {
 						argStr = match[2]

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -131,7 +131,7 @@ func (db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*pars
 		if !exists {
 			stmts = append(stmts, db.generateCreateTable(model, cm))
 		} else {
-			alterStmts, err := db.planExistingTable(model.Name, model.Name, model, cm)
+			alterStmts, err := db.planExistingTable(model, cm)
 			if err != nil {
 				return stmts, err
 			}
@@ -364,7 +364,7 @@ func (db *DB) tableExists(name string) (bool, error) {
 type DataLossRisk struct {
 	TableName  string
 	RowCount   int
-	Suggestion string // e.g. "model <new> renames <old>"
+	Suggestion string // human-readable hint, e.g. an ALTER TABLE RENAME statement
 }
 
 // DetectDataLossRisk inspects the database for tables that do not correspond
@@ -393,9 +393,10 @@ func (db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error) 
 		}
 
 		var count int
-		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM \"%s\"", tableName)
+		escaped := strings.ReplaceAll(tableName, `"`, `""`)
+		countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, escaped)
 		if err := db.conn.QueryRow(countQuery).Scan(&count); err != nil {
-			continue
+			return nil, fmt.Errorf("counting rows in %q: %w", tableName, err)
 		}
 		if count == 0 {
 			continue
@@ -410,7 +411,7 @@ func (db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error) 
 				strings.EqualFold(tableName+"s", m.Name) ||
 				strings.EqualFold(m.Name, tableName+"es") ||
 				strings.EqualFold(tableName, m.Name+"es") {
-				suggestion = fmt.Sprintf("model %s renames %s", m.Name, tableName)
+				suggestion = fmt.Sprintf(`run "ALTER TABLE %s RENAME TO %s;" before migrating to keep the data`, tableName, m.Name)
 				break
 			}
 		}
@@ -424,16 +425,10 @@ func (db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error) 
 	return risks, rows.Err()
 }
 
-// DataLossRisk describes a table in the database that is no longer represented
-// by any model in the current schema. If it contains rows, the migration may
-// leave data behind.
-// queryTable is the name to inspect for existing columns (may differ from ddlTable
-// when a rename has been planned but not yet executed).
-// ddlTable is the name used in the generated ALTER TABLE statements.
-func (db *DB) planExistingTable(queryTable, ddlTable string, model parser.Model, cm map[string]*parser.CustomFieldManifest) ([]string, error) {
+func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.CustomFieldManifest) ([]string, error) {
 	var stmts []string
 
-	existing, err := db.getColumns(queryTable)
+	existing, err := db.getColumns(model.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +449,7 @@ func (db *DB) planExistingTable(queryTable, ddlTable string, model parser.Model,
 		defaultClause := db.dialect.FieldToDefault(field)
 
 		stmt := fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"%s\" %s%s",
-			ddlTable, colName, sqlType, defaultClause)
+			model.Name, colName, sqlType, defaultClause)
 		stmts = append(stmts, stmt)
 	}
 
@@ -464,7 +459,7 @@ func (db *DB) planExistingTable(queryTable, ddlTable string, model parser.Model,
 			if db.dialect.DriverName() == "pgx" {
 				colType = "JSONB"
 			}
-			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" %s", ddlTable, colType))
+			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" %s", model.Name, colType))
 		}
 		// column-mode custom fields become real columns
 		if manifest, ok := cm[model.Name]; ok {
@@ -479,7 +474,7 @@ func (db *DB) planExistingTable(queryTable, ddlTable string, model parser.Model,
 					continue
 				}
 				sqlType := customKindToSQL(f.Kind, db.dialect.DriverName() == "pgx")
-				stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"%s\" %s", ddlTable, f.Name, sqlType))
+				stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"%s\" %s", model.Name, f.Name, sqlType))
 			}
 		}
 	}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -128,31 +128,9 @@ func (db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*pars
 			return stmts, err
 		}
 
-		renamed := false
-		if model.Renames != "" {
-			if !isValidIdentifier(model.Renames) {
-				return stmts, fmt.Errorf("invalid old model name: %q", model.Renames)
-			}
-			oldExists, err := db.tableExists(model.Renames)
-			if err != nil {
-				return stmts, err
-			}
-			if oldExists && !exists {
-				stmts = append(stmts, fmt.Sprintf(`ALTER TABLE "%s" RENAME TO "%s"`, model.Renames, model.Name))
-				// Plan ALTERs against the old table name because the rename hasn't executed yet.
-				alterStmts, err := db.planExistingTable(model.Renames, model.Name, model, cm)
-				if err != nil {
-					return stmts, err
-				}
-				stmts = append(stmts, alterStmts...)
-				exists = true
-				renamed = true
-			}
-		}
-
 		if !exists {
 			stmts = append(stmts, db.generateCreateTable(model, cm))
-		} else if !renamed {
+		} else {
 			alterStmts, err := db.planExistingTable(model.Name, model.Name, model, cm)
 			if err != nil {
 				return stmts, err
@@ -384,9 +362,9 @@ func (db *DB) tableExists(name string) (bool, error) {
 // by any model in the current schema. If it contains rows, the migration may
 // leave data behind.
 type DataLossRisk struct {
-	TableName   string
-	RowCount    int
-	Suggestion  string // e.g. "model <new> renames <old>"
+	TableName  string
+	RowCount   int
+	Suggestion string // e.g. "model <new> renames <old>"
 }
 
 // DetectDataLossRisk inspects the database for tables that do not correspond
@@ -396,9 +374,6 @@ func (db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error) 
 	modelNames := make(map[string]bool, len(models))
 	for _, m := range models {
 		modelNames[m.Name] = true
-		if m.Renames != "" {
-			modelNames[m.Renames] = true
-		}
 	}
 
 	rows, err := db.conn.Query(db.dialect.ListTablesSQL())
@@ -420,23 +395,21 @@ func (db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error) 
 		var count int
 		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM \"%s\"", tableName)
 		if err := db.conn.QueryRow(countQuery).Scan(&count); err != nil {
-			// Skip tables we can't inspect (e.g. views masquerading as tables)
 			continue
 		}
 		if count == 0 {
 			continue
 		}
 
-		// Suggest a rename if a model name looks like a plural/singular variant
 		var suggestion string
 		for _, m := range models {
-			if m.Renames == "" && strings.EqualFold(m.Name, tableName) {
+			if strings.EqualFold(m.Name, tableName) {
 				continue
 			}
-			if m.Renames == "" && (strings.EqualFold(m.Name+"s", tableName) ||
+			if strings.EqualFold(m.Name+"s", tableName) ||
 				strings.EqualFold(tableName+"s", m.Name) ||
 				strings.EqualFold(m.Name, tableName+"es") ||
-				strings.EqualFold(tableName, m.Name+"es")) {
+				strings.EqualFold(tableName, m.Name+"es") {
 				suggestion = fmt.Sprintf("model %s renames %s", m.Name, tableName)
 				break
 			}
@@ -451,7 +424,9 @@ func (db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error) 
 	return risks, rows.Err()
 }
 
-// planExistingTable returns ALTER TABLE statements needed without executing them.
+// DataLossRisk describes a table in the database that is no longer represented
+// by any model in the current schema. If it contains rows, the migration may
+// leave data behind.
 // queryTable is the name to inspect for existing columns (may differ from ddlTable
 // when a rename has been planned but not yet executed).
 // ddlTable is the name used in the generated ALTER TABLE statements.

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -128,10 +128,32 @@ func (db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*pars
 			return stmts, err
 		}
 
+		renamed := false
+		if model.Renames != "" {
+			if !isValidIdentifier(model.Renames) {
+				return stmts, fmt.Errorf("invalid old model name: %q", model.Renames)
+			}
+			oldExists, err := db.tableExists(model.Renames)
+			if err != nil {
+				return stmts, err
+			}
+			if oldExists && !exists {
+				stmts = append(stmts, fmt.Sprintf(`ALTER TABLE "%s" RENAME TO "%s"`, model.Renames, model.Name))
+				// Plan ALTERs against the old table name because the rename hasn't executed yet.
+				alterStmts, err := db.planExistingTable(model.Renames, model.Name, model, cm)
+				if err != nil {
+					return stmts, err
+				}
+				stmts = append(stmts, alterStmts...)
+				exists = true
+				renamed = true
+			}
+		}
+
 		if !exists {
 			stmts = append(stmts, db.generateCreateTable(model, cm))
-		} else {
-			alterStmts, err := db.planExistingTable(model, cm)
+		} else if !renamed {
+			alterStmts, err := db.planExistingTable(model.Name, model.Name, model, cm)
 			if err != nil {
 				return stmts, err
 			}
@@ -358,11 +380,85 @@ func (db *DB) tableExists(name string) (bool, error) {
 	return count > 0, err
 }
 
-// planExistingTable returns ALTER TABLE statements needed without executing them
-func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.CustomFieldManifest) ([]string, error) {
+// DataLossRisk describes a table in the database that is no longer represented
+// by any model in the current schema. If it contains rows, the migration may
+// leave data behind.
+type DataLossRisk struct {
+	TableName   string
+	RowCount    int
+	Suggestion  string // e.g. "model <new> renames <old>"
+}
+
+// DetectDataLossRisk inspects the database for tables that do not correspond
+// to any model in the provided slice and contain data. It returns a slice of
+// risks and any error encountered during introspection.
+func (db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error) {
+	modelNames := make(map[string]bool, len(models))
+	for _, m := range models {
+		modelNames[m.Name] = true
+		if m.Renames != "" {
+			modelNames[m.Renames] = true
+		}
+	}
+
+	rows, err := db.conn.Query(db.dialect.ListTablesSQL())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var risks []DataLossRisk
+	for rows.Next() {
+		var tableName string
+		if err := rows.Scan(&tableName); err != nil {
+			return nil, err
+		}
+		if modelNames[tableName] {
+			continue
+		}
+
+		var count int
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM \"%s\"", tableName)
+		if err := db.conn.QueryRow(countQuery).Scan(&count); err != nil {
+			// Skip tables we can't inspect (e.g. views masquerading as tables)
+			continue
+		}
+		if count == 0 {
+			continue
+		}
+
+		// Suggest a rename if a model name looks like a plural/singular variant
+		var suggestion string
+		for _, m := range models {
+			if m.Renames == "" && strings.EqualFold(m.Name, tableName) {
+				continue
+			}
+			if m.Renames == "" && (strings.EqualFold(m.Name+"s", tableName) ||
+				strings.EqualFold(tableName+"s", m.Name) ||
+				strings.EqualFold(m.Name, tableName+"es") ||
+				strings.EqualFold(tableName, m.Name+"es")) {
+				suggestion = fmt.Sprintf("model %s renames %s", m.Name, tableName)
+				break
+			}
+		}
+
+		risks = append(risks, DataLossRisk{
+			TableName:  tableName,
+			RowCount:   count,
+			Suggestion: suggestion,
+		})
+	}
+	return risks, rows.Err()
+}
+
+// planExistingTable returns ALTER TABLE statements needed without executing them.
+// queryTable is the name to inspect for existing columns (may differ from ddlTable
+// when a rename has been planned but not yet executed).
+// ddlTable is the name used in the generated ALTER TABLE statements.
+func (db *DB) planExistingTable(queryTable, ddlTable string, model parser.Model, cm map[string]*parser.CustomFieldManifest) ([]string, error) {
 	var stmts []string
 
-	existing, err := db.getColumns(model.Name)
+	existing, err := db.getColumns(queryTable)
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +479,7 @@ func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.Custom
 		defaultClause := db.dialect.FieldToDefault(field)
 
 		stmt := fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"%s\" %s%s",
-			model.Name, colName, sqlType, defaultClause)
+			ddlTable, colName, sqlType, defaultClause)
 		stmts = append(stmts, stmt)
 	}
 
@@ -393,7 +489,7 @@ func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.Custom
 			if db.dialect.DriverName() == "pgx" {
 				colType = "JSONB"
 			}
-			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" %s", model.Name, colType))
+			stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"custom\" %s", ddlTable, colType))
 		}
 		// column-mode custom fields become real columns
 		if manifest, ok := cm[model.Name]; ok {
@@ -408,7 +504,7 @@ func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.Custom
 					continue
 				}
 				sqlType := customKindToSQL(f.Kind, db.dialect.DriverName() == "pgx")
-				stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"%s\" %s", model.Name, f.Name, sqlType))
+				stmts = append(stmts, fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN \"%s\" %s", ddlTable, f.Name, sqlType))
 			}
 		}
 	}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1263,7 +1263,7 @@ func TestPlanExistingTableOmitsComputedFields(t *testing.T) {
 		},
 	}
 
-	stmts, err := db.planExistingTable(model, nil)
+	stmts, err := db.planExistingTable("invoice", "invoice", model, nil)
 	if err != nil {
 		t.Fatalf("planExistingTable: %v", err)
 	}
@@ -1274,204 +1274,7 @@ func TestPlanExistingTableOmitsComputedFields(t *testing.T) {
 	}
 }
 
-// ---------- Migrate rename ----------
-
-func TestMigrateRenamesTable(t *testing.T) {
-	db, cleanup := openTemp(t)
-	defer cleanup()
-
-	// v1: create "article" with some data
-	v1 := []parser.Model{{
-		Name: "article",
-		Fields: []parser.Field{
-			{Name: "title", Type: parser.FieldText, Required: true},
-		},
-	}}
-	if _, err := db.Migrate(v1); err != nil {
-		t.Fatalf("v1 Migrate: %v", err)
-	}
-	if _, err := db.Conn().Exec(`INSERT INTO "article" ("title") VALUES ('Hello')`); err != nil {
-		t.Fatalf("insert: %v", err)
-	}
-
-	// v2: rename "article" to "post"
-	v2 := []parser.Model{{
-		Name:    "post",
-		Renames: "article",
-		Fields: []parser.Field{
-			{Name: "title", Type: parser.FieldText, Required: true},
-		},
-	}}
-	stmts, err := db.Migrate(v2)
-	if err != nil {
-		t.Fatalf("v2 Migrate: %v", err)
-	}
-	if len(stmts) == 0 {
-		t.Fatal("expected migration statements for rename")
-	}
-	foundRename := false
-	for _, s := range stmts {
-		if strings.Contains(s, `ALTER TABLE "article" RENAME TO "post"`) {
-			foundRename = true
-			break
-		}
-	}
-	if !foundRename {
-		t.Fatalf("expected ALTER TABLE rename statement, got: %v", stmts)
-	}
-
-	// Data must survive
-	rows, err := db.QueryRows(`SELECT "title" FROM "post"`)
-	if err != nil {
-		t.Fatalf("query after rename: %v", err)
-	}
-	if len(rows) != 1 || rows[0]["title"] != "Hello" {
-		t.Fatalf("expected data to survive rename, got %v", rows)
-	}
-}
-
-func TestMigrateRenamesThenAddsColumn(t *testing.T) {
-	db, cleanup := openTemp(t)
-	defer cleanup()
-
-	v1 := []parser.Model{{
-		Name: "article",
-		Fields: []parser.Field{
-			{Name: "title", Type: parser.FieldText, Required: true},
-		},
-	}}
-	if _, err := db.Migrate(v1); err != nil {
-		t.Fatalf("v1 Migrate: %v", err)
-	}
-
-	v2 := []parser.Model{{
-		Name:    "post",
-		Renames: "article",
-		Fields: []parser.Field{
-			{Name: "title", Type: parser.FieldText, Required: true},
-			{Name: "body", Type: parser.FieldText},
-		},
-	}}
-	stmts, err := db.Migrate(v2)
-	if err != nil {
-		t.Fatalf("v2 Migrate: %v", err)
-	}
-	if len(stmts) < 2 {
-		t.Fatalf("expected rename + add-column, got %d statements: %v", len(stmts), stmts)
-	}
-	if !strings.Contains(stmts[0], `ALTER TABLE "article" RENAME TO "post"`) {
-		t.Errorf("expected rename first, got: %q", stmts[0])
-	}
-	if !strings.Contains(stmts[1], `ALTER TABLE "post" ADD COLUMN "body"`) {
-		t.Errorf("expected add column second, got: %q", stmts[1])
-	}
-}
-
-func TestMigrateRenamesNoOpWhenNewTableAlreadyExists(t *testing.T) {
-	db, cleanup := openTemp(t)
-	defer cleanup()
-
-	// Both "article" and "post" exist
-	if _, err := db.Conn().Exec(`CREATE TABLE "article" ("id" INTEGER PRIMARY KEY, "title" TEXT)`); err != nil {
-		t.Fatalf("create article: %v", err)
-	}
-	if _, err := db.Conn().Exec(`CREATE TABLE "post" ("id" INTEGER PRIMARY KEY, "title" TEXT)`); err != nil {
-		t.Fatalf("create post: %v", err)
-	}
-
-	v2 := []parser.Model{{
-		Name:    "post",
-		Renames: "article",
-		Fields: []parser.Field{
-			{Name: "title", Type: parser.FieldText},
-		},
-	}}
-	stmts, err := db.Migrate(v2)
-	if err != nil {
-		t.Fatalf("v2 Migrate: %v", err)
-	}
-	for _, s := range stmts {
-		if strings.Contains(s, "RENAME TO") {
-			t.Errorf("expected no rename when target table already exists, got: %q", s)
-		}
-	}
-}
-
-func TestMigrateRenamesCreatesWhenOldTableMissing(t *testing.T) {
-	db, cleanup := openTemp(t)
-	defer cleanup()
-
-	v2 := []parser.Model{{
-		Name:    "post",
-		Renames: "article",
-		Fields: []parser.Field{
-			{Name: "title", Type: parser.FieldText, Required: true},
-		},
-	}}
-	stmts, err := db.Migrate(v2)
-	if err != nil {
-		t.Fatalf("v2 Migrate: %v", err)
-	}
-	if len(stmts) == 0 {
-		t.Fatal("expected CREATE TABLE when old table does not exist")
-	}
-	if !strings.Contains(stmts[0], `CREATE TABLE "post"`) {
-		t.Fatalf("expected CREATE TABLE, got: %q", stmts[0])
-	}
-}
-
-func TestPlanMigrationRenamesDryRun(t *testing.T) {
-	db, cleanup := openTemp(t)
-	defer cleanup()
-
-	if _, err := db.Conn().Exec(`CREATE TABLE "article" ("id" INTEGER PRIMARY KEY, "title" TEXT)`); err != nil {
-		t.Fatalf("create article: %v", err)
-	}
-
-	models := []parser.Model{{
-		Name:    "post",
-		Renames: "article",
-		Fields: []parser.Field{
-			{Name: "title", Type: parser.FieldText},
-		},
-	}}
-	stmts, err := db.PlanMigration(models)
-	if err != nil {
-		t.Fatalf("PlanMigration: %v", err)
-	}
-	found := false
-	for _, s := range stmts {
-		if strings.Contains(s, `ALTER TABLE "article" RENAME TO "post"`) {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("expected rename in dry-run plan, got: %v", stmts)
-	}
-
-	// Dry-run must NOT execute
-	_, err = db.Conn().Exec(`SELECT "title" FROM "post"`)
-	if err == nil {
-		t.Error("dry-run should not execute rename")
-	}
-}
-
-func TestMigrateRenamesInvalidOldName(t *testing.T) {
-	db, cleanup := openTemp(t)
-	defer cleanup()
-
-	models := []parser.Model{{
-		Name:    "post",
-		Renames: "article; DROP TABLE post; --",
-		Fields: []parser.Field{
-			{Name: "title", Type: parser.FieldText},
-		},
-	}}
-	_, err := db.Migrate(models)
-	if err == nil {
-		t.Fatal("expected error for invalid old model name")
-	}
-}
+// ---------- Data-loss risk detection ----------
 
 func TestDetectDataLossRisk_NoRisk(t *testing.T) {
 	db, cleanup := openTemp(t)
@@ -1569,29 +1372,30 @@ func TestDetectDataLossRisk_Suggestion(t *testing.T) {
 	}
 }
 
-func TestDetectDataLossRisk_RenamesCleared(t *testing.T) {
+func TestDetectDataLossRisk_EmptyTableIgnored(t *testing.T) {
 	db, cleanup := openTemp(t)
 	defer cleanup()
 
-	// Migrate with renames
+	// Create old table but leave it empty
+	_, err := db.Conn().Exec(`CREATE TABLE "article" ("id" INTEGER PRIMARY KEY, "title" TEXT)`)
+	if err != nil {
+		t.Fatalf("create table failed: %v", err)
+	}
+
+	// New schema no longer has "article"
 	models := []parser.Model{{
-		Name:    "post",
-		Renames: "article",
+		Name: "post",
 		Fields: []parser.Field{
 			{Name: "title", Type: parser.FieldText},
 		},
 	}}
-	_, err := db.Migrate(models)
-	if err != nil {
-		t.Fatalf("migrate failed: %v", err)
-	}
 
-	// After rename, old table no longer exists; risk should be empty
+	// Empty orphan tables should not be reported as risks
 	risks, err := db.DetectDataLossRisk(models)
 	if err != nil {
 		t.Fatalf("DetectDataLossRisk failed: %v", err)
 	}
 	if len(risks) != 0 {
-		t.Fatalf("expected no risks after rename, got %d", len(risks))
+		t.Fatalf("expected 0 risks for empty table, got %d", len(risks))
 	}
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1273,3 +1273,325 @@ func TestPlanExistingTableOmitsComputedFields(t *testing.T) {
 		}
 	}
 }
+
+// ---------- Migrate rename ----------
+
+func TestMigrateRenamesTable(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// v1: create "article" with some data
+	v1 := []parser.Model{{
+		Name: "article",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText, Required: true},
+		},
+	}}
+	if _, err := db.Migrate(v1); err != nil {
+		t.Fatalf("v1 Migrate: %v", err)
+	}
+	if _, err := db.Conn().Exec(`INSERT INTO "article" ("title") VALUES ('Hello')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// v2: rename "article" to "post"
+	v2 := []parser.Model{{
+		Name:    "post",
+		Renames: "article",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText, Required: true},
+		},
+	}}
+	stmts, err := db.Migrate(v2)
+	if err != nil {
+		t.Fatalf("v2 Migrate: %v", err)
+	}
+	if len(stmts) == 0 {
+		t.Fatal("expected migration statements for rename")
+	}
+	foundRename := false
+	for _, s := range stmts {
+		if strings.Contains(s, `ALTER TABLE "article" RENAME TO "post"`) {
+			foundRename = true
+			break
+		}
+	}
+	if !foundRename {
+		t.Fatalf("expected ALTER TABLE rename statement, got: %v", stmts)
+	}
+
+	// Data must survive
+	rows, err := db.QueryRows(`SELECT "title" FROM "post"`)
+	if err != nil {
+		t.Fatalf("query after rename: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["title"] != "Hello" {
+		t.Fatalf("expected data to survive rename, got %v", rows)
+	}
+}
+
+func TestMigrateRenamesThenAddsColumn(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	v1 := []parser.Model{{
+		Name: "article",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText, Required: true},
+		},
+	}}
+	if _, err := db.Migrate(v1); err != nil {
+		t.Fatalf("v1 Migrate: %v", err)
+	}
+
+	v2 := []parser.Model{{
+		Name:    "post",
+		Renames: "article",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText, Required: true},
+			{Name: "body", Type: parser.FieldText},
+		},
+	}}
+	stmts, err := db.Migrate(v2)
+	if err != nil {
+		t.Fatalf("v2 Migrate: %v", err)
+	}
+	if len(stmts) < 2 {
+		t.Fatalf("expected rename + add-column, got %d statements: %v", len(stmts), stmts)
+	}
+	if !strings.Contains(stmts[0], `ALTER TABLE "article" RENAME TO "post"`) {
+		t.Errorf("expected rename first, got: %q", stmts[0])
+	}
+	if !strings.Contains(stmts[1], `ALTER TABLE "post" ADD COLUMN "body"`) {
+		t.Errorf("expected add column second, got: %q", stmts[1])
+	}
+}
+
+func TestMigrateRenamesNoOpWhenNewTableAlreadyExists(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Both "article" and "post" exist
+	if _, err := db.Conn().Exec(`CREATE TABLE "article" ("id" INTEGER PRIMARY KEY, "title" TEXT)`); err != nil {
+		t.Fatalf("create article: %v", err)
+	}
+	if _, err := db.Conn().Exec(`CREATE TABLE "post" ("id" INTEGER PRIMARY KEY, "title" TEXT)`); err != nil {
+		t.Fatalf("create post: %v", err)
+	}
+
+	v2 := []parser.Model{{
+		Name:    "post",
+		Renames: "article",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+		},
+	}}
+	stmts, err := db.Migrate(v2)
+	if err != nil {
+		t.Fatalf("v2 Migrate: %v", err)
+	}
+	for _, s := range stmts {
+		if strings.Contains(s, "RENAME TO") {
+			t.Errorf("expected no rename when target table already exists, got: %q", s)
+		}
+	}
+}
+
+func TestMigrateRenamesCreatesWhenOldTableMissing(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	v2 := []parser.Model{{
+		Name:    "post",
+		Renames: "article",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText, Required: true},
+		},
+	}}
+	stmts, err := db.Migrate(v2)
+	if err != nil {
+		t.Fatalf("v2 Migrate: %v", err)
+	}
+	if len(stmts) == 0 {
+		t.Fatal("expected CREATE TABLE when old table does not exist")
+	}
+	if !strings.Contains(stmts[0], `CREATE TABLE "post"`) {
+		t.Fatalf("expected CREATE TABLE, got: %q", stmts[0])
+	}
+}
+
+func TestPlanMigrationRenamesDryRun(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	if _, err := db.Conn().Exec(`CREATE TABLE "article" ("id" INTEGER PRIMARY KEY, "title" TEXT)`); err != nil {
+		t.Fatalf("create article: %v", err)
+	}
+
+	models := []parser.Model{{
+		Name:    "post",
+		Renames: "article",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+		},
+	}}
+	stmts, err := db.PlanMigration(models)
+	if err != nil {
+		t.Fatalf("PlanMigration: %v", err)
+	}
+	found := false
+	for _, s := range stmts {
+		if strings.Contains(s, `ALTER TABLE "article" RENAME TO "post"`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected rename in dry-run plan, got: %v", stmts)
+	}
+
+	// Dry-run must NOT execute
+	_, err = db.Conn().Exec(`SELECT "title" FROM "post"`)
+	if err == nil {
+		t.Error("dry-run should not execute rename")
+	}
+}
+
+func TestMigrateRenamesInvalidOldName(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{{
+		Name:    "post",
+		Renames: "article; DROP TABLE post; --",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+		},
+	}}
+	_, err := db.Migrate(models)
+	if err == nil {
+		t.Fatal("expected error for invalid old model name")
+	}
+}
+
+func TestDetectDataLossRisk_NoRisk(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{{
+		Name: "post",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+		},
+	}}
+	_, err := db.Migrate(models)
+	if err != nil {
+		t.Fatalf("migrate failed: %v", err)
+	}
+
+	risks, err := db.DetectDataLossRisk(models)
+	if err != nil {
+		t.Fatalf("DetectDataLossRisk failed: %v", err)
+	}
+	if len(risks) != 0 {
+		t.Fatalf("expected no risks, got %d", len(risks))
+	}
+}
+
+func TestDetectDataLossRisk_OrphanTableWithData(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Create old table and insert data
+	_, err := db.Conn().Exec(`CREATE TABLE "contato" (id INTEGER PRIMARY KEY, nome TEXT)`)
+	if err != nil {
+		t.Fatalf("create old table failed: %v", err)
+	}
+	_, err = db.Conn().Exec(`INSERT INTO "contato" (nome) VALUES ('Alice')`)
+	if err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+
+	// New schema no longer has "contato"
+	models := []parser.Model{{
+		Name: "canal_de_comunicacao",
+		Fields: []parser.Field{
+			{Name: "nome", Type: parser.FieldText},
+		},
+	}}
+
+	risks, err := db.DetectDataLossRisk(models)
+	if err != nil {
+		t.Fatalf("DetectDataLossRisk failed: %v", err)
+	}
+	if len(risks) != 1 {
+		t.Fatalf("expected 1 risk, got %d", len(risks))
+	}
+	if risks[0].TableName != "contato" {
+		t.Errorf("expected table 'contato', got %q", risks[0].TableName)
+	}
+	if risks[0].RowCount != 1 {
+		t.Errorf("expected 1 row, got %d", risks[0].RowCount)
+	}
+}
+
+func TestDetectDataLossRisk_Suggestion(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Old table with data
+	_, err := db.Conn().Exec(`CREATE TABLE "articles" (id INTEGER PRIMARY KEY, title TEXT)`)
+	if err != nil {
+		t.Fatalf("create table failed: %v", err)
+	}
+	_, err = db.Conn().Exec(`INSERT INTO "articles" (title) VALUES ('Hello')`)
+	if err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+
+	// New model is singular of old table
+	models := []parser.Model{{
+		Name: "article",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+		},
+	}}
+
+	risks, err := db.DetectDataLossRisk(models)
+	if err != nil {
+		t.Fatalf("DetectDataLossRisk failed: %v", err)
+	}
+	if len(risks) != 1 {
+		t.Fatalf("expected 1 risk, got %d", len(risks))
+	}
+	expected := "model article renames articles"
+	if risks[0].Suggestion != expected {
+		t.Errorf("expected suggestion %q, got %q", expected, risks[0].Suggestion)
+	}
+}
+
+func TestDetectDataLossRisk_RenamesCleared(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Migrate with renames
+	models := []parser.Model{{
+		Name:    "post",
+		Renames: "article",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+		},
+	}}
+	_, err := db.Migrate(models)
+	if err != nil {
+		t.Fatalf("migrate failed: %v", err)
+	}
+
+	// After rename, old table no longer exists; risk should be empty
+	risks, err := db.DetectDataLossRisk(models)
+	if err != nil {
+		t.Fatalf("DetectDataLossRisk failed: %v", err)
+	}
+	if len(risks) != 0 {
+		t.Fatalf("expected no risks after rename, got %d", len(risks))
+	}
+}

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1263,7 +1263,7 @@ func TestPlanExistingTableOmitsComputedFields(t *testing.T) {
 		},
 	}
 
-	stmts, err := db.planExistingTable("invoice", "invoice", model, nil)
+	stmts, err := db.planExistingTable(model, nil)
 	if err != nil {
 		t.Fatalf("planExistingTable: %v", err)
 	}
@@ -1366,9 +1366,59 @@ func TestDetectDataLossRisk_Suggestion(t *testing.T) {
 	if len(risks) != 1 {
 		t.Fatalf("expected 1 risk, got %d", len(risks))
 	}
-	expected := "model article renames articles"
+	expected := `run "ALTER TABLE articles RENAME TO article;" before migrating to keep the data`
 	if risks[0].Suggestion != expected {
 		t.Errorf("expected suggestion %q, got %q", expected, risks[0].Suggestion)
+	}
+}
+
+func TestDetectDataLossRisk_QuotedTableName(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	if _, err := db.Conn().Exec(`CREATE TABLE "weird""name" (id INTEGER PRIMARY KEY, x TEXT)`); err != nil {
+		t.Fatalf("create table failed: %v", err)
+	}
+	if _, err := db.Conn().Exec(`INSERT INTO "weird""name" (x) VALUES ('y')`); err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+
+	risks, err := db.DetectDataLossRisk(nil)
+	if err != nil {
+		t.Fatalf("DetectDataLossRisk failed: %v", err)
+	}
+	if len(risks) != 1 || risks[0].TableName != `weird"name` || risks[0].RowCount != 1 {
+		t.Fatalf("unexpected risks: %#v", risks)
+	}
+}
+
+func TestDetectDataLossRisk_SqliteInternalsFiltered(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{{
+		Name:   "thing",
+		Fields: []parser.Field{{Name: "n", Type: parser.FieldText}},
+	}}
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("migrate failed: %v", err)
+	}
+	if _, err := db.Conn().Exec(`INSERT INTO thing (n) VALUES ('a')`); err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+	// Create a sqlite_sequence row implicitly via AUTOINCREMENT? Skip; just ANALYZE
+	if _, err := db.Conn().Exec(`ANALYZE`); err != nil {
+		t.Fatalf("analyze failed: %v", err)
+	}
+
+	risks, err := db.DetectDataLossRisk(models)
+	if err != nil {
+		t.Fatalf("DetectDataLossRisk failed: %v", err)
+	}
+	for _, r := range risks {
+		if strings.HasPrefix(r.TableName, "sqlite_") {
+			t.Errorf("sqlite internal leaked into risks: %s", r.TableName)
+		}
 	}
 }
 

--- a/internal/database/dialect.go
+++ b/internal/database/dialect.go
@@ -27,6 +27,11 @@ type Dialect interface {
 	// The single ? / $1 parameter is the table name.
 	TableExistsSQL() string
 
+	// ListTablesSQL returns a query that yields (name TEXT) rows for all user
+	// tables in the database. Internal tables (starting with _kilnx_ and
+	// _<model>_field_defs) must be excluded by the query itself.
+	ListTablesSQL() string
+
 	// ColumnsSQL returns a query that yields (column_name TEXT) rows for a table.
 	// Receives the table name as a literal (not a parameter) for PRAGMA compat.
 	ColumnsSQL(table string) string

--- a/internal/database/dialect_postgres.go
+++ b/internal/database/dialect_postgres.go
@@ -33,6 +33,13 @@ func (PostgresDialect) TableExistsSQL() string {
 		WHERE table_schema = 'public' AND table_name = $1`
 }
 
+func (PostgresDialect) ListTablesSQL() string {
+	return `SELECT table_name FROM information_schema.tables
+		WHERE table_schema = 'public'
+		  AND table_name NOT LIKE '\_kilnx\_%' ESCAPE '\'
+		  AND table_name NOT LIKE '\_%\_field\_defs' ESCAPE '\'`
+}
+
 func (PostgresDialect) ColumnsSQL(table string) string {
 	return fmt.Sprintf(
 		`SELECT column_name FROM information_schema.columns

--- a/internal/database/dialect_sqlite.go
+++ b/internal/database/dialect_sqlite.go
@@ -32,6 +32,13 @@ func (SqliteDialect) TableExistsSQL() string {
 	return "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?"
 }
 
+func (SqliteDialect) ListTablesSQL() string {
+	return `SELECT name FROM sqlite_master
+		WHERE type='table'
+		  AND name NOT LIKE '\_kilnx\_%' ESCAPE '\'
+		  AND name NOT LIKE '\_%\_field\_defs' ESCAPE '\'`
+}
+
 func (SqliteDialect) ColumnsSQL(table string) string {
 	return fmt.Sprintf(`SELECT name FROM pragma_table_info("%s")`, table)
 }

--- a/internal/database/dialect_sqlite.go
+++ b/internal/database/dialect_sqlite.go
@@ -37,7 +37,7 @@ func (SqliteDialect) ListTablesSQL() string {
 		WHERE type='table'
 		  AND name NOT LIKE '\_kilnx\_%' ESCAPE '\'
 		  AND name NOT LIKE '\_%\_field\_defs' ESCAPE '\'
-		  AND name != 'sqlite_sequence'`
+		  AND name NOT LIKE 'sqlite\_%' ESCAPE '\'`
 }
 
 func (SqliteDialect) ColumnsSQL(table string) string {

--- a/internal/database/dialect_sqlite.go
+++ b/internal/database/dialect_sqlite.go
@@ -36,7 +36,8 @@ func (SqliteDialect) ListTablesSQL() string {
 	return `SELECT name FROM sqlite_master
 		WHERE type='table'
 		  AND name NOT LIKE '\_kilnx\_%' ESCAPE '\'
-		  AND name NOT LIKE '\_%\_field\_defs' ESCAPE '\'`
+		  AND name NOT LIKE '\_%\_field\_defs' ESCAPE '\'
+		  AND name != 'sqlite_sequence'`
 }
 
 func (SqliteDialect) ColumnsSQL(table string) string {


### PR DESCRIPTION
## Summary

Two features bundled.

### [#99](https://github.com/kilnx-org/kilnx/issues/99), Migration data-loss protection
- `kilnx migrate` detects orphan tables with rows and blocks migration
- `--allow-dataloss` flag bypasses guard
- `kilnx run` emits non-blocking warning in dev mode
- Risk suggestion outputs concrete `ALTER TABLE old RENAME TO new;` SQL hint
- `ListTablesSQL` filters all `sqlite_%` internal tables (not just `sqlite_sequence`)

### [#26](https://github.com/kilnx-org/kilnx/issues/26), Project templates (`kilnx init`)
- `kilnx init <template> <directory>` scaffolds new app
- Templates: `blog`, `api` (embedded via `go:embed`)
- Auto-substitutes `{{PROJECT_NAME}}` with target dir name
- Guards against overwriting existing `app.kilnx`

### Review fixups baked in
- `planExistingTable(model, cm)` signature kept aligned with main; orphan duplicate doc comment removed
- `DetectDataLossRisk` propagates Scan errors instead of swallowing
- COUNT query escapes `"` in interpolated table name
- Templates default to port 8080 to match project convention
- `cmdInit` checks `outPath` existence before `MkdirAll`
- `api.kilnx` mutations use `respond status` (parser silently dropped `return`)
- Test blocks rewritten with documented `visit/fill/submit/expect` verbs
- Analyzer `checkFragmentComponents` skips built-in directives (`each`, `end`, `if`, `else`, `t`, `plural`) so `{{each}}` template syntax stops triggering false "unknown component fragment" errors

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` green across all packages
- [x] 6 new `TestDetectDataLossRisk_*` tests
- [x] 5 new `TestCLI_Init_*` tests, each runs `kilnx check` on generated app
- [x] New `_QuotedTableName`, `_SqliteInternalsFiltered`, `_MissingArgs` regression tests