### PR TITLE
feat(#77): advanced requires — feature flags and rate limiting

### DIFF
--- a/internal/database/dialect_postgres.go
+++ b/internal/database/dialect_postgres.go
@@ -158,5 +158,16 @@ func (PostgresDialect) InternalTableDDL() []string {
 			completed_at TIMESTAMP,
 			last_error TEXT
 		)`,
+		`CREATE TABLE IF NOT EXISTS _kilnx_flags (
+			name TEXT PRIMARY KEY,
+			enabled BOOLEAN NOT NULL DEFAULT FALSE
+		)`,
+		`CREATE TABLE IF NOT EXISTS _kilnx_rate_limits (
+			scope_key TEXT NOT NULL,
+			limit_period TEXT NOT NULL,
+			window_start BIGINT NOT NULL,
+			request_count INTEGER NOT NULL DEFAULT 1,
+			PRIMARY KEY (scope_key, limit_period, window_start)
+		)`,
 	}
 }

--- a/internal/database/dialect_sqlite.go
+++ b/internal/database/dialect_sqlite.go
@@ -141,5 +141,16 @@ func (SqliteDialect) InternalTableDDL() []string {
 			completed_at DATETIME,
 			last_error TEXT
 		)`,
+		`CREATE TABLE IF NOT EXISTS _kilnx_flags (
+			name TEXT PRIMARY KEY,
+			enabled BOOLEAN NOT NULL DEFAULT 0
+		)`,
+		`CREATE TABLE IF NOT EXISTS _kilnx_rate_limits (
+			scope_key TEXT NOT NULL,
+			limit_period TEXT NOT NULL,
+			window_start INTEGER NOT NULL,
+			request_count INTEGER NOT NULL DEFAULT 1,
+			PRIMARY KEY (scope_key, limit_period, window_start)
+		)`,
 	}
 }

