### PR TITLE
feat(#91): route-based action= attribute (v0.2 phase 1 MVP)

### DIFF
--- a/internal/analyzer/action_attribute_test.go
+++ b/internal/analyzer/action_attribute_test.go
@@ -1,0 +1,45 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/lexer"
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+func TestCheckActionAttributesUnknown(t *testing.T) {
+	src := `page /
+  html
+    <button action="/unknown">Do</button>
+`
+	tokens := lexer.Tokenize(src)
+	app, _ := parser.Parse(tokens, src)
+	diags := Analyze(app)
+	found := false
+	for _, d := range diags {
+		if d.Message == "action attribute references unknown route '/unknown'" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error for unknown action, got: %v", diags)
+	}
+}
+
+func TestCheckActionAttributesValid(t *testing.T) {
+	src := `action /tasks/:id/delete
+  query: DELETE FROM task WHERE id = :id
+
+page /
+  html
+    <button action="/tasks/123/delete">Delete</button>
+`
+	tokens := lexer.Tokenize(src)
+	app, _ := parser.Parse(tokens, src)
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Message == "action attribute references unknown route '/tasks/123/delete'" {
+			t.Errorf("unexpected diagnostic: %v", d)
+		}
+	}
+}

--- a/internal/analyzer/action_attribute_test.go
+++ b/internal/analyzer/action_attribute_test.go
@@ -43,3 +43,41 @@ page /
 		}
 	}
 }
+
+// TestCheckActionAttributesIgnoresForm guards Issue 2/6: <form action="/login">
+// must not be flagged as an unknown action — analyzer only checks button/a/input.
+func TestCheckActionAttributesIgnoresForm(t *testing.T) {
+	src := `page /login
+  html
+    <form action="/login" method="POST"><button type="submit">Go</button></form>
+`
+	tokens := lexer.Tokenize(src)
+	app, _ := parser.Parse(tokens, src)
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Message == "action attribute references unknown route '/login'" {
+			t.Errorf("form action should not be flagged: %v", d)
+		}
+	}
+}
+
+// TestCheckActionAttributesPageRoute guards Issue 6: a button or link with
+// action="/page-path" pointing at a page route should not be flagged.
+func TestCheckActionAttributesPageRoute(t *testing.T) {
+	src := `page /login
+  html
+    Login
+
+page /home
+  html
+    <a action="/login">Sign in</a>
+`
+	tokens := lexer.Tokenize(src)
+	app, _ := parser.Parse(tokens, src)
+	diags := Analyze(app)
+	for _, d := range diags {
+		if d.Message == "action attribute references unknown route '/login'" {
+			t.Errorf("page route should suppress diagnostic: %v", d)
+		}
+	}
+}

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -135,6 +135,7 @@ func Analyze(app *parser.App) []Diagnostic {
 	diags = append(diags, checkCustomManifestRefs(app)...)
 	diags = append(diags, checkFragmentComponents(app)...)
 	diags = append(diags, checkTranslationParams(app)...)
+	diags = append(diags, checkActionAttributes(app)...)
 
 	return diags
 }
@@ -1573,4 +1574,77 @@ func checkTranslationParams(app *parser.App) []Diagnostic {
 	}
 
 	return diags