--- a/internal/database/dialect_test.go
+++ b/internal/database/dialect_test.go
@@ -152,8 +152,8 @@ func TestPostgresDialectAutoIncrementPK(t *testing.T) {
 func TestPostgresDialectInternalTableDDL(t *testing.T) {
 	d := PostgresDialect{}
 	stmts := d.InternalTableDDL()
-	if len(stmts) != 4 {
-		t.Fatalf("expected 4 internal tables, got %d", len(stmts))
+	if len(stmts) != 6 {
+		t.Fatalf("expected 6 internal tables, got %d", len(stmts))
 	}
 	// Sessions table should use TIMESTAMP, not DATETIME
 	if !strings.Contains(stmts[0], "TIMESTAMP") {
@@ -162,6 +162,14 @@ func TestPostgresDialectInternalTableDDL(t *testing.T) {
 	// Migrations table should use BIGSERIAL, not AUTOINCREMENT
 	if !strings.Contains(stmts[2], "BIGSERIAL") {
 		t.Errorf("migrations DDL should use BIGSERIAL, got: %s", stmts[2])
+	}
+	// Flags table should exist
+	if !strings.Contains(stmts[4], "_kilnx_flags") {
+		t.Errorf("flags DDL missing, got: %s", stmts[4])
+	}
+	// Rate limits table should exist
+	if !strings.Contains(stmts[5], "_kilnx_rate_limits") {
+		t.Errorf("rate limits DDL missing, got: %s", stmts[5])
 	}
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -149,13 +149,18 @@ const (
 	RequiresClauseRole                                // named role, e.g. "admin"
 	RequiresClauseExpr                                // expression, e.g. "current_user.plan in ['cad','full']"
 	RequiresClauseSuperuser                           // "superuser" — platform operator
+	RequiresClauseFlag                                // flag "name"
+	RequiresClauseRateLimit                           // limit 10/hour per user
 )
 
 // RequiresClause is one predicate in a comma-separated requires list.
 // All clauses are ANDed: the user must satisfy every clause.
 type RequiresClause struct {
-	Kind  RequiresClauseKind
-	Value string // role name for Role; expression text for Expr; empty for Auth/Superuser
+	Kind        RequiresClauseKind
+	Value       string // role name for Role; expression text for Expr; flag name for Flag; empty for Auth/Superuser
+	LimitCount  int    // for RateLimit: max requests
+	LimitPeriod string // for RateLimit: "minute", "hour", "day"
+	LimitScope  string // for RateLimit: "ip", "user", "tenant"
 }
 
 type Model struct {
@@ -3322,7 +3327,8 @@ func splitClauseText(text string) []string {
 // parseOneClause classifies a single requires segment.
 func parseOneClause(s string) RequiresClause {
 	s = strings.TrimSpace(s)
-	switch strings.ToLower(s) {
+	lower := strings.ToLower(s)
+	switch lower {
 	case "", "auth":
 		return RequiresClause{Kind: RequiresClauseAuth}
 	case "superuser":
@@ -3331,7 +3337,40 @@ func parseOneClause(s string) RequiresClause {
 	if strings.HasPrefix(s, ":") {
 		return RequiresClause{Kind: RequiresClauseExpr, Value: strings.TrimPrefix(s, ":")}
 	}
+	// flag "name"
+	if strings.HasPrefix(lower, "flag ") {
+		flagName := strings.TrimSpace(s[5:])
+		flagName = strings.Trim(flagName, `"'`)
+		return RequiresClause{Kind: RequiresClauseFlag, Value: flagName}
+	}
+	// limit 10/hour per user
+	if strings.HasPrefix(lower, "limit ") {
+		return parseRateLimitClause(s[6:])
+	}
 	return RequiresClause{Kind: RequiresClauseRole, Value: s}
+}
+
+// parseRateLimitClause parses "10/hour per user" into a RequiresClause.
+func parseRateLimitClause(s string) RequiresClause {
+	s = strings.TrimSpace(s)
+	// Format: number/period [per scope]
+	parts := strings.Fields(s)
+	if len(parts) == 0 {
+		return RequiresClause{Kind: RequiresClauseRateLimit}
+	}
+	// Parse count/period
+	countPeriod := parts[0]
+	if slashIdx := strings.Index(countPeriod, "/"); slashIdx > 0 {
+		countStr := countPeriod[:slashIdx]
+		period := strings.ToLower(countPeriod[slashIdx+1:])
+		count, _ := strconv.Atoi(countStr)
+		scope := "ip" // default
+		if len(parts) >= 3 && strings.ToLower(parts[1]) == "per" {
+			scope = strings.ToLower(parts[2])
+		}
+		return RequiresClause{Kind: RequiresClauseRateLimit, LimitCount: count, LimitPeriod: period, LimitScope: scope}
+	}
+	return RequiresClause{Kind: RequiresClauseRateLimit}
 }
 
 // skipRequiresClauses advances the token stream past clause tokens, stopping

--- a/internal/parser/requires_clause_test.go
+++ b/internal/parser/requires_clause_test.go
@@ -1,0 +1,79 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/lexer"
+)
+
+func TestParseRequiresFlag(t *testing.T) {
+	src := `page /beta requires auth, flag "beta_ui"
+  "Beta"
+`
+	tokens := lexer.Tokenize(src)
+	app, err := Parse(tokens, src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(app.Pages) != 1 {
+		t.Fatalf("expected 1 page, got %d", len(app.Pages))
+	}
+	clauses := app.Pages[0].RequiresClauses
+	if len(clauses) != 2 {
+		t.Fatalf("expected 2 clauses, got %d", len(clauses))
+	}
+	if clauses[1].Kind != RequiresClauseFlag {
+		t.Errorf("expected Flag clause, got %d", clauses[1].Kind)
+	}
+	if clauses[1].Value != "beta_ui" {
+		t.Errorf("expected flag name 'beta_ui', got %q", clauses[1].Value)
+	}
+}
+
+func TestParseRequiresRateLimit(t *testing.T) {
+	src := `api /exports requires auth, limit 10/hour per tenant
+  query: SELECT * FROM export
+`
+	tokens := lexer.Tokenize(src)
+	app, err := Parse(tokens, src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(app.APIs) != 1 {
+		t.Fatalf("expected 1 api, got %d", len(app.APIs))
+	}
+	clauses := app.APIs[0].RequiresClauses
+	if len(clauses) != 2 {
+		t.Fatalf("expected 2 clauses, got %d", len(clauses))
+	}
+	if clauses[1].Kind != RequiresClauseRateLimit {
+		t.Errorf("expected RateLimit clause, got %d", clauses[1].Kind)
+	}
+	if clauses[1].LimitCount != 10 {
+		t.Errorf("expected limit count 10, got %d", clauses[1].LimitCount)
+	}
+	if clauses[1].LimitPeriod != "hour" {
+		t.Errorf("expected limit period 'hour', got %q", clauses[1].LimitPeriod)
+	}
+	if clauses[1].LimitScope != "tenant" {
+		t.Errorf("expected limit scope 'tenant', got %q", clauses[1].LimitScope)
+	}
+}
+
+func TestParseRequiresRateLimitDefaultScope(t *testing.T) {
+	src := `page /login requires limit 20/minute
+  "Login"
+`
+	tokens := lexer.Tokenize(src)
+	app, err := Parse(tokens, src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	clauses := app.Pages[0].RequiresClauses
+	if len(clauses) != 1 {
+		t.Fatalf("expected 1 clause, got %d", len(clauses))
+	}
+	if clauses[0].LimitScope != "ip" {
+		t.Errorf("expected default scope 'ip', got %q", clauses[0].LimitScope)
+	}
+}

--- a/internal/runtime/api.go
+++ b/internal/runtime/api.go
@@ -174,7 +174,6 @@ func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request, endpoint pars
 					return
 				}
 				allRows = rows
-				// Merge SELECT results into params for subsequent queries
 				name := node.Name
 				if name == "" {
 					name = "_last"

--- a/internal/runtime/auth.go
+++ b/internal/runtime/auth.go
@@ -385,34 +385,42 @@ func (s *Server) hasPermission(userRole, requiredRole string, perms []parser.Per
 }
 
 // evalRequiresClauses returns true when the session satisfies ALL clauses (AND semantics).
-// A superuser (matched by identity) bypasses all checks.
+//
+// Privilege checks (auth, role, expr, superuser) are bypassed for the configured
+// superuser identity. Availability and traffic controls (flag, rate-limit) are
+// always evaluated, since a disabled flag or exhausted endpoint is a signal that
+// no caller, including the operator, should reach the handler.
 func (s *Server) evalRequiresClauses(clauses []parser.RequiresClause, session *Session, r *http.Request) bool {
-	if s.superuserIdentity != "" && session != nil && session.Identity == s.superuserIdentity {
-		return true
-	}
+	isSuperuser := s.superuserIdentity != "" && session != nil && session.Identity == s.superuserIdentity
 	app := s.getApp()
 	for _, clause := range clauses {
 		switch clause.Kind {
-		case parser.RequiresClauseAuth:
-			// satisfied by session existing (already checked before calling this)
-		case parser.RequiresClauseRole:
-			if session.Role != clause.Value && !s.hasPermission(session.Role, clause.Value, app.Permissions) {
-				return false
-			}
-		case parser.RequiresClauseExpr:
-			if !evalAuthExpr(clause.Value, session) {
-				return false
-			}
-		case parser.RequiresClauseSuperuser:
-			if s.superuserIdentity == "" || session.Identity != s.superuserIdentity {
-				return false
-			}
 		case parser.RequiresClauseFlag:
 			if !s.resolveFlag(clause.Value) {
 				return false
 			}
 		case parser.RequiresClauseRateLimit:
 			if r != nil && !s.checkRateLimit(clause.LimitCount, clause.LimitPeriod, clause.LimitScope, r, session) {
+				return false
+			}
+		case parser.RequiresClauseAuth:
+			// satisfied by session existing (already checked before calling this)
+		case parser.RequiresClauseRole:
+			if isSuperuser {
+				continue
+			}
+			if session.Role != clause.Value && !s.hasPermission(session.Role, clause.Value, app.Permissions) {
+				return false
+			}
+		case parser.RequiresClauseExpr:
+			if isSuperuser {
+				continue
+			}
+			if !evalAuthExpr(clause.Value, session) {
+				return false
+			}
+		case parser.RequiresClauseSuperuser:
+			if s.superuserIdentity == "" || session.Identity != s.superuserIdentity {
 				return false
 			}
 		}
@@ -1004,94 +1012,54 @@ func (s *Server) resolveFlag(name string) bool {
 }
 
 // rateLimitKey returns the key for rate limiting based on scope.
-func rateLimitKey(scope string, r *http.Request, session *Session) string {
+// Returns empty string when the scope cannot be resolved (e.g. `per tenant`
+// on a single-tenant app); the caller treats empty as "no limit applied".
+func (s *Server) rateLimitKey(scope string, r *http.Request, session *Session) string {
 	switch scope {
 	case "user":
 		if session != nil {
-			return session.Identity
+			return "user:" + session.Identity
 		}
 		return ""
 	case "tenant":
 		if session != nil {
-			// Try to extract tenant from user row data
 			if tenantID, ok := session.Data["tenant_id"]; ok && tenantID != "" {
-				return tenantID
+				return "tenant:" + tenantID
 			}
 			if orgID, ok := session.Data["org_id"]; ok && orgID != "" {
-				return orgID
+				return "tenant:" + orgID
 			}
 		}
+		s.warnTenantScopeOnce()
 		return ""
 	case "ip":
-		return r.RemoteAddr
+		return "ip:" + clientIP(r)
 	default:
-		return r.RemoteAddr
+		return "ip:" + clientIP(r)
 	}
+}
+
+// warnTenantScopeOnce logs once that `per tenant` resolved to an empty key.
+// Surfaces a misconfiguration that would otherwise silently disable the limit.
+func (s *Server) warnTenantScopeOnce() {
+	s.tenantWarnOnce.Do(func() {
+		if s.logger != nil {
+			s.logger.LogSecurity("rate-limit clause uses `per tenant` but no tenant_id/org_id present on session; clause is a no-op", nil)
+		}
+	})
 }
 
 // checkRateLimit returns true if the request is within the rate limit.
-// It increments the counter in the _kilnx_rate_limits table.
+// Uses the in-memory RateLimiter (mutex-protected, race-safe) so the check
+// works identically on SQLite and PostgreSQL deployments. Single-instance only:
+// in a multi-process deployment each instance enforces its own counter.
 func (s *Server) checkRateLimit(count int, period string, scope string, r *http.Request, session *Session) bool {
-	if s.db == nil {
-		return true
-	}
-	key := rateLimitKey(scope, r, session)
+	key := s.rateLimitKey(scope, r, session)
 	if key == "" {
-		return true // no key to rate limit by
-	}
-
-	rawDB, ok := s.db.(*database.DB)
-	if !ok || rawDB == nil {
 		return true
 	}
-
-	window := rateLimitWindow(period)
-	if window == 0 {
+	if s.rateLimiter == nil {
 		return true
 	}
-
-	now := time.Now().Unix()
-	windowStart := now - window
-
-	// Clean old entries and count current window
-	_, _ = rawDB.Conn().Exec("DELETE FROM _kilnx_rate_limits WHERE window_start < ?", windowStart)
-
-	var currentCount int
-	err := rawDB.Conn().QueryRow(
-		"SELECT request_count FROM _kilnx_rate_limits WHERE scope_key = ? AND limit_period = ? AND window_start = ?",
-		key, period, windowStart,
-	).Scan(&currentCount)
-
-	if err != nil {
-		// No entry yet, create one
-		_, _ = rawDB.Conn().Exec(
-			"INSERT INTO _kilnx_rate_limits (scope_key, limit_period, window_start, request_count) VALUES (?, ?, ?, 1)",
-			key, period, windowStart,
-		)
-		return true
-	}
-
-	if currentCount >= count {
-		return false
-	}
-
-	_, _ = rawDB.Conn().Exec(
-		"UPDATE _kilnx_rate_limits SET request_count = request_count + 1 WHERE scope_key = ? AND limit_period = ? AND window_start = ?",
-		key, period, windowStart,
-	)
-	return true
-}
-
-func rateLimitWindow(period string) int64 {
-	switch strings.ToLower(period) {
-	case "second":
-		return 1
-	case "minute":
-		return 60
-	case "hour":
-		return 3600
-	case "day":
-		return 86400
-	}
-	return 0
+	return s.rateLimiter.CheckClause(count, period, key)
 }

--- a/internal/runtime/auth.go
+++ b/internal/runtime/auth.go
@@ -289,7 +289,7 @@ func (s *Server) requireAuth(w http.ResponseWriter, r *http.Request, page parser
 	}
 
 	if len(page.RequiresClauses) > 0 {
-		if !s.evalRequiresClauses(page.RequiresClauses, session) {
+		if !s.evalRequiresClauses(page.RequiresClauses, session, r) {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusForbidden)
 			w.Write([]byte(renderForbidden(app.Pages, session)))
@@ -332,7 +332,7 @@ func (s *Server) requireAPIAuth(w http.ResponseWriter, r *http.Request, page par
 	}
 
 	if len(page.RequiresClauses) > 0 {
-		if !s.evalRequiresClauses(page.RequiresClauses, session) {
+		if !s.evalRequiresClauses(page.RequiresClauses, session, r) {
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			w.WriteHeader(http.StatusForbidden)
 			w.Write([]byte(`{"error":"forbidden"}`))
@@ -386,7 +386,7 @@ func (s *Server) hasPermission(userRole, requiredRole string, perms []parser.Per
 
 // evalRequiresClauses returns true when the session satisfies ALL clauses (AND semantics).
 // A superuser (matched by identity) bypasses all checks.
-func (s *Server) evalRequiresClauses(clauses []parser.RequiresClause, session *Session) bool {
+func (s *Server) evalRequiresClauses(clauses []parser.RequiresClause, session *Session, r *http.Request) bool {
 	if s.superuserIdentity != "" && session != nil && session.Identity == s.superuserIdentity {
 		return true
 	}
@@ -405,6 +405,14 @@ func (s *Server) evalRequiresClauses(clauses []parser.RequiresClause, session *S
 			}
 		case parser.RequiresClauseSuperuser:
 			if s.superuserIdentity == "" || session.Identity != s.superuserIdentity {
+				return false
+			}
+		case parser.RequiresClauseFlag:
+			if !s.resolveFlag(clause.Value) {
+				return false
+			}
+		case parser.RequiresClauseRateLimit:
+			if r != nil && !s.checkRateLimit(clause.LimitCount, clause.LimitPeriod, clause.LimitScope, r, session) {
 				return false
 			}
 		}
@@ -974,4 +982,116 @@ func sanitizeIdentifier(name string) string {
 		result = "_" + result
 	}
 	return result
+}
+
+// resolveFlag checks if a feature flag is enabled.
+// Priority: 1) env var FLAG_<NAME>, 2) DB table _kilnx_flags, 3) false
+func (s *Server) resolveFlag(name string) bool {
+	envName := "FLAG_" + strings.ToUpper(name)
+	if v := os.Getenv(envName); v != "" {
+		return v == "true" || v == "1" || v == "yes"
+	}
+	if s.db != nil {
+		if rawDB, ok := s.db.(*database.DB); ok && rawDB != nil {
+			var enabled bool
+			err := rawDB.Conn().QueryRow("SELECT enabled FROM _kilnx_flags WHERE name = ?", name).Scan(&enabled)
+			if err == nil {
+				return enabled
+			}
+		}
+	}
+	return false
+}
+
+// rateLimitKey returns the key for rate limiting based on scope.
+func rateLimitKey(scope string, r *http.Request, session *Session) string {
+	switch scope {
+	case "user":
+		if session != nil {
+			return session.Identity
+		}
+		return ""
+	case "tenant":
+		if session != nil {
+			// Try to extract tenant from user row data
+			if tenantID, ok := session.Data["tenant_id"]; ok && tenantID != "" {
+				return tenantID
+			}
+			if orgID, ok := session.Data["org_id"]; ok && orgID != "" {
+				return orgID
+			}
+		}
+		return ""
+	case "ip":
+		return r.RemoteAddr
+	default:
+		return r.RemoteAddr
+	}
+}
+
+// checkRateLimit returns true if the request is within the rate limit.
+// It increments the counter in the _kilnx_rate_limits table.
+func (s *Server) checkRateLimit(count int, period string, scope string, r *http.Request, session *Session) bool {
+	if s.db == nil {
+		return true
+	}
+	key := rateLimitKey(scope, r, session)
+	if key == "" {
+		return true // no key to rate limit by
+	}
+
+	rawDB, ok := s.db.(*database.DB)
+	if !ok || rawDB == nil {
+		return true
+	}
+
+	window := rateLimitWindow(period)
+	if window == 0 {
+		return true
+	}
+
+	now := time.Now().Unix()
+	windowStart := now - window
+
+	// Clean old entries and count current window
+	_, _ = rawDB.Conn().Exec("DELETE FROM _kilnx_rate_limits WHERE window_start < ?", windowStart)
+
+	var currentCount int
+	err := rawDB.Conn().QueryRow(
+		"SELECT request_count FROM _kilnx_rate_limits WHERE scope_key = ? AND limit_period = ? AND window_start = ?",
+		key, period, windowStart,
+	).Scan(&currentCount)
+
+	if err != nil {
+		// No entry yet, create one
+		_, _ = rawDB.Conn().Exec(
+			"INSERT INTO _kilnx_rate_limits (scope_key, limit_period, window_start, request_count) VALUES (?, ?, ?, 1)",
+			key, period, windowStart,
+		)
+		return true
+	}
+
+	if currentCount >= count {
+		return false
+	}
+
+	_, _ = rawDB.Conn().Exec(
+		"UPDATE _kilnx_rate_limits SET request_count = request_count + 1 WHERE scope_key = ? AND limit_period = ? AND window_start = ?",
+		key, period, windowStart,
+	)
+	return true
+}
+
+func rateLimitWindow(period string) int64 {
+	switch strings.ToLower(period) {
+	case "second":
+		return 1
+	case "minute":
+		return 60
+	case "hour":
+		return 3600
+	case "day":
+		return 86400
+	}
+	return 0
 }

--- a/internal/runtime/auth_test.go
+++ b/internal/runtime/auth_test.go
@@ -68,6 +68,22 @@ func TestSessionVerify_InvalidSignature(t *testing.T) {
 	}
 }
 
+func TestSessionVerify_NoSecret(t *testing.T) {
+	ss := &SessionStore{sessions: make(map[string]*Session), secret: ""}
+	id, valid := ss.verifySessionID("plain-id")
+	if !valid || id != "plain-id" {
+		t.Errorf("expected plain-id when secret is empty, got %q, valid=%v", id, valid)
+	}
+}
+
+func TestSessionVerify_MalformedCookie(t *testing.T) {
+	ss := NewSessionStore("my-secret")
+	_, valid := ss.verifySessionID("nosig")
+	if valid {
+		t.Error("verifySessionID should return false for malformed cookie")
+	}
+}
+
 func TestCheckPasswordInvalidHash(t *testing.T) {
 	if CheckPassword("anything", "not-a-bcrypt-hash") {
 		t.Error("CheckPassword should return false for invalid hash")
@@ -1139,5 +1155,59 @@ func TestDelete_WithDB(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected DB delete to be called")
+	}
+}
+
+func TestValidateFormData_CustomFieldsColumnMode(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name:             "product",
+			CustomFieldsFile: "product.json",
+			Fields: []parser.Field{
+				{Name: "name", Type: parser.FieldText, Required: true},
+			},
+		}},
+		CustomManifests: map[string]*parser.CustomFieldManifest{
+			"product": {
+				ModelName: "product",
+				Fields: []parser.CustomFieldDef{
+					{Name: "sku", Kind: parser.CustomFieldKindText, Mode: parser.CustomFieldModeColumn, Required: true},
+				},
+			},
+		},
+	}
+	// Missing column-mode field (promoted to top-level)
+	errs := validateFormData("product", app, map[string]string{"name": "Widget"})
+	if len(errs) == 0 {
+		t.Fatal("expected error for missing column-mode custom field")
+	}
+	// Valid column-mode field
+	errs = validateFormData("product", app, map[string]string{"name": "Widget", "sku": "W123"})
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateFormData_CustomFieldsInvalidNumber(t *testing.T) {
+	app := &parser.App{
+		Models: []parser.Model{{
+			Name:             "invoice",
+			CustomFieldsFile: "invoice.json",
+			Fields: []parser.Field{
+				{Name: "number", Type: parser.FieldText, Required: true},
+			},
+		}},
+		CustomManifests: map[string]*parser.CustomFieldManifest{
+			"invoice": {
+				ModelName: "invoice",
+				Fields: []parser.CustomFieldDef{
+					{Name: "amount", Kind: parser.CustomFieldKindNumber, Required: false},
+				},
+			},
+		},
+	}
+	errs := validateFormData("invoice", app, map[string]string{"number": "INV1", "custom": `{"amount":"not-a-number"}`})
+	if len(errs) == 0 {
+		t.Fatal("expected error for invalid number custom field")
 	}
 }

--- a/internal/runtime/flag_rate_limit_test.go
+++ b/internal/runtime/flag_rate_limit_test.go
@@ -1,0 +1,101 @@
+package runtime
+
+import (
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/database"
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+func TestResolveFlagEnv(t *testing.T) {
+	os.Setenv("FLAG_BETA_UI", "true")
+	defer os.Unsetenv("FLAG_BETA_UI")
+
+	app := &parser.App{}
+	srv := NewServer(app, nil, 0)
+	if !srv.resolveFlag("beta_ui") {
+		t.Error("expected flag to be true from env")
+	}
+}
+
+func TestResolveFlagEnvFalse(t *testing.T) {
+	os.Setenv("FLAG_BETA_UI", "false")
+	defer os.Unsetenv("FLAG_BETA_UI")
+
+	app := &parser.App{}
+	srv := NewServer(app, nil, 0)
+	if srv.resolveFlag("beta_ui") {
+		t.Error("expected flag to be false from env")
+	}
+}
+
+func TestResolveFlagDB(t *testing.T) {
+	tmp := t.TempDir() + "/test.db"
+	db, _ := database.Open(tmp)
+	defer db.Close()
+
+	// Create flags table manually
+	db.Conn().Exec(`CREATE TABLE _kilnx_flags (name TEXT PRIMARY KEY, enabled BOOLEAN NOT NULL DEFAULT 0)`)
+	db.Conn().Exec(`INSERT INTO _kilnx_flags (name, enabled) VALUES ('beta_ui', 1)`)
+
+	app := &parser.App{}
+	srv := NewServer(app, db, 0)
+	if !srv.resolveFlag("beta_ui") {
+		t.Error("expected flag to be true from DB")
+	}
+}
+
+func TestRateLimitIP(t *testing.T) {
+	tmp := t.TempDir() + "/test.db"
+	db, _ := database.Open(tmp)
+	defer db.Close()
+
+	// Create rate limits table manually
+	db.Conn().Exec(`CREATE TABLE _kilnx_rate_limits (
+		scope_key TEXT NOT NULL,
+		limit_period TEXT NOT NULL,
+		window_start INTEGER NOT NULL,
+		request_count INTEGER NOT NULL DEFAULT 1,
+		PRIMARY KEY (scope_key, limit_period, window_start)
+	)`)
+
+	app := &parser.App{}
+	srv := NewServer(app, db, 0)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	// First 5 requests should pass
+	for i := 0; i < 5; i++ {
+		if !srv.checkRateLimit(5, "minute", "ip", r, nil) {
+			t.Fatalf("request %d should pass", i+1)
+		}
+	}
+	// 6th request should fail
+	if srv.checkRateLimit(5, "minute", "ip", r, nil) {
+		t.Error("6th request should be rate limited")
+	}
+}
+
+func TestRateLimitUser(t *testing.T) {
+	tmp := t.TempDir() + "/test.db"
+	db, _ := database.Open(tmp)
+	defer db.Close()
+
+	db.Conn().Exec(`CREATE TABLE _kilnx_rate_limits (
+		scope_key TEXT NOT NULL,
+		limit_period TEXT NOT NULL,
+		window_start INTEGER NOT NULL,
+		request_count INTEGER NOT NULL DEFAULT 1,
+		PRIMARY KEY (scope_key, limit_period, window_start)
+	)`)
+
+	app := &parser.App{}
+	srv := NewServer(app, db, 0)
+
+	sess := &Session{Identity: "user@example.com"}
+	r := httptest.NewRequest("GET", "/", nil)
+	if !srv.checkRateLimit(10, "hour", "user", r, sess) {
+		t.Error("first request should pass")
+	}
+}

--- a/internal/runtime/forms_test.go
+++ b/internal/runtime/forms_test.go
@@ -118,3 +118,14 @@ func TestExtractFormData_CustomBrackets(t *testing.T) {
 		t.Errorf("expected region promoted to top level, got %q", data["region"])
 	}
 }
+
+func TestExtractFormData_MultipartParseError(t *testing.T) {
+	// invalid multipart body
+	req := httptest.NewRequest("POST", "/upload", strings.NewReader("not multipart"))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=----fake")
+
+	data := extractFormData(req, nil)
+	if data == nil {
+		t.Error("expected empty map, not nil")
+	}
+}

--- a/internal/runtime/fragment_component_test.go
+++ b/internal/runtime/fragment_component_test.go
@@ -316,3 +316,58 @@ func TestExpandFragmentCallsWithQueryValue(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+func TestExpandFragmentCallsNilComponents(t *testing.T) {
+	ctx := &renderContext{}
+	content := `{{badge status=active}}`
+	got := expandFragmentCalls(content, ctx)
+	if got != content {
+		t.Errorf("expected unchanged when components nil, got %q", got)
+	}
+}
+
+func TestExpandFragmentCallsEmptyComponents(t *testing.T) {
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{},
+	}
+	content := `{{badge status=active}}`
+	got := expandFragmentCalls(content, ctx)
+	if got != content {
+		t.Errorf("expected unchanged when components empty, got %q", got)
+	}
+}
+
+func TestExpandFragmentCallsNoHTMLBody(t *testing.T) {
+	badge := &parser.Page{
+		Path:         "badge",
+		FragmentArgs: []parser.FragmentArg{{Name: "status"}},
+		Body:         []parser.Node{},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"badge": badge},
+	}
+	content := `{{badge status=active}}`
+	got := expandFragmentCalls(content, ctx)
+	if got != "" {
+		t.Errorf("expected empty when no HTML body, got %q", got)
+	}
+}
+
+func TestExpandFragmentCallsLiteralFallback(t *testing.T) {
+	badge := &parser.Page{
+		Path:         "badge",
+		FragmentArgs: []parser.FragmentArg{{Name: "status"}},
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<span>{status}</span>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"badge": badge},
+	}
+	content := `{{badge status=unresolved_var}}`
+	got := expandFragmentCalls(content, ctx)
+	want := `<span>unresolved_var</span>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/handlers_test.go
+++ b/internal/runtime/handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,7 @@ func newTestServer(db database.Executor) *Server {
 			Identity:     "email",
 			Password:     "password_hash",
 			LoginPath:    "/login",
+			LogoutPath:   "/logout",
 			RegisterPath: "/register",
 			ForgotPath:   "/forgot-password",
 			ResetPath:    "/reset-password",
@@ -33,12 +35,13 @@ func newTestServer(db database.Executor) *Server {
 		},
 	}
 	s := &Server{
-		app:      app,
-		db:       db,
-		sessions: NewSessionStore("test-secret"),
-		logger:   NewLogger(nil),
-		i18n:     NewI18n(nil, "en", false),
-		tenants:  nil,
+		app:         app,
+		db:          db,
+		sessions:    NewSessionStore("test-secret"),
+		logger:      NewLogger(nil),
+		i18n:        NewI18n(nil, "en", false),
+		tenants:     nil,
+		rateLimiter: NewRateLimiter(nil),
 	}
 	if db != nil {
 		s.sessions.SetDB(db)
@@ -801,6 +804,34 @@ func TestHandleActionNodes_FetchError(t *testing.T) {
 	// Should log error and continue
 }
 
+func TestHandleActionNodes_QueryTenantError(t *testing.T) {
+	mock := newMockExecutor()
+	s := newTestServer(mock)
+	s.tenants = TenantMap{"orders": "org"}
+	req := httptest.NewRequest("POST", "/action", nil)
+	rec := httptest.NewRecorder()
+	s.handleActionNodes(rec, req, []parser.Node{
+		{Type: parser.NodeQuery, SQL: `SELECT * FROM orders`},
+	}, map[string]string{}, s.getApp())
+	// Should log security and continue
+}
+
+func TestHandleActionNodes_EnqueueMissingParam(t *testing.T) {
+	mock := newMockExecutor()
+	s := newTestServer(mock)
+	app := s.getApp()
+	app.Jobs = []parser.Job{{Name: "notify"}}
+	s.jobQueue = NewJobQueue(s)
+	req := httptest.NewRequest("POST", "/action", nil)
+	rec := httptest.NewRecorder()
+	s.handleActionNodes(rec, req, []parser.Node{
+		{Type: parser.NodeEnqueue, JobName: "notify", JobParams: map[string]string{
+			"user_id": ":missing",
+		}},
+	}, map[string]string{}, s.getApp())
+	// Should fall through to literal value when param missing
+}
+
 // ---------- handleLogin ----------
 
 func TestHandleLogin_Success(t *testing.T) {
@@ -1075,6 +1106,27 @@ func TestHandleRegister_NoAuthConfig(t *testing.T) {
 	s.handleRegister(rec, req)
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("code = %d, want 500", rec.Code)
+	}
+}
+
+func TestHandleRegister_DBError(t *testing.T) {
+	mock := newMockExecutor()
+	mock.execErr[`INSERT INTO "users" (name, "email", "password_hash") VALUES (:name, :identity, :password)`] = fmt.Errorf("disk full")
+	s := newTestServer(mock)
+	csrf := generateCSRFToken()
+
+	form := url.Values{"_csrf": {csrf}, "identity": {"new@example.com"}, "password": {"secret123"}, "confirm_password": {"secret123"}}
+	req := httptest.NewRequest("POST", "/register", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	s.handleRegister(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("code = %d, want 303", rec.Code)
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.Contains(loc, "error=Could+not+create+account") {
+		t.Errorf("expected db error, got %q", loc)
 	}
 }
 
@@ -1666,10 +1718,11 @@ func TestHandleAction_OnForbiddenWithSession(t *testing.T) {
 }
 
 func TestHandleAction_SendEmailWithToQuery(t *testing.T) {
-	db, err := database.Open("file::memory:?cache=shared")
+	db, err := database.Open("/tmp/test_email.db")
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
+	defer os.Remove("/tmp/test_email.db")
 	defer db.Close()
 
 	if _, err := db.Conn().Exec("CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT)"); err != nil {
@@ -2217,6 +2270,44 @@ func TestHandleAction_LLMNodeDefaultName(t *testing.T) {
 	}
 }
 
+func TestHandleAction_LLMWithTx(t *testing.T) {
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Conn().Exec("CREATE TABLE prompts (id INTEGER PRIMARY KEY, content TEXT)"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+	if _, err := db.Conn().Exec("INSERT INTO prompts (content) VALUES ('Say hi')"); err != nil {
+		t.Fatalf("failed to insert: %v", err)
+	}
+
+	s := newTestServer(db)
+	csrf := generateCSRFToken()
+	form := url.Values{"_csrf": {csrf}}
+	req := httptest.NewRequest("POST", "/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	action := parser.Page{
+		Path: "/action",
+		Body: []parser.Node{
+			{Type: parser.NodeQuery, SQL: `SELECT content FROM prompts`, Name: "prompt"},
+			{Type: parser.NodeLLM, SQL: "Say hello", Name: "response", Props: map[string]string{
+				"prompt_query": "prompt",
+			}},
+			{Type: parser.NodeRedirect, Value: "/done"},
+		},
+	}
+	s.handleAction(rec, req, action, s.getApp())
+	// LLM may fail without API key, but should not panic and tx path should be covered
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("code = %d, want 303", rec.Code)
+	}
+}
+
 func TestHandleAction_RespondWithQueryTenantReject(t *testing.T) {
 	db, err := database.Open(":memory:")
 	if err != nil {
@@ -2643,5 +2734,165 @@ func TestRenderPage_QueryError(t *testing.T) {
 	// Query error is logged but page continues rendering
 	if !strings.Contains(got, "hello") {
 		t.Errorf("expected hello in output, got %q", got)
+	}
+}
+
+func TestHandleAction_RedirectHXRequest(t *testing.T) {
+	s := newTestServer(nil)
+	csrf := generateCSRFToken()
+	form := url.Values{"_csrf": {csrf}}
+	req := httptest.NewRequest("POST", "/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rec := httptest.NewRecorder()
+
+	action := parser.Page{
+		Path: "/action",
+		Body: []parser.Node{
+			{Type: parser.NodeRedirect, Value: "/success"},
+		},
+	}
+	s.handleAction(rec, req, action, s.getApp())
+	if rec.Code != http.StatusOK {
+		t.Errorf("code = %d, want 200 for htmx redirect", rec.Code)
+	}
+	hxRedirect := rec.Header().Get("HX-Redirect")
+	if hxRedirect != "/success" {
+		t.Errorf("hx-redirect = %q, want /success", hxRedirect)
+	}
+}
+
+func TestHandleAction_RespondQueryError(t *testing.T) {
+	mock := newMockExecutor()
+	mock.queryRowsErr[`SELECT name FROM users`] = fmt.Errorf("db error")
+	s := newTestServer(mock)
+	csrf := generateCSRFToken()
+	form := url.Values{"_csrf": {csrf}}
+	req := httptest.NewRequest("POST", "/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	action := parser.Page{
+		Path: "/action",
+		Body: []parser.Node{
+			{Type: parser.NodeRespond, QuerySQL: `SELECT name FROM users`, StatusCode: 200},
+		},
+	}
+	s.handleAction(rec, req, action, s.getApp())
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("code = %d, want 500", rec.Code)
+	}
+}
+
+func TestHandleAction_RedirectHXRequestFragmentMatch(t *testing.T) {
+	s := newTestServer(nil)
+	s.app.Fragments = []parser.Page{
+		{Path: "/channel/:id/messages", Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div>messages</div>`},
+		}},
+	}
+	csrf := generateCSRFToken()
+	form := url.Values{"_csrf": {csrf}}
+	req := httptest.NewRequest("POST", "/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rec := httptest.NewRecorder()
+
+	action := parser.Page{
+		Path: "/action",
+		Body: []parser.Node{
+			{Type: parser.NodeRedirect, Value: "/channel/6/messages"},
+		},
+	}
+	s.handleAction(rec, req, action, s.getApp())
+	if rec.Code != http.StatusOK {
+		t.Errorf("code = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "messages") {
+		t.Errorf("expected fragment content, got %q", rec.Body.String())
+	}
+}
+
+func TestHandleAction_RedirectHXRequestPrefixMatch(t *testing.T) {
+	s := newTestServer(nil)
+	s.app.Fragments = []parser.Page{
+		{Path: "/channel/:id/messages/list", Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div>list</div>`},
+		}},
+	}
+	csrf := generateCSRFToken()
+	form := url.Values{"_csrf": {csrf}}
+	req := httptest.NewRequest("POST", "/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	rec := httptest.NewRecorder()
+
+	action := parser.Page{
+		Path: "/action",
+		Body: []parser.Node{
+			{Type: parser.NodeRedirect, Value: "/channel/6/messages"},
+		},
+	}
+	s.handleAction(rec, req, action, s.getApp())
+	if rec.Code != http.StatusOK {
+		t.Errorf("code = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "list") {
+		t.Errorf("expected fragment content, got %q", rec.Body.String())
+	}
+}
+
+func TestHandleAction_GeneratePDFDataQueryNotFound(t *testing.T) {
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	s := newTestServer(db)
+	csrf := generateCSRFToken()
+	form := url.Values{"_csrf": {csrf}}
+	req := httptest.NewRequest("POST", "/action", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	action := parser.Page{
+		Path: "/action",
+		Body: []parser.Node{
+			{Type: parser.NodeQuery, SQL: `SELECT name FROM users`, Name: "users"},
+			{Type: parser.NodeGeneratePDF, TemplateName: "Report", DataQueryName: "nonexistent"},
+			{Type: parser.NodeRedirect, Value: "/done"},
+		},
+	}
+	s.handleAction(rec, req, action, s.getApp())
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("code = %d, want 303", rec.Code)
+	}
+}
+
+func TestHandleResetPassword_WithSMTP(t *testing.T) {
+	t.Setenv("KILNX_SMTP_HOST", "invalid.smtp.host")
+	t.Setenv("KILNX_SMTP_FROM", "noreply@example.com")
+	t.Setenv("KILNX_SMTP_USER", "user")
+
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+	db.Conn().Exec("CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, password_hash TEXT)")
+	db.Conn().Exec("INSERT INTO users (email, password_hash) VALUES ('user@example.com', 'oldhash')")
+	db.Conn().Exec("CREATE TABLE _kilnx_password_resets (token TEXT, email TEXT, expires_at TEXT)")
+	db.Conn().Exec("INSERT INTO _kilnx_password_resets (token, email, expires_at) VALUES ('abc123', 'user@example.com', datetime('now', '+1 hour'))")
+
+	s := newTestServer(db)
+	csrf := generateCSRFToken()
+	form := url.Values{"_csrf": {csrf}, "password": {"newpass123"}, "confirm_password": {"newpass123"}}
+	req := httptest.NewRequest("POST", "/reset-password?token=abc123", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	s.handleResetPassword(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("code = %d, want 303", rec.Code)
 	}
 }

--- a/internal/runtime/helpers_test.go
+++ b/internal/runtime/helpers_test.go
@@ -422,6 +422,7 @@ func TestExpandCustomFields(t *testing.T) {
 	rows := []database.Row{
 		{"name": "Deal A", "custom": `{"revenue":"100"}`},
 		{"name": "Deal B", "custom": ``},
+		{"name": "Deal C", "custom": `not json`},
 	}
 	got := expandCustomFields(rows)
 	if got[0]["custom.revenue"] != "100" {
@@ -429,6 +430,9 @@ func TestExpandCustomFields(t *testing.T) {
 	}
 	if _, ok := got[1]["custom.revenue"]; ok {
 		t.Error("empty custom should not produce fields")
+	}
+	if _, ok := got[2]["custom.revenue"]; ok {
+		t.Error("invalid json should not produce fields")
 	}
 }
 
@@ -504,8 +508,9 @@ func TestFlattenPayload(t *testing.T) {
 		"nested": map[string]interface{}{
 			"foo": "bar",
 		},
-		"flag":  true,
-		"count": 5,
+		"flag":   true,
+		"count":  5,
+		"active": false,
 	}
 	got := flattenPayload(payload, "stripe")
 	if got["stripe_id"] != "evt_123" {
@@ -522,6 +527,9 @@ func TestFlattenPayload(t *testing.T) {
 	}
 	if got["stripe_count"] != "5" {
 		t.Errorf("stripe_count = %q, want 5", got["stripe_count"])
+	}
+	if got["stripe_active"] != "false" {
+		t.Errorf("stripe_active = %q, want false", got["stripe_active"])
 	}
 }
 
@@ -733,6 +741,34 @@ func TestNextCronOccurrence_Weekday(t *testing.T) {
 	}
 	if got.Hour() != 9 || got.Minute() != 0 {
 		t.Errorf("expected 09:00, got %02d:%02d", got.Hour(), got.Minute())
+	}
+}
+
+func TestNextCronOccurrence_TodayPassed(t *testing.T) {
+	// Use a time far in the past so "today" has definitely passed
+	got := nextCronOccurrence("every monday at 0:00")
+	if got.IsZero() {
+		t.Fatal("expected non-zero time")
+	}
+	if got.Weekday() != time.Monday {
+		t.Errorf("expected Monday, got %v", got.Weekday())
+	}
+	// If today is Monday, the time should be next Monday (7 days later)
+	if time.Now().Weekday() == time.Monday {
+		expected := time.Now().AddDate(0, 0, 7)
+		if got.Day() != expected.Day() {
+			t.Errorf("expected next Monday (day %d), got day %d", expected.Day(), got.Day())
+		}
+	}
+}
+
+func TestNextCronOccurrence_NoMinutes(t *testing.T) {
+	got := nextCronOccurrence("every day at 5")
+	if got.IsZero() {
+		t.Fatal("expected non-zero time")
+	}
+	if got.Hour() != 5 || got.Minute() != 0 {
+		t.Errorf("expected 05:00, got %02d:%02d", got.Hour(), got.Minute())
 	}
 }
 
@@ -961,6 +997,29 @@ func TestVerifyStripeSignature_OldTimestamp(t *testing.T) {
 	}
 }
 
+func TestVerifyStripeSignature_InvalidTimestamp(t *testing.T) {
+	header := "t=notanumber,v1=abc"
+	if verifyStripeSignature([]byte("{}"), header, "secret") {
+		t.Error("expected invalid timestamp to fail")
+	}
+}
+
+func TestVerifyStripeSignature_ExtraParts(t *testing.T) {
+	secret := "whsec_test"
+	payload := []byte(`{"id":"evt_123"}`)
+	timestamp := fmt.Sprintf("%d", time.Now().Unix())
+
+	signedPayload := timestamp + "." + string(payload)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signedPayload))
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	header := fmt.Sprintf("foo=bar,t=%s,v1=%s", timestamp, sig)
+	if !verifyStripeSignature(payload, header, secret) {
+		t.Error("expected valid signature with extra parts to pass")
+	}
+}
+
 // ---------- websocket.go ----------
 
 func TestWriteWSFrame_Small(t *testing.T) {
@@ -1025,6 +1084,30 @@ func TestBuildCustomIterRows_EmptyManifest(t *testing.T) {
 	got := buildCustomIterRows(row, manifest)
 	if len(got) != 0 {
 		t.Errorf("expected 0 rows, got %d", len(got))
+	}
+}
+
+func TestBuildCustomIterRows_InvalidJSON(t *testing.T) {
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields:    []parser.CustomFieldDef{{Name: "revenue", Kind: parser.CustomFieldKindNumber, Label: "Revenue"}},
+	}
+	row := database.Row{"custom": `not json`}
+	got := buildCustomIterRows(row, manifest)
+	if len(got) != 1 || got[0]["value"] != "" {
+		t.Errorf("expected empty value for invalid JSON, got %v", got)
+	}
+}
+
+func TestBuildCustomIterRows_EmptyLabel(t *testing.T) {
+	manifest := &parser.CustomFieldManifest{
+		ModelName: "deal",
+		Fields:    []parser.CustomFieldDef{{Name: "revenue", Kind: parser.CustomFieldKindNumber}},
+	}
+	row := database.Row{"custom": `{"revenue":100}`}
+	got := buildCustomIterRows(row, manifest)
+	if len(got) != 1 || got[0]["label"] != "revenue" {
+		t.Errorf("expected label fallback to name, got %v", got)
 	}
 }
 
@@ -1470,6 +1553,39 @@ func TestLogger_LogSlowQuery_Disabled(t *testing.T) {
 	l.LogSlowQuery("SELECT *", 500*time.Millisecond) // should not print
 }
 
+func TestLoggingMiddleware(t *testing.T) {
+	l := NewLogger(&parser.LogConfig{LogRequests: true})
+	handler := l.LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		w.Write([]byte("hello"))
+	}))
+	req := httptest.NewRequest("GET", "/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("code = %d, want 418", rec.Code)
+	}
+	if rec.Body.String() != "hello" {
+		t.Errorf("body = %q, want hello", rec.Body.String())
+	}
+}
+
+func TestLoggingResponseWriter_HijackUnsupported(t *testing.T) {
+	rec := httptest.NewRecorder()
+	lw := &loggingResponseWriter{ResponseWriter: rec, statusCode: 200}
+	_, _, err := lw.Hijack()
+	if err == nil {
+		t.Error("expected error for unsupported hijack")
+	}
+}
+
+func TestLoggingResponseWriter_FlushUnsupported(t *testing.T) {
+	rec := httptest.NewRecorder()
+	lw := &loggingResponseWriter{ResponseWriter: rec, statusCode: 200}
+	// Should not panic even if underlying writer doesn't support Flusher
+	lw.Flush()
+}
+
 // ---------- permissions.go ----------
 
 func TestResolvePermissionPlaceholders_Missing(t *testing.T) {
@@ -1706,5 +1822,25 @@ func TestResolveManifest_DynamicPathNoFallback(t *testing.T) {
 	got := s.resolveManifest(model, app, nil, map[string]string{"org": "missing"}, nil)
 	if got != nil {
 		t.Error("expected nil when file missing and no fallback")
+	}
+}
+
+func TestResolveManifest_DynamicPathNonKilnxExtension(t *testing.T) {
+	manifest := &parser.CustomFieldManifest{ModelName: "deal"}
+	s := &Server{}
+	model := &parser.Model{
+		Name:                 "deal",
+		CustomFieldsFile:     "tenant_{:org}.json",
+		CustomFieldsFallback: "static",
+	}
+	app := &parser.App{
+		CustomManifests: map[string]*parser.CustomFieldManifest{
+			"deal": manifest,
+		},
+	}
+	// Resolved path does not end in .kilnx and dynamic fields false → nil
+	got := s.resolveManifest(model, app, nil, map[string]string{"org": "acme"}, nil)
+	if got != nil {
+		t.Errorf("expected nil for non-.kilnx resolved path without dynamic fields, got %v", got)
 	}
 }

--- a/internal/runtime/i18n_params_test.go
+++ b/internal/runtime/i18n_params_test.go
@@ -193,3 +193,68 @@ func TestExpandTranslationsWithQuery(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+func TestExpandTranslationsMissingParam(t *testing.T) {
+	i18n := NewI18n(map[string]map[string]string{
+		"en": {"greeting": "Hello {name} from {place}"},
+	}, "en", false)
+	ctx := &renderContext{
+		i18n:    i18n,
+		request: &http.Request{},
+	}
+	content := `{t.greeting name="World"}`
+	got := expandTranslations(content, ctx)
+	want := "Hello World from {place}"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandTranslationsNoParams(t *testing.T) {
+	i18n := NewI18n(map[string]map[string]string{
+		"en": {"hello": "Hello"},
+	}, "en", false)
+	ctx := &renderContext{
+		i18n:    i18n,
+		request: &http.Request{},
+	}
+	content := `{t.hello}`
+	got := expandTranslations(content, ctx)
+	want := "Hello"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandPluralizationTwo(t *testing.T) {
+	i18n := NewI18n(map[string]map[string]string{
+		"en": {"items": "{count|plural: two='a pair', other='{count} items'}"},
+	}, "en", false)
+	ctx := &renderContext{
+		i18n:    i18n,
+		request: &http.Request{},
+	}
+	content := `{t.items count=2}`
+	got := expandTranslations(content, ctx)
+	want := "a pair"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandPluralizationNonNumeric(t *testing.T) {
+	i18n := NewI18n(map[string]map[string]string{
+		"en": {"items": "{count|plural:'item','items'}"},
+	}, "en", false)
+	ctx := &renderContext{
+		i18n:    i18n,
+		request: &http.Request{},
+	}
+	content := `{t.items count=xyz}`
+	got := expandTranslations(content, ctx)
+	// Non-numeric count parses as 0, which falls to plural form
+	want := "items"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/permissions_test.go
+++ b/internal/runtime/permissions_test.go
@@ -433,3 +433,16 @@ func TestRewritePermissionSQL_UnresolvedPlaceholder(t *testing.T) {
 		t.Errorf("expected unchanged SQL when placeholder unresolved, got %q", result)
 	}
 }
+
+func TestBuildPermissionMap_InvalidRule(t *testing.T) {
+	app := &parser.App{
+		Permissions: []parser.Permission{
+			{Role: "admin", Rules: []string{"invalid_rule_format!!!"}},
+		},
+	}
+	pm := BuildPermissionMap(app)
+	// Role map is created but contains no rules
+	if len(pm["admin"]) != 0 {
+		t.Errorf("expected empty rule map for invalid rule, got %v", pm)
+	}
+}

--- a/internal/runtime/query_conditional_test.go
+++ b/internal/runtime/query_conditional_test.go
@@ -90,3 +90,23 @@ func TestExpandQueryConditionalsNoConditionals(t *testing.T) {
 		t.Errorf("got %q, want %q", got, sql)
 	}
 }
+
+func TestExpandQueryConditionalsMalformedTag(t *testing.T) {
+	sql := "SELECT * FROM orders {{if params.status AND status = 1"
+	params := map[string]string{"status": "shipped"}
+	got := expandQueryConditionals(sql, params)
+	// Malformed tag (no }}) should be preserved as-is
+	if got != sql {
+		t.Errorf("got %q, want %q", got, sql)
+	}
+}
+
+func TestExpandQueryConditionalsMissingEnd(t *testing.T) {
+	sql := "SELECT * FROM orders {{if params.status}}AND status = 1"
+	params := map[string]string{"status": "shipped"}
+	got := expandQueryConditionals(sql, params)
+	// Missing {{end}} should be preserved as-is
+	if got != sql {
+		t.Errorf("got %q, want %q", got, sql)
+	}
+}

--- a/internal/runtime/ratelimit.go
+++ b/internal/runtime/ratelimit.go
@@ -68,6 +68,37 @@ func NewRateLimiter(rules []parser.RateLimit) *RateLimiter {
 	return rl
 }
 
+// CheckClause enforces a per-key counter for `requires limit N/period per scope`
+// clauses. Returns true if the request is within the limit. Uses the same
+// in-memory map as path-level rules, scoped under a "clause:" prefix.
+func (rl *RateLimiter) CheckClause(count int, period string, key string) bool {
+	if key == "" || count <= 0 {
+		return true
+	}
+	window := windowDuration(period)
+	if window == 0 {
+		return true
+	}
+
+	mapKey := "clause:" + period + ":" + key
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := time.Now()
+	entry, exists := rl.entries[mapKey]
+	if !exists || now.After(entry.expiresAt) {
+		rl.entries[mapKey] = &rateLimitEntry{
+			count:     1,
+			expiresAt: now.Add(window),
+		}
+		return true
+	}
+	if entry.count >= count {
+		return false
+	}
+	entry.count++
+	return true
+}
+
 // minWindow returns the shortest window duration across all rules
 func (rl *RateLimiter) minWindow() time.Duration {
 	min := time.Hour

--- a/internal/runtime/render_test.go
+++ b/internal/runtime/render_test.go
@@ -1387,3 +1387,25 @@ func TestFindMatchingEnd_LoopExhausted(t *testing.T) {
 		t.Error("expected empty body/elseBody")
 	}
 }
+
+// ---------- inferHTTPVerb ----------
+
+func TestInferHTTPVerb(t *testing.T) {
+	tests := []struct {
+		name   string
+		action parser.Page
+		want   string
+	}{
+		{"explicit GET", parser.Page{Method: "GET"}, "GET"},
+		{"explicit post lowercase", parser.Page{Method: "post"}, "POST"},
+		{"empty body defaults to POST", parser.Page{Body: []parser.Node{}}, "POST"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferHTTPVerb(&tt.action)
+			if got != tt.want {
+				t.Errorf("inferHTTPVerb() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/requires_clauses_test.go
+++ b/internal/runtime/requires_clauses_test.go
@@ -89,7 +89,7 @@ func TestEvalRequiresClauses_auth(t *testing.T) {
 	s := makeServer("")
 	sess := makeSession("u@e.com", "viewer", nil)
 	clauses := []parser.RequiresClause{{Kind: parser.RequiresClauseAuth}}
-	if !s.evalRequiresClauses(clauses, sess) {
+	if !s.evalRequiresClauses(clauses, sess, nil) {
 		t.Error("auth clause should pass for logged-in user")
 	}
 }
@@ -100,10 +100,10 @@ func TestEvalRequiresClauses_role(t *testing.T) {
 	viewer := makeSession("v@e.com", "viewer", nil)
 
 	clauses := []parser.RequiresClause{{Kind: parser.RequiresClauseRole, Value: "admin"}}
-	if !s.evalRequiresClauses(clauses, admin) {
+	if !s.evalRequiresClauses(clauses, admin, nil) {
 		t.Error("admin clause should pass for admin user")
 	}
-	if s.evalRequiresClauses(clauses, viewer) {
+	if s.evalRequiresClauses(clauses, viewer, nil) {
 		t.Error("admin clause should fail for viewer")
 	}
 }
@@ -115,11 +115,11 @@ func TestEvalRequiresClauses_expr(t *testing.T) {
 		{Kind: parser.RequiresClauseAuth},
 		{Kind: parser.RequiresClauseExpr, Value: "current_user.plan in ['cad','full']"},
 	}
-	if !s.evalRequiresClauses(clauses, sess) {
+	if !s.evalRequiresClauses(clauses, sess, nil) {
 		t.Error("should pass: user has plan=cad")
 	}
 	sess2 := makeSession("u@e.com", "viewer", database.Row{"plan": "basic"})
-	if s.evalRequiresClauses(clauses, sess2) {
+	if s.evalRequiresClauses(clauses, sess2, nil) {
 		t.Error("should fail: user has plan=basic")
 	}
 }
@@ -130,10 +130,10 @@ func TestEvalRequiresClauses_superuser_clause(t *testing.T) {
 	regular := makeSession("user@example.com", "admin", nil)
 
 	clauses := []parser.RequiresClause{{Kind: parser.RequiresClauseSuperuser}}
-	if !s.evalRequiresClauses(clauses, ops) {
+	if !s.evalRequiresClauses(clauses, ops, nil) {
 		t.Error("superuser clause should pass for superuser identity")
 	}
-	if s.evalRequiresClauses(clauses, regular) {
+	if s.evalRequiresClauses(clauses, regular, nil) {
 		t.Error("superuser clause should fail for non-superuser")
 	}
 }
@@ -144,7 +144,7 @@ func TestEvalRequiresClauses_superuserBypass(t *testing.T) {
 
 	// superuser bypasses even an admin-only clause
 	clauses := []parser.RequiresClause{{Kind: parser.RequiresClauseRole, Value: "admin"}}
-	if !s.evalRequiresClauses(clauses, ops) {
+	if !s.evalRequiresClauses(clauses, ops, nil) {
 		t.Error("superuser identity should bypass role check")
 	}
 }
@@ -222,5 +222,13 @@ func TestCompareNumeric_invalid(t *testing.T) {
 	}
 	if compareNumeric("abc", "def") != -1 {
 		t.Errorf("expected -1 (abc < def lexicographically), got %d", compareNumeric("abc", "def"))
+	}
+}
+
+func TestEvalSingleAuthCondition_UnknownOperator(t *testing.T) {
+	sess := makeSession("user@example.com", "viewer", nil)
+	got := evalSingleAuthCondition("current_user.role ~= admin", sess)
+	if got != false {
+		t.Errorf("expected false for unknown operator, got %v", got)
 	}
 }

--- a/internal/runtime/scheduler_test.go
+++ b/internal/runtime/scheduler_test.go
@@ -252,6 +252,21 @@ func TestJobQueueStartWithNoDB(t *testing.T) {
 	jq.Start()
 }
 
+func TestServer_StartJobQueue(t *testing.T) {
+	srv := &Server{app: &parser.App{}, db: nil, port: 0}
+	srv.jobQueue = NewJobQueue(srv)
+	// Should delegate to jobQueue.Start without panic
+	srv.StartJobQueue()
+}
+
+func TestJobQueueStart_WithJobs(t *testing.T) {
+	srv := &Server{app: &parser.App{Jobs: []parser.Job{{Name: "test"}}}, db: nil, port: 0}
+	jq := NewJobQueue(srv)
+	jq.jobs["test"] = parser.Job{Name: "test"}
+	// Should not panic and should print ready message
+	jq.Start()
+}
+
 // ---------- recoverOrphanedJobs ----------
 
 func TestRecoverOrphanedJobsNilDB(t *testing.T) {
@@ -696,16 +711,15 @@ func TestExecuteNodes_SendEmailWithQuery(t *testing.T) {
 }
 
 func TestSafeExecuteNodes_PanicRecovery(t *testing.T) {
-	mock := newMockExecutor()
-	s := newTestServer(mock)
-	jq := NewJobQueue(s)
-	// Pass a node that will cause a panic inside executeNodes
-	// (nil server should not happen, but we can test recovery)
+	jq := &JobQueue{server: nil}
 	err := jq.safeExecuteNodes([]parser.Node{
 		{Type: parser.NodeQuery, SQL: `SELECT 1`},
 	}, nil)
-	if err != nil {
-		t.Errorf("expected no error for simple query, got %v", err)
+	if err == nil {
+		t.Fatal("expected error when server is nil (panic recovered)")
+	}
+	if !strings.Contains(err.Error(), "panic") {
+		t.Errorf("expected panic error, got %v", err)
 	}
 }
 
@@ -800,9 +814,8 @@ func TestExecuteNodes_SendEmailWithAttachment(t *testing.T) {
 	mock := newMockExecutor()
 	s := newTestServer(mock)
 	err := s.executeNodes([]parser.Node{
-		{Type: parser.NodeSendEmail, EmailTo: "user@example.com", EmailSubject: "Hello", Props: map[string]string{
-			"body":   "See attached",
-			"attach": "_generated_pdf",
+		{Type: parser.NodeSendEmail, EmailTo: "user@example.com", EmailSubject: "Hello", EmailAttach: "_generated_pdf", Props: map[string]string{
+			"body": "See attached",
 		}},
 	}, map[string]string{"_generated_pdf": "/tmp/fake.pdf"})
 	if err == nil {
@@ -814,13 +827,63 @@ func TestExecuteNodes_SendEmailWithAttachmentFromParam(t *testing.T) {
 	mock := newMockExecutor()
 	s := newTestServer(mock)
 	err := s.executeNodes([]parser.Node{
-		{Type: parser.NodeSendEmail, EmailTo: "user@example.com", EmailSubject: "Hello", Props: map[string]string{
-			"body":   "See attached",
-			"attach": "report_path",
+		{Type: parser.NodeSendEmail, EmailTo: "user@example.com", EmailSubject: "Hello", EmailAttach: "report_path", Props: map[string]string{
+			"body": "See attached",
 		}},
 	}, map[string]string{"report_path": "/tmp/report.pdf"})
 	if err == nil {
 		t.Error("expected error when SMTP is not configured")
+	}
+}
+
+func TestExecuteNodes_SendEmailQueryTenantRejection(t *testing.T) {
+	mock := newMockExecutor()
+	s := newTestServer(mock)
+	s.tenants = TenantMap{"users": "org_id"}
+	err := s.executeNodes([]parser.Node{
+		{Type: parser.NodeSendEmail, EmailTo: "user@example.com", EmailSubject: "Hello", Props: map[string]string{
+			"to_query": `SELECT email FROM users`,
+		}},
+	}, map[string]string{})
+	if err == nil {
+		t.Error("expected error when SMTP is not configured")
+	}
+}
+
+func TestExecuteNodes_EnqueueMissingParam(t *testing.T) {
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Conn().Exec(`CREATE TABLE _kilnx_jobs (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		name TEXT NOT NULL,
+		params TEXT NOT NULL DEFAULT '{}',
+		state TEXT NOT NULL DEFAULT 'available',
+		attempts INTEGER NOT NULL DEFAULT 0,
+		max_attempts INTEGER NOT NULL DEFAULT 1,
+		scheduled_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		started_at DATETIME,
+		completed_at DATETIME,
+		last_error TEXT
+	)`); err != nil {
+		t.Fatalf("failed to create jobs table: %v", err)
+	}
+
+	s := newTestServer(db)
+	s.app.Jobs = []parser.Job{{Name: "notify", MaxRetries: 3}}
+	s.jobQueue = NewJobQueue(s)
+
+	err = s.executeNodes([]parser.Node{
+		{Type: parser.NodeEnqueue, JobName: "notify", JobParams: map[string]string{
+			"user_id": ":missing",
+			"msg":     "hello",
+		}},
+	}, map[string]string{})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
 	}
 }
 
@@ -887,6 +950,57 @@ func TestRunCronSchedule_Executes(t *testing.T) {
 		// expected
 	case <-time.After(2 * time.Second):
 		t.Fatal("runCronSchedule did not exit")
+	}
+}
+
+func TestExecuteNodes_NilParams(t *testing.T) {
+	s := newTestServer(nil)
+	err := s.executeNodes([]parser.Node{
+		{Type: parser.NodeQuery, SQL: `SELECT 1`, Name: "q"},
+	}, nil)
+	if err != nil {
+		t.Errorf("expected no error with nil params, got %v", err)
+	}
+}
+
+func TestExecuteNodes_FetchNoName(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id": 1}`))
+	}))
+	defer ts.Close()
+
+	s := newTestServer(nil)
+	err := s.executeNodes([]parser.Node{
+		{Type: parser.NodeFetch, FetchURL: ts.URL},
+	}, map[string]string{})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestExecuteNodes_SendEmailToQueryTenantRejection(t *testing.T) {
+	s := newTestServer(nil)
+	s.tenants = TenantMap{"users": "users"}
+	err := s.executeNodes([]parser.Node{
+		{Type: parser.NodeSendEmail, EmailTo: ":email", EmailSubject: "Hello", Props: map[string]string{
+			"to_query": `SELECT email FROM users WHERE tenant_id = 1`,
+		}},
+	}, map[string]string{})
+	// Tenant guard rejects query because no current_user.tenant_id
+	if err == nil {
+		t.Error("expected error when tenant guard rejects to_query")
+	}
+}
+
+func TestExecuteNodes_EnqueueUnknownJob(t *testing.T) {
+	s := newTestServer(nil)
+	s.jobQueue = NewJobQueue(s)
+	err := s.executeNodes([]parser.Node{
+		{Type: parser.NodeEnqueue, JobName: "unknown"},
+	}, map[string]string{})
+	if err == nil {
+		t.Error("expected error for unknown job")
 	}
 }
 
@@ -994,5 +1108,63 @@ func TestExecuteNodes_GeneratePDFNoData(t *testing.T) {
 	}, map[string]string{})
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestRunSchedule_CronBranch(t *testing.T) {
+	app := &parser.App{
+		Schedules: []parser.Schedule{
+			{
+				Name: "cron",
+				Cron: "something invalid",
+				Body: []parser.Node{},
+			},
+		},
+	}
+	srv := &Server{app: app, port: 0}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		srv.runSchedule(app.Schedules[0], stop)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// expected: invalid cron causes immediate return via runCronSchedule
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSchedule should exit immediately for invalid cron")
+	}
+}
+
+func TestRunCronSchedule_ExecuteError(t *testing.T) {
+	mock := newMockExecutor()
+	mock.execErr[`INSERT INTO logs (msg) VALUES (:msg)`] = fmt.Errorf("db error")
+
+	app := &parser.App{
+		Schedules: []parser.Schedule{
+			{
+				Name: "fast",
+				Cron: "every day at 23:59",
+				Body: []parser.Node{
+					{Type: parser.NodeQuery, SQL: `INSERT INTO logs (msg) VALUES (:msg)`},
+				},
+			},
+		},
+	}
+	srv := &Server{app: app, db: mock, port: 0}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		srv.runCronSchedule(app.Schedules[0], stop)
+		close(done)
+	}()
+	// Wait long enough for the timer to fire (it won't because next is far future)
+	// Instead close stop immediately to test the stop path
+	close(stop)
+	select {
+	case <-done:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("runCronSchedule did not exit")
 	}
 }

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	superuserIdentity  string                  // identity of the platform operator; bypasses all role checks
 	fragmentComponents map[string]*parser.Page // component name -> fragment (for inline rendering)
 	mu                 sync.RWMutex
+	tenantWarnOnce     sync.Once
 	port               int
 	scheduleStop       chan struct{}
 }

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -1098,7 +1098,7 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action par
 				if sess == nil {
 					shouldExecute = true
 				} else if len(action.RequiresClauses) > 0 {
-					shouldExecute = !s.evalRequiresClauses(action.RequiresClauses, sess)
+					shouldExecute = !s.evalRequiresClauses(action.RequiresClauses, sess, r)
 				} else if action.RequiresRole != "" && action.RequiresRole != "auth" {
 					shouldExecute = sess.Role != action.RequiresRole &&
 						!s.hasPermission(sess.Role, action.RequiresRole, app.Permissions)

--- a/internal/runtime/server_render_test.go
+++ b/internal/runtime/server_render_test.go
@@ -808,3 +808,137 @@ func TestRenderFragment_CustomFieldsNoManifest(t *testing.T) {
 		t.Errorf("expected Deal A, got %q", got)
 	}
 }
+
+func TestRenderPage_LayoutWithEmptyQuery(t *testing.T) {
+	s := newTestServer(nil)
+	s.app.Layouts = []parser.Layout{
+		{
+			Name:        "main",
+			HTMLContent: `<html><body>{page.content}</body></html>`,
+			Queries: []parser.Node{
+				{SQL: ""},
+			},
+		},
+	}
+	s.app.Pages = append(s.app.Pages, parser.Page{
+		Path:   "/layout-empty-query",
+		Layout: "main",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<h1>Hi</h1>`},
+		},
+	})
+
+	req := httptest.NewRequest("GET", "/layout-empty-query", nil)
+	page := findPageByPath(s.app.Pages, "/layout-empty-query")
+	if page == nil {
+		t.Fatal("page not found")
+	}
+	got := s.renderPage(*page, s.app.Pages, req)
+	if !strings.Contains(got, "<h1>Hi</h1>") {
+		t.Errorf("expected page content, got %q", got)
+	}
+}
+
+func TestRenderPage_LayoutWithTenantRejection(t *testing.T) {
+	mock := newMockExecutor()
+	s := newTestServer(mock)
+	s.tenants = TenantMap{"settings": "org_id"}
+	s.app.Layouts = []parser.Layout{
+		{
+			Name:        "main",
+			HTMLContent: `<html><body>{page.content}</body></html>`,
+			Queries: []parser.Node{
+				{SQL: `SELECT title FROM settings`, Name: "settings"},
+			},
+		},
+	}
+	s.app.Pages = append(s.app.Pages, parser.Page{
+		Path:   "/layout-tenant-reject",
+		Layout: "main",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<h1>Hi</h1>`},
+		},
+	})
+
+	req := httptest.NewRequest("GET", "/layout-tenant-reject", nil)
+	page := findPageByPath(s.app.Pages, "/layout-tenant-reject")
+	if page == nil {
+		t.Fatal("page not found")
+	}
+	got := s.renderPage(*page, s.app.Pages, req)
+	if !strings.Contains(got, "<h1>Hi</h1>") {
+		t.Errorf("expected page content despite layout tenant rejection, got %q", got)
+	}
+}
+
+func TestRenderNav_NoTitle(t *testing.T) {
+	pages := []parser.Page{
+		{Path: "/", Title: "Home"},
+		{Path: "/about", Title: ""},
+		{Path: "/contact", Title: "Contact Us"},
+	}
+	nav := renderNav(pages, "/about", nil, "MyApp", "")
+	if !strings.Contains(nav, ">About<") {
+		t.Errorf("expected 'About' label for page without title, got %q", nav)
+	}
+	if !strings.Contains(nav, ">Home<") {
+		t.Errorf("expected 'Home' label, got %q", nav)
+	}
+	if !strings.Contains(nav, ">Contact Us<") {
+		t.Errorf("expected 'Contact Us' label, got %q", nav)
+	}
+}
+
+func TestRenderNav_WithSession(t *testing.T) {
+	pages := []parser.Page{
+		{Path: "/", Title: "Home"},
+	}
+	session := &Session{Identity: "alice@example.com"}
+	nav := renderNav(pages, "/", session, "MyApp", "/custom-logout")
+	if !strings.Contains(nav, "alice@example.com") {
+		t.Errorf("expected identity in nav, got %q", nav)
+	}
+	if !strings.Contains(nav, "/custom-logout") {
+		t.Errorf("expected custom logout path, got %q", nav)
+	}
+}
+
+func TestRenderNav_SkipsParamPaths(t *testing.T) {
+	pages := []parser.Page{
+		{Path: "/", Title: "Home"},
+		{Path: "/user/:id", Title: "User"},
+	}
+	nav := renderNav(pages, "/", nil, "", "")
+	if strings.Contains(nav, "User") {
+		t.Errorf("expected param path to be skipped, got %q", nav)
+	}
+}
+
+func TestRenderPage_PaginationNoParams(t *testing.T) {
+	mock := newMockExecutor()
+	countSQL := `SELECT COUNT(*) as _count FROM (SELECT id FROM users)`
+	dataSQL := `SELECT id FROM users LIMIT 10 OFFSET 0`
+	mock.queryRowsResults[countSQL] = []database.Row{{"_count": "5"}}
+	mock.queryRowsResults[dataSQL] = []database.Row{
+		{"id": "1"},
+		{"id": "2"},
+	}
+	s := newTestServer(mock)
+	s.app.Pages = append(s.app.Pages, parser.Page{
+		Path: "/users",
+		Body: []parser.Node{
+			{Type: parser.NodeQuery, SQL: `SELECT id FROM users`, Name: "users", Paginate: 10},
+			{Type: parser.NodeHTML, HTMLContent: `<p>{paginate.users.total}</p>`},
+		},
+	})
+
+	req := httptest.NewRequest("GET", "/users", nil)
+	page := findPageByPath(s.app.Pages, "/users")
+	if page == nil {
+		t.Fatal("page not found")
+	}
+	got := s.renderPage(*page, s.app.Pages, req)
+	if !strings.Contains(got, "5") {
+		t.Errorf("expected total count, got %q", got)
+	}
+}

--- a/internal/runtime/stream.go
+++ b/internal/runtime/stream.go
@@ -23,7 +23,7 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request, stream par
 			return
 		}
 		if len(stream.RequiresClauses) > 0 {
-			if !s.evalRequiresClauses(stream.RequiresClauses, session) {
+			if !s.evalRequiresClauses(stream.RequiresClauses, session, r) {
 				http.Error(w, "Forbidden", http.StatusForbidden)
 				return
 			}

--- a/internal/runtime/tenant_test.go
+++ b/internal/runtime/tenant_test.go
@@ -221,6 +221,17 @@ func TestRewriteTenantSQL_MutationNeedleInsideCommentRejected(t *testing.T) {
 	}
 }
 
+func TestRewriteTenantSQL_NonSelectNonMutationPasses(t *testing.T) {
+	// PRAGMA does not touch tenant tables
+	got, err := RewriteTenantSQL("PRAGMA foreign_keys = ON", BuildTenantMap(buildApp(t)), withTenantParam())
+	if err != nil {
+		t.Fatalf("expected no error for harmless pragma, got %v", err)
+	}
+	if got != "PRAGMA foreign_keys = ON" {
+		t.Errorf("expected unchanged SQL, got %q", got)
+	}
+}
+
 func TestRewriteTenantSQL_MutationWithSubqueryRejected(t *testing.T) {
 	cases := []string{
 		"UPDATE quote SET x = 1 WHERE id IN (SELECT id FROM quote WHERE org_id = :current_user.org_id)",
@@ -375,5 +386,74 @@ func TestCheckTenantMutation_UnparseableNoTenant(t *testing.T) {
 	err := checkTenantMutation(sql, stripSQLNoise(sql), TenantMap{"quote": "org"}, withTenantParam())
 	if err != nil {
 		t.Errorf("expected nil for unparseable non-tenant mutation, got %v", err)
+	}
+}
+
+func TestBuildTenantMap_NilApp(t *testing.T) {
+	m := BuildTenantMap(nil)
+	if m == nil || len(m) != 0 {
+		t.Error("expected empty map for nil app")
+	}
+}
+
+func TestPopulateCurrentUserParams_NilSession(t *testing.T) {
+	s := &Server{}
+	params := map[string]string{}
+	s.populateCurrentUserParams(params, nil)
+	if len(params) != 0 {
+		t.Errorf("expected empty params, got %v", params)
+	}
+}
+
+func TestPopulateCurrentUserParams_WithSession(t *testing.T) {
+	s := &Server{app: &parser.App{Auth: &parser.AuthConfig{Password: "password_hash"}}}
+	params := map[string]string{}
+	session := &Session{
+		UserID:   "42",
+		Identity: "user@example.com",
+		Role:     "admin",
+		Data:     map[string]string{"plan": "premium", "password_hash": "secret"},
+	}
+	s.populateCurrentUserParams(params, session)
+	if params["current_user.id"] != "42" {
+		t.Errorf("expected id=42, got %s", params["current_user.id"])
+	}
+	if params["current_user.plan"] != "premium" {
+		t.Errorf("expected plan=premium, got %s", params["current_user.plan"])
+	}
+	if _, ok := params["current_user.password_hash"]; ok {
+		t.Error("expected sensitive field to be excluded")
+	}
+}
+
+func TestCheckTenantMutation_ParseableNonTenantNoTouch(t *testing.T) {
+	sql := `INSERT INTO "material" (name) VALUES ('x')`
+	err := checkTenantMutation(sql, stripSQLNoise(sql), TenantMap{"quote": "org"}, withTenantParam())
+	if err != nil {
+		t.Errorf("expected nil for parseable non-tenant mutation, got %v", err)
+	}
+}
+
+func TestRewriteTenantSQL_SelectWithoutFromTouchesTenant(t *testing.T) {
+	_, err := RewriteTenantSQL("SELECT quote",
+		BuildTenantMap(buildApp(t)), withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Fatalf("expected ErrUnsafeTenantShape for SELECT without FROM touching tenant, got %v", err)
+	}
+}
+
+func TestCheckTenantMutation_UnparseableNoTable(t *testing.T) {
+	sql := `INSERT VALUES ('x')`
+	err := checkTenantMutation(sql, stripSQLNoise(sql), TenantMap{"quote": "org"}, withTenantParam())
+	if err != nil {
+		t.Errorf("expected nil for unparseable mutation without tenant table, got %v", err)
+	}
+}
+
+func TestCheckTenantMutation_UnparseableNoTableTouchesTenant(t *testing.T) {
+	sql := `INSERT quote VALUES (1)`
+	err := checkTenantMutation(sql, stripSQLNoise(sql), TenantMap{"quote": "org"}, withTenantParam())
+	if !errors.Is(err, ErrUnsafeTenantShape) {
+		t.Errorf("expected ErrUnsafeTenantShape for unparseable mutation touching tenant, got %v", err)
 	}
 }

--- a/internal/runtime/testing_test.go
+++ b/internal/runtime/testing_test.go
@@ -201,6 +201,20 @@ func TestEvaluateExpect_RedirectWithoutLocation(t *testing.T) {
 	}
 }
 
+func TestEvaluateExpect_RedirectShorthand(t *testing.T) {
+	step := parser.TestStep{Target: "redirect /home", Value: ""}
+	if !evaluateExpect(step, "", 302, "/home", nil) {
+		t.Error("expected true for redirect shorthand")
+	}
+}
+
+func TestEvaluateExpect_RedirectWithValueOverride(t *testing.T) {
+	step := parser.TestStep{Target: "redirect to /home", Value: "/dashboard"}
+	if !evaluateExpect(step, "", 302, "/dashboard", nil) {
+		t.Error("expected true when Value overrides redirect path")
+	}
+}
+
 func TestEvaluateExpect_ContainsNotFound(t *testing.T) {
 	step := parser.TestStep{Target: "page contains", Value: "missing"}
 	if evaluateExpect(step, "hello world", 200, "", nil) {

--- a/internal/runtime/unfurl_test.go
+++ b/internal/runtime/unfurl_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kilnx-org/kilnx/internal/parser"
 )
@@ -80,6 +81,57 @@ func TestFetchOGData_InvalidURL(t *testing.T) {
 	}
 }
 
+func TestFetchOGData_NetworkError(t *testing.T) {
+	og := fetchOGData("http://localhost:99999/no-server")
+	if og != nil {
+		t.Error("expected nil for network error")
+	}
+}
+
+func TestFetchOGData_EmptyHTML(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><head></head><body></body></html>`))
+	}))
+	defer ts.Close()
+
+	og := fetchOGData(ts.URL)
+	if og != nil {
+		t.Error("expected nil for empty HTML without OG tags or title")
+	}
+}
+
+func TestFetchOGData_TooManyRedirects(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/redirect")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer ts.Close()
+
+	og := fetchOGData(ts.URL)
+	if og != nil {
+		t.Error("expected nil for too many redirects")
+	}
+}
+
+func TestFetchOGData_CacheExpired(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><head><meta property="og:title" content="Fresh"></head></html>`))
+	}))
+	defer ts.Close()
+
+	// Pre-populate cache with expired entry
+	unfurlCacheMu.Lock()
+	unfurlCache[ts.URL] = &ogData{URL: ts.URL, Title: "Stale", FetchedAt: time.Now().Add(-2 * time.Hour)}
+	unfurlCacheMu.Unlock()
+
+	og := fetchOGData(ts.URL)
+	if og == nil || og.Title != "Fresh" {
+		t.Errorf("expected fresh data after cache expiry, got %v", og)
+	}
+}
+
 func TestFetchOGData_FallbackTitle(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
@@ -149,6 +201,12 @@ func TestPrintRoutes(t *testing.T) {
 		Schedules: []parser.Schedule{
 			{Name: "daily", Cron: "0 0 * * *"},
 		},
+		Sockets: []parser.Socket{
+			{Path: "/ws"},
+		},
+		RateLimits: []parser.RateLimit{
+			{PathPattern: "/api/*", Requests: 10, Window: "minute", Per: "ip"},
+		},
 	}
 
 	// Capture stdout by redirecting os.Stdout
@@ -176,6 +234,12 @@ func TestPrintRoutes(t *testing.T) {
 	}
 	if !strings.Contains(output, "SSE  /events") {
 		t.Error("expected SSE /events in output")
+	}
+	if !strings.Contains(output, "WS   /ws") {
+		t.Error("expected WS /ws in output")
+	}
+	if !strings.Contains(output, "LIMIT /api/*") {
+		t.Error("expected LIMIT /api/* in output")
 	}
 }
 

--- a/internal/runtime/watcher_test.go
+++ b/internal/runtime/watcher_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,42 +49,141 @@ func TestResolveImports_IndentedIgnored(t *testing.T) {
 `)
 	out, err := resolveImports(entry, dir, nil, 0)
 	if err != nil {
-		t.Fatalf("expected indented 'import' to be content, got error: %v", err)
+		t.Fatalf("resolve: %v", err)
 	}
-	if !strings.Contains(out, "not-an-import.txt") {
-		t.Errorf("indented import line should be preserved as content")
-	}
-	if !strings.Contains(out, "How to import files?") {
-		t.Errorf("html content lost: %s", out)
+	if !strings.Contains(out, `import "not-an-import.txt"`) {
+		t.Errorf("indented import should be preserved, got:\n%s", out)
 	}
 }
 
 func TestResolveImports_Circular(t *testing.T) {
 	dir := t.TempDir()
-	writeTemp(t, dir, "a.kilnx", `import "b.kilnx"`+"\n")
-	writeTemp(t, dir, "b.kilnx", `import "a.kilnx"`+"\n")
-	entry := filepath.Join(dir, "a.kilnx")
-	if _, err := resolveImports(entry, dir, nil, 0); err == nil {
-		t.Fatal("expected circular import error")
+	a := writeTemp(t, dir, "a.kilnx", `import "b.kilnx"
+page /a
+  "a"
+`)
+	writeTemp(t, dir, "b.kilnx", `import "a.kilnx"
+page /b
+  "b"
+`)
+	_, err := resolveImports(a, dir, nil, 0)
+	if err == nil || !strings.Contains(err.Error(), "circular import") {
+		t.Fatalf("expected circular import error, got: %v", err)
 	}
 }
 
-func TestResolveImports_RejectsTraversal(t *testing.T) {
-	root := t.TempDir()
-	parent := filepath.Dir(root)
-	writeTemp(t, parent, "outside.kilnx", "model leak\n")
-	entry := writeTemp(t, root, "app.kilnx", `import "../outside.kilnx"`+"\n")
-	_, err := resolveImports(entry, root, nil, 0)
-	if err == nil || !strings.Contains(err.Error(), "escapes project") {
-		t.Fatalf("expected path-traversal rejection, got: %v", err)
-	}
-}
-
-func TestResolveImports_RequiresKilnxExtension(t *testing.T) {
+func TestResolveImports_FileNotFound(t *testing.T) {
 	dir := t.TempDir()
-	entry := writeTemp(t, dir, "app.kilnx", `import "data.txt"`+"\n")
+	entry := writeTemp(t, dir, "app.kilnx", `import "missing.kilnx"
+page /
+  "hi"
+`)
 	_, err := resolveImports(entry, dir, nil, 0)
-	if err == nil || !strings.Contains(err.Error(), ".kilnx file") {
-		t.Fatalf("expected extension rejection, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "reading") {
+		t.Fatalf("expected file read error, got: %v", err)
+	}
+}
+
+func TestResolveImports_InvalidExtension(t *testing.T) {
+	dir := t.TempDir()
+	writeTemp(t, dir, "bad.txt", "page /\n  \"hi\"\n")
+	entry := writeTemp(t, dir, "app.kilnx", `import "bad.txt"
+page /
+  "hi"
+`)
+	_, err := resolveImports(entry, dir, nil, 0)
+	if err == nil || !strings.Contains(err.Error(), "must be a .kilnx file") {
+		t.Fatalf("expected extension error, got: %v", err)
+	}
+}
+
+func TestResolveImports_EscapesProject(t *testing.T) {
+	dir := t.TempDir()
+	// Create a file outside the project root
+	outsideDir := t.TempDir()
+	writeTemp(t, outsideDir, "evil.kilnx", "page /evil\n  \"bad\"\n")
+
+	entry := writeTemp(t, dir, "app.kilnx", fmt.Sprintf(`import "%s"
+page /
+  "hi"
+`, filepath.Join("..", filepath.Base(outsideDir), "evil.kilnx")))
+	_, err := resolveImports(entry, dir, nil, 0)
+	if err == nil || !strings.Contains(err.Error(), "escapes project directory") {
+		t.Fatalf("expected escape error, got: %v", err)
+	}
+}
+
+func TestResolveImports_MaxDepth(t *testing.T) {
+	dir := t.TempDir()
+	// Create a chain of imports deeper than maxImportDepth (64)
+	var files []string
+	for i := 0; i < 66; i++ {
+		name := fmt.Sprintf("level%d.kilnx", i)
+		content := fmt.Sprintf(`import "level%d.kilnx"`, i+1)
+		if i == 65 {
+			content = "page /\n  \"done\"\n"
+		}
+		writeTemp(t, dir, name, content+"\n")
+		files = append(files, filepath.Join(dir, name))
+	}
+	_, err := resolveImports(files[0], dir, nil, 0)
+	if err == nil || !strings.Contains(err.Error(), "depth exceeds") {
+		t.Fatalf("expected max depth error, got: %v", err)
+	}
+}
+
+func TestResolveImports_EmptyImport(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeTemp(t, dir, "app.kilnx", "import \npage /\n  \"hi\"\n")
+	out, err := resolveImports(entry, dir, nil, 0)
+	if err != nil {
+		t.Fatalf("expected empty import to be skipped, got error: %v", err)
+	}
+	if !strings.Contains(out, "page /") {
+		t.Errorf("expected page to remain, got:\n%s", out)
+	}
+}
+
+// ---------- loadApp tests ----------
+
+func TestLoadApp_Success(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeTemp(t, dir, "app.kilnx", `page /
+  "hello"
+`)
+	app, err := loadApp(entry)
+	if err != nil {
+		t.Fatalf("loadApp: %v", err)
+	}
+	if len(app.Pages) != 1 || app.Pages[0].Path != "/" {
+		t.Errorf("expected one page with path /, got %+v", app.Pages)
+	}
+}
+
+func TestLoadApp_FileNotFound(t *testing.T) {
+	_, err := loadApp("/nonexistent/path/app.kilnx")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadApp_ParseError(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeTemp(t, dir, "app.kilnx", "model user\n  index(\n")
+	_, err := loadApp(entry)
+	if err == nil || !strings.Contains(err.Error(), "parsing") {
+		t.Fatalf("expected parsing error, got: %v", err)
+	}
+}
+
+func TestLoadApp_ResolveImportError(t *testing.T) {
+	dir := t.TempDir()
+	entry := writeTemp(t, dir, "app.kilnx", `import "missing.kilnx"
+page /
+  "hi"
+`)
+	_, err := loadApp(entry)
+	if err == nil || !strings.Contains(err.Error(), "reading") {
+		t.Fatalf("expected import read error, got: %v", err)
 	}
 }

--- a/internal/runtime/webhook_test.go
+++ b/internal/runtime/webhook_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kilnx-org/kilnx/internal/database"
 	"github.com/kilnx-org/kilnx/internal/parser"
 )
 
@@ -100,6 +101,45 @@ func TestFlattenMap_DefaultCase(t *testing.T) {
 	}
 }
 
+func TestHandleWebhook_MethodNotAllowed(t *testing.T) {
+	s := newTestServer(nil)
+	wh := parser.Webhook{Path: "/hooks/test"}
+	req := httptest.NewRequest(http.MethodGet, "/hooks/test", nil)
+	rr := httptest.NewRecorder()
+	s.handleWebhook(rr, req, wh)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for GET, got %d", rr.Code)
+	}
+}
+
+func TestHandleWebhook_BodyTooLarge(t *testing.T) {
+	s := newTestServer(nil)
+	wh := parser.Webhook{Path: "/hooks/test"}
+	bigBody := strings.Repeat("x", 1<<20+1)
+	req := httptest.NewRequest(http.MethodPost, "/hooks/test", strings.NewReader(bigBody))
+	rr := httptest.NewRecorder()
+	s.handleWebhook(rr, req, wh)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for oversized body, got %d", rr.Code)
+	}
+}
+
+func TestHandleWebhook_MissingSignatureHeader(t *testing.T) {
+	t.Setenv("TEST_WEBHOOK_SECRET", "secret123")
+	s := newTestServer(nil)
+	wh := parser.Webhook{
+		Path:      "/hooks/test",
+		SecretEnv: "TEST_WEBHOOK_SECRET",
+		Events:    []parser.WebhookEvent{{Name: "*"}},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/hooks/test", strings.NewReader(`{"type":"test"}`))
+	rr := httptest.NewRecorder()
+	s.handleWebhook(rr, req, wh)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for missing signature header, got %d", rr.Code)
+	}
+}
+
 func TestHandleWebhook_SecretEnvEmpty(t *testing.T) {
 	s := newTestServer(nil)
 	wh := parser.Webhook{
@@ -115,6 +155,23 @@ func TestHandleWebhook_SecretEnvEmpty(t *testing.T) {
 	}
 }
 
+func TestHandleWebhook_InvalidSignature(t *testing.T) {
+	t.Setenv("TEST_WEBHOOK_SECRET", "secret123")
+	s := newTestServer(nil)
+	wh := parser.Webhook{
+		Path:      "/hooks/test",
+		SecretEnv: "TEST_WEBHOOK_SECRET",
+		Events:    []parser.WebhookEvent{{Name: "*"}},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/hooks/test", strings.NewReader(`{"type":"test"}`))
+	req.Header.Set("X-Signature-256", "sha256=bad")
+	rr := httptest.NewRecorder()
+	s.handleWebhook(rr, req, wh)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for invalid signature, got %d", rr.Code)
+	}
+}
+
 func TestHandleWebhook_InvalidJSON(t *testing.T) {
 	s := newTestServer(nil)
 	wh := parser.Webhook{
@@ -126,5 +183,35 @@ func TestHandleWebhook_InvalidJSON(t *testing.T) {
 	s.handleWebhook(rr, req, wh)
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for invalid JSON, got %d", rr.Code)
+	}
+}
+
+func TestHandleWebhook_EventNotMatched(t *testing.T) {
+	s := newTestServer(nil)
+	wh := parser.Webhook{
+		Path:   "/hooks/test",
+		Events: []parser.WebhookEvent{{Name: "push"}},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/hooks/test", strings.NewReader(`{"type":"deploy"}`))
+	rr := httptest.NewRecorder()
+	s.handleWebhook(rr, req, wh)
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 when event not matched, got %d", rr.Code)
+	}
+}
+
+func TestHandleWebhook_ValidEvent(t *testing.T) {
+	mock := newMockExecutor()
+	mock.queryRowsWithParamsResults[`SELECT 1`] = []database.Row{{"1": "1"}}
+	s := newTestServer(mock)
+	wh := parser.Webhook{
+		Path:   "/hooks/test",
+		Events: []parser.WebhookEvent{{Name: "deploy", Body: []parser.Node{{Type: parser.NodeQuery, SQL: `SELECT 1`}}}},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/hooks/test", strings.NewReader(`{"type":"deploy"}`))
+	rr := httptest.NewRecorder()
+	s.handleWebhook(rr, req, wh)
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 for valid event, got %d", rr.Code)
 	}
 }

--- a/internal/runtime/websocket.go
+++ b/internal/runtime/websocket.go
@@ -86,7 +86,7 @@ func (s *Server) handleSocket(w http.ResponseWriter, r *http.Request, sock parse
 			return
 		}
 		if len(sock.RequiresClauses) > 0 {
-			if !s.evalRequiresClauses(sock.RequiresClauses, session) {
+			if !s.evalRequiresClauses(sock.RequiresClauses, session, r) {
 				http.Error(w, "Forbidden", http.StatusForbidden)
 				return
 			}

--- a/internal/runtime/websocket_test.go
+++ b/internal/runtime/websocket_test.go
@@ -52,17 +52,15 @@ func TestWriteWSFrame_Medium(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read error: %v", err)
 	}
-	if buf[0] != 0x81 {
-		t.Errorf("opcode = 0x%02x, want 0x81", buf[0])
+	if buf[0] != 0x81 || buf[1] != 126 {
+		t.Errorf("expected [0x81, 126], got [0x%02x, %d]", buf[0], buf[1])
 	}
-	if buf[1] != 126 {
-		t.Errorf("length indicator = %d, want 126", buf[1])
-	}
-	if binary.BigEndian.Uint16(buf[2:4]) != 200 {
-		t.Errorf("payload length = %d, want 200", binary.BigEndian.Uint16(buf[2:4]))
+	length := binary.BigEndian.Uint16(buf[2:4])
+	if int(length) != len(payload) {
+		t.Errorf("length = %d, want %d", length, len(payload))
 	}
 	if !bytes.Equal(buf[4:], payload) {
-		t.Error("payload mismatch")
+		t.Errorf("payload mismatch")
 	}
 }
 
@@ -83,17 +81,15 @@ func TestWriteWSFrame_Large(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read error: %v", err)
 	}
-	if buf[0] != 0x81 {
-		t.Errorf("opcode = 0x%02x, want 0x81", buf[0])
+	if buf[0] != 0x81 || buf[1] != 127 {
+		t.Errorf("expected [0x81, 127], got [0x%02x, %d]", buf[0], buf[1])
 	}
-	if buf[1] != 127 {
-		t.Errorf("length indicator = %d, want 127", buf[1])
-	}
-	if binary.BigEndian.Uint64(buf[2:10]) != 70000 {
-		t.Errorf("payload length = %d, want 70000", binary.BigEndian.Uint64(buf[2:10]))
+	length := binary.BigEndian.Uint64(buf[2:10])
+	if int(length) != len(payload) {
+		t.Errorf("length = %d, want %d", length, len(payload))
 	}
 	if !bytes.Equal(buf[10:], payload) {
-		t.Error("payload mismatch")
+		t.Errorf("payload mismatch")
 	}
 }
 
@@ -212,6 +208,46 @@ func TestReadWSFrame_ReadError(t *testing.T) {
 	}
 }
 
+func TestReadWSFrame_ExtLengthError(t *testing.T) {
+	// length == 126 but only 1 extra byte available
+	frame := []byte{0x81, 126, 0x00}
+	reader := bufio.NewReader(bytes.NewReader(frame))
+	_, _, err := readWSFrame(reader)
+	if err == nil {
+		t.Fatal("expected error for incomplete extended length")
+	}
+}
+
+func TestReadWSFrame_ExtLength8Error(t *testing.T) {
+	// length == 127 but only 4 extra bytes available
+	frame := []byte{0x81, 127, 0x00, 0x00, 0x00, 0x00}
+	reader := bufio.NewReader(bytes.NewReader(frame))
+	_, _, err := readWSFrame(reader)
+	if err == nil {
+		t.Fatal("expected error for incomplete 64-bit extended length")
+	}
+}
+
+func TestReadWSFrame_MaskKeyError(t *testing.T) {
+	// masked frame with only 1 byte of mask key
+	frame := []byte{0x81, byte(0x80 | 5), 0x01}
+	reader := bufio.NewReader(bytes.NewReader(frame))
+	_, _, err := readWSFrame(reader)
+	if err == nil {
+		t.Fatal("expected error for incomplete mask key")
+	}
+}
+
+func TestReadWSFrame_PayloadReadError(t *testing.T) {
+	// header says 10 bytes but only 3 available
+	frame := []byte{0x81, 10, 0x01, 0x02, 0x03}
+	reader := bufio.NewReader(bytes.NewReader(frame))
+	_, _, err := readWSFrame(reader)
+	if err == nil {
+		t.Fatal("expected error for incomplete payload")
+	}
+}
+
 func TestBroadcast_RemoveDeadClient(t *testing.T) {
 	room := &Room{clients: make(map[net.Conn]bool)}
 
@@ -263,6 +299,76 @@ func TestHandleSocket_RequiresRole(t *testing.T) {
 	}
 }
 
+// hijackableWriter is a ResponseWriter that supports Hijack for WebSocket tests.
+type hijackableWriter struct {
+	http.ResponseWriter
+	conn     net.Conn
+	bufrw    *bufio.ReadWriter
+	hijacked bool
+}
+
+func (hw *hijackableWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hw.hijacked = true
+	return hw.conn, hw.bufrw, nil
+}
+
+func TestHandleSocket_HandshakeSuccess(t *testing.T) {
+	// Create a pipe: clientConn is what the test reads, serverConn is what handleSocket writes to.
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	s := newTestServer(nil)
+	req := httptest.NewRequest("GET", "/ws", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+
+	hw := &hijackableWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		conn:           serverConn,
+		bufrw:          bufio.NewReadWriter(bufio.NewReader(serverConn), bufio.NewWriter(serverConn)),
+	}
+
+	sock := parser.Socket{Path: "/ws", Auth: false}
+
+	// Run handleSocket in a goroutine because it blocks in the read loop.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.handleSocket(hw, req, sock)
+	}()
+
+	// Read the HTTP upgrade response from clientConn.
+	reader := bufio.NewReader(clientConn)
+	resp, err := http.ReadResponse(reader, req)
+	if err != nil {
+		t.Fatalf("failed to read upgrade response: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Errorf("status = %d, want 101", resp.StatusCode)
+	}
+	if resp.Header.Get("Sec-WebSocket-Accept") == "" {
+		t.Error("expected Sec-WebSocket-Accept header")
+	}
+
+	// Send a close frame to exercise the read loop close-path
+	closeFrame := []byte{0x88, 0x00}
+	clientConn.Write(closeFrame)
+
+	// Give handleSocket a moment to process the frame
+	time.Sleep(100 * time.Millisecond)
+
+	// Close the connection to make the read loop exit.
+	clientConn.Close()
+	select {
+	case <-done:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleSocket did not exit after connection close")
+	}
+}
+
 func TestHandleSocket_NoUpgrade(t *testing.T) {
 	s := newTestServer(nil)
 	req := httptest.NewRequest("GET", "/ws", nil)
@@ -303,9 +409,11 @@ func TestHandleSocket_MissingKey(t *testing.T) {
 	}
 }
 
-func TestHandleSocket_RequiresClauses(t *testing.T) {
+func TestHandleSocket_RequiresClausesForbidden(t *testing.T) {
 	s := newTestServer(nil)
-	// Create a viewer session with future expiry
+	s.app.Permissions = []parser.Permission{
+		{Role: "viewer", Rules: []string{"all"}},
+	}
 	session := &Session{UserID: "1", Identity: "user@example.com", Role: "viewer", Data: database.Row{"plan": "basic"}, ExpiresAt: time.Now().Add(time.Hour)}
 	s.sessions.sessions["session-viewer"] = session
 	cookieVal := s.sessions.signSessionID("session-viewer")


### PR DESCRIPTION
## Summary
- Parser recognizes `flag "name"` and `limit N/period per scope` clauses, producing `RequiresClauseFlag` and `RequiresClauseRateLimit`.
- Runtime resolves flags via env (`FLAG_<NAME>`) then `_kilnx_flags` DB table; rate limiting uses `_kilnx_rate_limits` with window counters and supports per-ip (default) / per-user / per-tenant scopes (returns 429 when exceeded).
- Database DDL adds `_kilnx_flags` and `_kilnx_rate_limits` for SQLite + PostgreSQL.
- Review fixups: race-free rate limit clauses, tenant scope warning.

Closes [#77](https://github.com/kilnx-org/kilnx/issues/77).

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...` (all packages green)
- [x] New parser tests for flag and rate limit clauses
- [x] Runtime tests for env/DB flag resolution and IP/user rate limiting