+}
+
+// checkActionAttributes validates that action="/path" attributes in HTML
+// reference existing action blocks.
+func checkActionAttributes(app *parser.App) []Diagnostic {
+	var diags []Diagnostic
+
+	// Build action path index
+	actionPaths := make(map[string]bool)
+	for _, a := range app.Actions {
+		actionPaths[a.Path] = true
+	}
+
+	actionAttrRe := regexp.MustCompile(`action="([^"]+)"`)
+
+	var scanNodes func([]parser.Node, string)
+	scanNodes = func(nodes []parser.Node, ctx string) {
+		for _, node := range nodes {
+			if node.Type == parser.NodeHTML {
+				for _, match := range actionAttrRe.FindAllStringSubmatch(node.HTMLContent, -1) {
+					path := match[1]
+					found := false
+					for apath := range actionPaths {
+						if pathsMatchAction(apath, path) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						diags = append(diags, Diagnostic{
+							Level:   "error",
+							Message: fmt.Sprintf("action attribute references unknown route '%s'", path),
+							Context: ctx,
+						})
+					}
+				}
+			}
+			scanNodes(node.Children, ctx)
+		}
+	}
+
+	for _, p := range app.Pages {
+		scanNodes(p.Body, "page "+p.Path)
+	}
+	for _, f := range app.Fragments {
+		scanNodes(f.Body, "fragment "+f.Path)
+	}
+	for _, a := range app.Actions {
+		scanNodes(a.Body, "action "+a.Path)
+	}
+	for _, a := range app.APIs {
+		scanNodes(a.Body, "api "+a.Path)
+	}
+
+	return diags
+}
+
+// pathsMatchAction checks if a route template matches a concrete path.
+func pathsMatchAction(template, path string) bool {
+	tParts := strings.Split(template, "/")
+	pParts := strings.Split(path, "/")
+	if len(tParts) != len(pParts) {
+		return false
+	}
+	for i, tp := range tParts {
+		if strings.HasPrefix(tp, ":") {
+			continue
+		}
+		if tp != pParts[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -7,6 +7,7 @@ import (
 	"unicode"
 
 	"github.com/kilnx-org/kilnx/internal/parser"
+	"github.com/kilnx-org/kilnx/internal/pathutil"
 )
 
 // Diagnostic represents a compile-time finding from static analysis.
@@ -1576,18 +1577,35 @@ func checkTranslationParams(app *parser.App) []Diagnostic {
 	return diags
 }
 
-// checkActionAttributes validates that action="/path" attributes in HTML
-// reference existing action blocks.
+// checkActionAttributes validates that action="/path" attributes on
+// <button>, <a> and <input> elements reference an existing action block
+// (or page route, for forms posting to a page). The regex is anchored to
+// these tag names so native <form action="..."> never trips this check.
 func checkActionAttributes(app *parser.App) []Diagnostic {
 	var diags []Diagnostic
 
-	// Build action path index
-	actionPaths := make(map[string]bool)
+	// Build route indexes for actions and pages.
+	actionPaths := make([]string, 0, len(app.Actions))
 	for _, a := range app.Actions {
-		actionPaths[a.Path] = true
+		actionPaths = append(actionPaths, a.Path)
+	}
+	pagePaths := make([]string, 0, len(app.Pages))
+	for _, p := range app.Pages {
+		pagePaths = append(pagePaths, p.Path)
 	}
 
-	actionAttrRe := regexp.MustCompile(`action="([^"]+)"`)
+	// Mirror the runtime regex (render.go: actionAttrRe): only flag action=
+	// usage on button/a/input. <form> is excluded by design.
+	actionAttrRe := regexp.MustCompile(`<(?:button|a|input)\b[^>]*?\saction="([^"]+)"`)
+
+	matchesAny := func(routes []string, path string) bool {
+		for _, r := range routes {
+			if pathutil.Match(r, path) {
+				return true
+			}
+		}
+		return false
+	}
 
 	var scanNodes func([]parser.Node, string)
 	scanNodes = func(nodes []parser.Node, ctx string) {
@@ -1595,20 +1613,20 @@ func checkActionAttributes(app *parser.App) []Diagnostic {
 			if node.Type == parser.NodeHTML {
 				for _, match := range actionAttrRe.FindAllStringSubmatch(node.HTMLContent, -1) {
 					path := match[1]
-					found := false
-					for apath := range actionPaths {
-						if pathsMatchAction(apath, path) {
-							found = true
-							break
-						}
+					if matchesAny(actionPaths, path) {
+						continue
 					}
-					if !found {
-						diags = append(diags, Diagnostic{
-							Level:   "error",
-							Message: fmt.Sprintf("action attribute references unknown route '%s'", path),
-							Context: ctx,
-						})
+					// Suppress diagnostic when the path matches a page
+					// route. Buttons/links pointing at a page are valid
+					// (e.g. an htmx GET to a page fragment).
+					if matchesAny(pagePaths, path) {
+						continue
 					}
+					diags = append(diags, Diagnostic{
+						Level:   "error",
+						Message: fmt.Sprintf("action attribute references unknown route '%s'", path),
+						Context: ctx,
+					})
 				}
 			}
 			scanNodes(node.Children, ctx)
@@ -1629,22 +1647,4 @@ func checkActionAttributes(app *parser.App) []Diagnostic {
 	}
 
 	return diags
-}
-
-// pathsMatchAction checks if a route template matches a concrete path.
-func pathsMatchAction(template, path string) bool {
-	tParts := strings.Split(template, "/")
-	pParts := strings.Split(path, "/")
-	if len(tParts) != len(pParts) {
-		return false
-	}
-	for i, tp := range tParts {
-		if strings.HasPrefix(tp, ":") {
-			continue
-		}
-		if tp != pParts[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/pathutil/match.go
+++ b/internal/pathutil/match.go
@@ -1,0 +1,25 @@
+// Package pathutil provides helpers for matching declarative route templates
+// (e.g. "/tasks/:id/delete") against concrete request paths (e.g. "/tasks/123/delete").
+package pathutil
+
+import "strings"
+
+// Match reports whether template (a route pattern with optional :param segments)
+// matches path (a concrete URL path). Both must have the same number of segments.
+// Segments starting with ':' in template act as wildcards.
+func Match(template, path string) bool {
+	tParts := strings.Split(template, "/")
+	pParts := strings.Split(path, "/")
+	if len(tParts) != len(pParts) {
+		return false
+	}
+	for i, tp := range tParts {
+		if strings.HasPrefix(tp, ":") {
+			continue
+		}
+		if tp != pParts[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pathutil/match_test.go
+++ b/internal/pathutil/match_test.go
@@ -1,0 +1,26 @@
+package pathutil
+
+import "testing"
+
+func TestMatch(t *testing.T) {
+	cases := []struct {
+		template string
+		path     string
+		want     bool
+	}{
+		{"/tasks/:id/delete", "/tasks/123/delete", true},
+		{"/tasks/:id", "/tasks/abc", true},
+		{"/tasks/:id", "/tasks/abc/extra", false},
+		{"/tasks", "/tasks", true},
+		{"/tasks", "/users", false},
+		{"/", "/", true},
+		{"/a/:b/:c", "/a/x/y", true},
+		{"/a/:b/c", "/a/x/y", false},
+	}
+	for _, tc := range cases {
+		got := Match(tc.template, tc.path)
+		if got != tc.want {
+			t.Errorf("Match(%q,%q) = %v, want %v", tc.template, tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/runtime/action_attribute_integration_test.go
+++ b/internal/runtime/action_attribute_integration_test.go
@@ -1,0 +1,81 @@
+package runtime
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/database"
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// TestActionAttributeEndToEndCSRF guards Issue 1 (BLOCKER): a button with
+// action="/foo" must end up with a CSRF token its POST can satisfy. Render
+// the page, pull the token out of hx-vals, then post it back through
+// handleAction. The request must NOT be rejected with 403.
+func TestActionAttributeEndToEndCSRF(t *testing.T) {
+	db, err := database.Open("file::memory:?cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.Conn().Exec("CREATE TABLE task (id INTEGER PRIMARY KEY, title TEXT)")
+
+	action := parser.Page{
+		Path:   "/tasks/create",
+		Method: "POST",
+		Body: []parser.Node{
+			{Type: parser.NodeQuery, SQL: "INSERT INTO task (title) VALUES ('hello')"},
+		},
+	}
+	app := &parser.App{
+		Actions: []parser.Page{action},
+	}
+
+	s := &Server{app: app, db: db}
+	s.sessions = NewSessionStore("test-secret")
+	s.sessions.SetDB(db)
+	s.logger = NewLogger(nil)
+	s.i18n = NewI18n(nil, "en", false)
+
+	// Render a page snippet through renderHTML so the {csrf} placeholder is
+	// substituted just like during a real request.
+	ctx := &renderContext{
+		actions:  app.Actions,
+		i18n:     s.i18n,
+		queries:  map[string][]database.Row{},
+		paginate: map[string]PaginateInfo{},
+	}
+	rendered := renderHTML(`<button action="/tasks/create">Create</button>`, ctx)
+
+	if !strings.Contains(rendered, `hx-post="/tasks/create"`) {
+		t.Fatalf("expected hx-post in rendered output: %s", rendered)
+	}
+	// {csrf} must have been substituted (no literal placeholder left).
+	if strings.Contains(rendered, "{csrf}") {
+		t.Fatalf("csrf placeholder not substituted: %s", rendered)
+	}
+
+	// Pull the CSRF token out of the rendered hx-vals JSON.
+	tokenRe := regexp.MustCompile(`hx-vals='\{"_csrf":"([^"]+)"\}'`)
+	m := tokenRe.FindStringSubmatch(rendered)
+	if len(m) < 2 {
+		t.Fatalf("could not find csrf token in rendered output: %s", rendered)
+	}
+	csrf := m[1]
+
+	// POST it back through handleAction. The handler reads _csrf from
+	// formData; htmx in the browser would translate hx-vals into form
+	// fields, so we mirror that here.
+	form := url.Values{"_csrf": {csrf}}
+	req := httptest.NewRequest("POST", "/tasks/create", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	s.handleAction(rec, req, action, s.getApp())
+
+	if rec.Code == 403 {
+		t.Fatalf("CSRF rejected: action= flow does not propagate a valid token (got 403, body=%q)", rec.Body.String())
+	}
+}

--- a/internal/runtime/action_attribute_test.go
+++ b/internal/runtime/action_attribute_test.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+func TestExpandActionAttributesBasic(t *testing.T) {
+	actions := []parser.Page{
+		{Path: "/tasks/:id/delete", Method: "DELETE"},
+	}
+	ctx := &renderContext{
+		actions: actions,
+	}
+	content := `<button action="/tasks/123/delete">Delete</button>`
+	got := expandActionAttributes(content, ctx)
+	if !strContains(got, `hx-delete="/tasks/123/delete"`) {
+		t.Errorf("missing hx-delete, got: %s", got)
+	}
+	if !strContains(got, `hx-target="closest [data-action-scope='/tasks/:id/delete']"`) {
+		t.Errorf("missing hx-target, got: %s", got)
+	}
+}
+
+func TestExpandActionAttributesPost(t *testing.T) {
+	actions := []parser.Page{
+		{Path: "/tasks", Method: "POST"},
+	}
+	ctx := &renderContext{
+		actions: actions,
+	}
+	content := `<button action="/tasks">Create</button>`
+	got := expandActionAttributes(content, ctx)
+	if !strContains(got, `hx-post="/tasks"`) {
+		t.Errorf("missing hx-post, got: %s", got)
+	}
+}
+
+func TestExpandActionAttributesUnknown(t *testing.T) {
+	actions := []parser.Page{
+		{Path: "/tasks", Method: "POST"},
+	}
+	ctx := &renderContext{
+		actions: actions,
+	}
+	content := `<button action="/unknown">Do</button>`
+	got := expandActionAttributes(content, ctx)
+	if got != content {
+		t.Errorf("expected unchanged for unknown action, got: %s", got)
+	}
+}
+
+func TestExpandActionAttributesInferFromSQL(t *testing.T) {
+	actions := []parser.Page{
+		{
+			Path: "/tasks/:id",
+			Body: []parser.Node{
+				{Type: parser.NodeQuery, SQL: "DELETE FROM task WHERE id = :id"},
+			},
+		},
+	}
+	ctx := &renderContext{
+		actions: actions,
+	}
+	content := `<button action="/tasks/123">Delete</button>`
+	got := expandActionAttributes(content, ctx)
+	if !strContains(got, `hx-delete="/tasks/123"`) {
+		t.Errorf("expected hx-delete inferred from SQL, got: %s", got)
+	}
+}
+
+func strContains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/internal/runtime/action_attribute_test.go
+++ b/internal/runtime/action_attribute_test.go
@@ -16,11 +16,16 @@ func TestExpandActionAttributesBasic(t *testing.T) {
 	}
 	content := `<button action="/tasks/123/delete">Delete</button>`
 	got := expandActionAttributes(content, ctx)
-	if !strContains(got, `hx-delete="/tasks/123/delete"`) {
+	if !strings.Contains(got, `hx-delete="/tasks/123/delete"`) {
 		t.Errorf("missing hx-delete, got: %s", got)
 	}
-	if !strContains(got, `hx-target="closest [data-action-scope='/tasks/:id/delete']"`) {
-		t.Errorf("missing hx-target, got: %s", got)
+	// CSRF placeholder must be emitted for non-GET verbs.
+	if !strings.Contains(got, `hx-vals='{"_csrf":"{csrf}"}'`) {
+		t.Errorf("missing hx-vals csrf, got: %s", got)
+	}
+	// hx-target intentionally omitted; htmx default ("this") applies.
+	if strings.Contains(got, "hx-target=") {
+		t.Errorf("expected no hx-target, got: %s", got)
 	}
 }
 
@@ -33,8 +38,11 @@ func TestExpandActionAttributesPost(t *testing.T) {
 	}
 	content := `<button action="/tasks">Create</button>`
 	got := expandActionAttributes(content, ctx)
-	if !strContains(got, `hx-post="/tasks"`) {
+	if !strings.Contains(got, `hx-post="/tasks"`) {
 		t.Errorf("missing hx-post, got: %s", got)
+	}
+	if !strings.Contains(got, `hx-vals='{"_csrf":"{csrf}"}'`) {
+		t.Errorf("missing csrf hx-vals, got: %s", got)
 	}
 }
 
@@ -52,25 +60,55 @@ func TestExpandActionAttributesUnknown(t *testing.T) {
 	}
 }
 
-func TestExpandActionAttributesInferFromSQL(t *testing.T) {
+// TestExpandActionAttributesGetNoCSRF verifies GET actions do NOT get a CSRF
+// hx-vals payload. Only non-GET verbs need it.
+func TestExpandActionAttributesGetNoCSRF(t *testing.T) {
 	actions := []parser.Page{
-		{
-			Path: "/tasks/:id",
-			Body: []parser.Node{
-				{Type: parser.NodeQuery, SQL: "DELETE FROM task WHERE id = :id"},
-			},
-		},
+		{Path: "/search", Method: "GET"},
 	}
-	ctx := &renderContext{
-		actions: actions,
-	}
-	content := `<button action="/tasks/123">Delete</button>`
+	ctx := &renderContext{actions: actions}
+	content := `<button action="/search">Search</button>`
 	got := expandActionAttributes(content, ctx)
-	if !strContains(got, `hx-delete="/tasks/123"`) {
-		t.Errorf("expected hx-delete inferred from SQL, got: %s", got)
+	if !strings.Contains(got, `hx-get="/search"`) {
+		t.Errorf("missing hx-get, got: %s", got)
+	}
+	if strings.Contains(got, "hx-vals") {
+		t.Errorf("GET should not emit hx-vals csrf, got: %s", got)
 	}
 }
 
-func strContains(s, substr string) bool {
-	return strings.Contains(s, substr)
+// TestExpandActionAttributesSkipsForm guards against the unanchored-regex
+// regression: <form action="..."> must remain untouched so native form
+// submission and extractFormAction in testing.go keep working.
+func TestExpandActionAttributesSkipsForm(t *testing.T) {
+	actions := []parser.Page{
+		{Path: "/login", Method: "POST"},
+	}
+	ctx := &renderContext{actions: actions}
+	content := `<form action="/login" method="POST"><button action="/login">Go</button></form>`
+	got := expandActionAttributes(content, ctx)
+	if !strings.Contains(got, `<form action="/login" method="POST">`) {
+		t.Errorf("form action must be preserved, got: %s", got)
+	}
+	// The button inside the form should still be rewritten.
+	if !strings.Contains(got, `hx-post="/login"`) {
+		t.Errorf("button inside form should still get hx-post, got: %s", got)
+	}
+}
+
+// TestExpandActionAttributesPreservesOtherAttrs checks that surrounding
+// attributes on the button stay intact when the action= attribute is rewritten.
+func TestExpandActionAttributesPreservesOtherAttrs(t *testing.T) {
+	actions := []parser.Page{
+		{Path: "/tasks", Method: "POST"},
+	}
+	ctx := &renderContext{actions: actions}
+	content := `<button class="btn" action="/tasks" id="x">Go</button>`
+	got := expandActionAttributes(content, ctx)
+	if !strings.Contains(got, `class="btn"`) || !strings.Contains(got, `id="x"`) {
+		t.Errorf("surrounding attrs lost, got: %s", got)
+	}
+	if !strings.Contains(got, `hx-post="/tasks"`) {
+		t.Errorf("missing hx-post, got: %s", got)
+	}
 }

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -283,6 +283,9 @@ func renderHTML(content string, ctx *renderContext) string {
 		result = expandTranslations(result, ctx)
 	}
 
+	// Step 0.5: Expand action= attributes to htmx equivalents
+	result = expandActionAttributes(result, ctx)
+
 	// Step 1: Replace each {csrf} with a unique token (one per occurrence for multi-form pages)
 	for strings.Contains(result, "{csrf}") {
 		token := generateCSRFToken()
@@ -1554,4 +1557,116 @@ func splitArgPairs(s string) []string {
 		tokens = append(tokens, cur.String())
 	}
 	return tokens
+}
+
+// actionAttrRe matches action="/path" or action="/path/{id}"
+var actionAttrRe = regexp.MustCompile(`action="([^"]+)"`)
+
+// expandActionAttributes replaces action="/path" with hx-post/hx-delete/etc.
+// It infers the HTTP verb from the matching action block and sets hx-target
+// and hx-swap appropriately.
+func expandActionAttributes(content string, ctx *renderContext) string {
+	if len(ctx.actions) == 0 {
+		return content
+	}
+	return actionAttrRe.ReplaceAllStringFunc(content, func(match string) string {
+		parts := actionAttrRe.FindStringSubmatch(match)
+		if len(parts) < 2 {
+			return match
+		}
+		path := parts[1]
+
+		// Find matching action
+		var matchedAction *parser.Page
+		for i := range ctx.actions {
+			if pathsMatch(ctx.actions[i].Path, path) {
+				matchedAction = &ctx.actions[i]
+				break
+			}
+		}
+		if matchedAction == nil {
+			return match // unknown action, leave for analyzer to catch
+		}
+
+		// Infer HTTP verb
+		verb := inferHTTPVerb(matchedAction)
+
+		// Build hx- attributes
+		var attrs []string
+		switch verb {
+		case "GET":
+			attrs = append(attrs, fmt.Sprintf(`hx-get="%s"`, path))
+		case "POST":
+			attrs = append(attrs, fmt.Sprintf(`hx-post="%s"`, path))
+		case "PUT":
+			attrs = append(attrs, fmt.Sprintf(`hx-put="%s"`, path))
+		case "PATCH":
+			attrs = append(attrs, fmt.Sprintf(`hx-patch="%s"`, path))
+		case "DELETE":
+			attrs = append(attrs, fmt.Sprintf(`hx-delete="%s"`, path))
+		}
+
+		// hx-target: closest ancestor with matching data-action-scope
+		attrs = append(attrs, fmt.Sprintf(`hx-target="closest [data-action-scope='%s']"`, matchedAction.Path))
+
+		// hx-swap: look for swap directive in action body
+		swap := findSwapDirective(matchedAction)
+		if swap != "" {
+			attrs = append(attrs, fmt.Sprintf(`hx-swap="%s"`, swap))
+		}
+
+		return strings.Join(attrs, " ")
+	})
+}
+
+// pathsMatch checks if a route template matches a concrete path.
+// e.g. /tasks/:id/delete matches /tasks/123/delete
+func pathsMatch(template, path string) bool {
+	tParts := strings.Split(template, "/")
+	pParts := strings.Split(path, "/")
+	if len(tParts) != len(pParts) {
+		return false
+	}
+	for i, tp := range tParts {
+		if strings.HasPrefix(tp, ":") {
+			continue
+		}
+		if tp != pParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// inferHTTPVerb guesses the HTTP verb from an action block.
+func inferHTTPVerb(action *parser.Page) string {
+	if action.Method != "" {
+		return strings.ToUpper(action.Method)
+	}
+	// Infer from body nodes
+	for _, node := range action.Body {
+		if node.Type == parser.NodeQuery && node.SQL != "" {
+			sql := strings.ToUpper(strings.TrimSpace(node.SQL))
+			if strings.HasPrefix(sql, "DELETE") {
+				return "DELETE"
+			}
+			if strings.HasPrefix(sql, "UPDATE") {
+				return "PUT"
+			}
+			if strings.HasPrefix(sql, "INSERT") {
+				return "POST"
+			}
+		}
+	}
+	return "POST"
+}
+
+// findSwapDirective searches for a swap: directive in the action body.
+func findSwapDirective(action *parser.Page) string {
+	for _, node := range action.Body {
+		if node.Type == parser.NodeOn && node.Value == "swap" {
+			return "outerHTML"
+		}
+	}
+	return ""
 }

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kilnx-org/kilnx/internal/database"
 	"github.com/kilnx-org/kilnx/internal/parser"
+	"github.com/kilnx-org/kilnx/internal/pathutil"
 )
 
 // Template directives:
@@ -1559,27 +1560,33 @@ func splitArgPairs(s string) []string {
 	return tokens
 }
 
-// actionAttrRe matches action="/path" or action="/path/{id}"
-var actionAttrRe = regexp.MustCompile(`action="([^"]+)"`)
+// actionAttrRe matches action="/path" only inside <button>, <a>, or <input>
+// tags. It deliberately excludes <form action="..."> so native form submission
+// keeps working. Captures: 1=tag name, 2=attrs before action, 3=path,
+// 4=attrs after action.
+var actionAttrRe = regexp.MustCompile(`<(button|a|input)\b([^>]*?)\saction="([^"]+)"([^>]*)>`)
 
-// expandActionAttributes replaces action="/path" with hx-post/hx-delete/etc.
-// It infers the HTTP verb from the matching action block and sets hx-target
-// and hx-swap appropriately.
+// expandActionAttributes replaces action="/path" on supported elements with
+// hx-post/hx-delete/etc. It uses the matching action block's Method (always
+// set by parser, defaults to POST for `action ...`) to pick the verb. For
+// non-GET verbs a CSRF placeholder ({csrf}) is emitted via hx-vals; the
+// surrounding pipeline replaces {csrf} with a real token. <form> elements
+// are intentionally not rewritten.
 func expandActionAttributes(content string, ctx *renderContext) string {
 	if len(ctx.actions) == 0 {
 		return content
 	}
 	return actionAttrRe.ReplaceAllStringFunc(content, func(match string) string {
 		parts := actionAttrRe.FindStringSubmatch(match)
-		if len(parts) < 2 {
+		if len(parts) < 5 {
 			return match
 		}
-		path := parts[1]
+		tag, before, path, after := parts[1], parts[2], parts[3], parts[4]
 
 		// Find matching action
 		var matchedAction *parser.Page
 		for i := range ctx.actions {
-			if pathsMatch(ctx.actions[i].Path, path) {
+			if pathutil.Match(ctx.actions[i].Path, path) {
 				matchedAction = &ctx.actions[i]
 				break
 			}
@@ -1588,10 +1595,8 @@ func expandActionAttributes(content string, ctx *renderContext) string {
 			return match // unknown action, leave for analyzer to catch
 		}
 
-		// Infer HTTP verb
 		verb := inferHTTPVerb(matchedAction)
 
-		// Build hx- attributes
 		var attrs []string
 		switch verb {
 		case "GET":
@@ -1606,67 +1611,29 @@ func expandActionAttributes(content string, ctx *renderContext) string {
 			attrs = append(attrs, fmt.Sprintf(`hx-delete="%s"`, path))
 		}
 
-		// hx-target: closest ancestor with matching data-action-scope
-		attrs = append(attrs, fmt.Sprintf(`hx-target="closest [data-action-scope='%s']"`, matchedAction.Path))
-
-		// hx-swap: look for swap directive in action body
-		swap := findSwapDirective(matchedAction)
-		if swap != "" {
-			attrs = append(attrs, fmt.Sprintf(`hx-swap="%s"`, swap))
+		// CSRF: required for all non-GET verbs (handleAction validates it).
+		// Use the {csrf} placeholder; it is replaced with a fresh token in
+		// step 1 of renderHTML, after this expansion runs.
+		if verb != "GET" {
+			attrs = append(attrs, `hx-vals='{"_csrf":"{csrf}"}'`)
 		}
 
-		return strings.Join(attrs, " ")
+		// No hx-target / hx-swap: omit so htmx defaults apply. The earlier
+		// data-action-scope mechanism was incomplete; revisit when adding
+		// scoped swap support and a real swap-directive grammar.
+
+		return fmt.Sprintf("<%s%s %s%s>", tag, before, strings.Join(attrs, " "), after)
 	})
 }
 
-// pathsMatch checks if a route template matches a concrete path.
-// e.g. /tasks/:id/delete matches /tasks/123/delete
-func pathsMatch(template, path string) bool {
-	tParts := strings.Split(template, "/")
-	pParts := strings.Split(path, "/")
-	if len(tParts) != len(pParts) {
-		return false
-	}
-	for i, tp := range tParts {
-		if strings.HasPrefix(tp, ":") {
-			continue
-		}
-		if tp != pParts[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// inferHTTPVerb guesses the HTTP verb from an action block.
+// inferHTTPVerb returns the HTTP verb declared on an action block.
+// Method is always set by the parser (default "POST" for `action ...`,
+// see parser.parseAction), so this is a thin uppercase wrapper kept for
+// clarity at call sites.
 func inferHTTPVerb(action *parser.Page) string {
 	if action.Method != "" {
 		return strings.ToUpper(action.Method)
 	}
-	// Infer from body nodes
-	for _, node := range action.Body {
-		if node.Type == parser.NodeQuery && node.SQL != "" {
-			sql := strings.ToUpper(strings.TrimSpace(node.SQL))
-			if strings.HasPrefix(sql, "DELETE") {
-				return "DELETE"
-			}
-			if strings.HasPrefix(sql, "UPDATE") {
-				return "PUT"
-			}
-			if strings.HasPrefix(sql, "INSERT") {
-				return "POST"
-			}
-		}
-	}
 	return "POST"
 }
 
-// findSwapDirective searches for a swap: directive in the action body.
-func findSwapDirective(action *parser.Page) string {
-	for _, node := range action.Body {
-		if node.Type == parser.NodeOn && node.Value == "swap" {
-			return "outerHTML"
-		}
-	}
-	return ""
-}

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -1636,4 +1636,3 @@ func inferHTTPVerb(action *parser.Page) string {
 	}
 	return "POST"
 }
-

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -881,7 +881,7 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 	app := s.getApp()
 	ctx := &renderContext{
 		fragmentComponents: s.fragmentComponents,
-				actions: app.Actions,
+		actions:            app.Actions,
 		i18n:               s.i18n,
 		request:            nil,
 		queries:            make(map[string][]database.Row),

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -371,6 +371,7 @@ type renderContext struct {
 	fragmentArgs       map[string]string                      // active component argument bindings
 	fragmentDepth      int                                    // recursion guard for component fragments
 	fragmentComponents map[string]*parser.Page                // component name -> fragment (for inline rendering)
+	actions            []parser.Page                          // declared actions for action= attribute expansion
 	i18n               *I18n                                  // translation engine
 	request            *http.Request                          // current HTTP request (for language detection)
 }
@@ -379,6 +380,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 	app := s.getApp()
 	ctx := &renderContext{
 		fragmentComponents: s.fragmentComponents,
+		actions:            app.Actions,
 		i18n:               s.i18n,
 		request:            r,
 		queries:            make(map[string][]database.Row),
@@ -562,6 +564,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 				if len(layout.Queries) > 0 && s.db != nil {
 					layoutCtx = &renderContext{
 						fragmentComponents: s.fragmentComponents,
+						actions:            app.Actions,
 						i18n:               s.i18n,
 						request:            r,
 						queries:            make(map[string][]database.Row),
@@ -606,6 +609,7 @@ func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Reque
 				if layoutCtx == nil {
 					layoutCtx = &renderContext{
 						fragmentComponents: s.fragmentComponents,
+						actions:            app.Actions,
 						i18n:               s.i18n,
 						request:            r,
 						queries:            make(map[string][]database.Row),
@@ -759,6 +763,7 @@ func (s *Server) renderFragment(frag parser.Page, r *http.Request) string {
 	app := s.getApp()
 	ctx := &renderContext{
 		fragmentComponents: s.fragmentComponents,
+		actions:            app.Actions,
 		i18n:               s.i18n,
 		request:            r,
 		queries:            make(map[string][]database.Row),
@@ -876,6 +881,7 @@ func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]st
 	app := s.getApp()
 	ctx := &renderContext{
 		fragmentComponents: s.fragmentComponents,
+				actions: app.Actions,
 		i18n:               s.i18n,
 		request:            nil,
 		queries:            make(map[string][]database.Row),
@@ -1261,6 +1267,7 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 			}
 			htmlCtx := &renderContext{
 				fragmentComponents: s.fragmentComponents,
+				actions:            app.Actions,
 				i18n:               s.i18n,
 				request:            r,
 				queries:            map[string][]database.Row{"_form": {formRow}},
@@ -1396,6 +1403,7 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 				respondApp := s.getApp()
 				ctx := &renderContext{
 					fragmentComponents: s.fragmentComponents,
+					actions:            respondApp.Actions,
 					i18n:               s.i18n,
 					request:            r,
 					queries:            map[string][]database.Row{"_result": rows},


### PR DESCRIPTION
## Summary

Closes #91.

- **Route-based `action=` attribute**: `<button action="/path">` and `<a action="/path">` and `<input action="/path">` rewrite to the appropriate `hx-{verb}` attribute based on the matching `action` block. `<form action="...">` is intentionally not rewritten so native form submission keeps working.
- **HTTP verb inference**: uses `action.Method` (always set by parser, defaults to POST). DELETE, PUT, PATCH, GET supported.
- **CSRF propagation**: non-GET verbs emit `hx-vals='{\"_csrf\":\"{csrf}\"}'`; the surrounding render pipeline replaces `{csrf}` with a per-occurrence token (`handleAction` validates).
- **Path-template matching**: `pathutil.Match` matches `:param` placeholders so `/tasks/:id/delete` matches `/tasks/123/delete`.

## Review fixes

`a6c567d` addresses post-iteration review:
- **Anchored regex**: `actionAttrRe` now matches only `<button|a|input ... action=\"...\">`. Previous broad `action=\"...\"` regex would have rewritten `<form action>` and unrelated attributes.
- **CSRF for non-GET**: previous version omitted CSRF token; `handleAction` would reject every htmx-issued mutation.
- **Removed dead branches**: `findSwapDirective` checked `node.Type == NodeOn && node.Value == \"swap\"`, but `NodeOn` stores condition in `node.Props[\"condition\"]`, never `Value`. Function was permanently dead. Removed function and call site; comment now reads `// No hx-target / hx-swap: omit so htmx defaults apply.`
- **Path matcher**: extracted `pathutil.Match` (also covered by direct unit tests).

## Test plan

- [x] `go test -race ./...` passes including new tests for action-attribute integration, anchored regex, CSRF emission, pathutil.Match
- [x] `gofmt -l .` clean
- [x] Rebased onto main after #28, #51, #50 merges