### PR TITLE
docs: auto-generate contributors/packages from internal/* source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,16 +128,25 @@ jobs:
       - name: Regenerate docs
         run: go run ./cmd/kilnx-gendocs -o /tmp/kilnx-docs-fresh
 
-      - name: Diff against committed docs
+      - name: Diff reference against committed docs
         run: |
-          if ! diff -r docs/devs/reference /tmp/kilnx-docs-fresh > /tmp/docs-diff.txt; then
+          if ! diff -r docs/devs/reference /tmp/kilnx-docs-fresh/devs/reference > /tmp/ref-diff.txt; then
             echo "::error::docs/devs/reference is out of sync with internal/spec."
             echo "Run 'go generate ./...' locally and commit the result."
-            cat /tmp/docs-diff.txt
+            cat /tmp/ref-diff.txt
             exit 1
           fi
 
-      - name: Check for stale entity descriptions
+      - name: Diff packages against committed docs
+        run: |
+          if ! diff -r docs/contributors/packages /tmp/kilnx-docs-fresh/contributors/packages > /tmp/pkg-diff.txt; then
+            echo "::error::docs/contributors/packages is out of sync with internal/* source."
+            echo "Run 'go generate ./...' locally and commit the result."
+            cat /tmp/pkg-diff.txt
+            exit 1
+          fi
+
+      - name: Check for stale entries
         run: go run ./cmd/kilnx-gendocs -check-stale -o /tmp/kilnx-docs-stale-check
 
   docker:

--- a/cmd/kilnx-gendocs/main.go
+++ b/cmd/kilnx-gendocs/main.go
@@ -1,7 +1,10 @@
-// Command kilnx-gendocs regenerates the reference docs from internal/spec.
+// Command kilnx-gendocs regenerates documentation from source.
 //
-//	go run ./cmd/kilnx-gendocs            # writes to docs/devs/reference
-//	go run ./cmd/kilnx-gendocs -o /tmp    # writes to /tmp/devs/reference
+//	go run ./cmd/kilnx-gendocs                          # writes all targets
+//	go run ./cmd/kilnx-gendocs -only=reference          # docs/devs/reference only
+//	go run ./cmd/kilnx-gendocs -only=packages           # docs/contributors/packages only
+//	go run ./cmd/kilnx-gendocs -o /tmp                  # writes to /tmp
+//	go run ./cmd/kilnx-gendocs -check-stale             # exit 1 if any target is stale
 package main
 
 import (
@@ -13,17 +16,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"text/template"
-	"time"
-
-	"github.com/kilnx-org/kilnx/internal/spec"
-
-	// Blank imports to trigger init()-time entity registration. Each
-	// package registers the keywords/attributes it implements.
-	_ "github.com/kilnx-org/kilnx/internal/parser"
 )
 
 //go:embed templates/*.md.tmpl
@@ -33,30 +28,10 @@ var templatesFS embed.FS
 // so provenance lookups work regardless of `go generate` working dir.
 var repoRoot string
 
-type indexCtx struct {
-	Keywords   []spec.Entity
-	Attributes []spec.Entity
-}
-
-// entityCtx wraps a spec.Entity with provenance data sourced from `git log`.
-// SpecSHA/Date track the spec file (where the entity is registered);
-// SourceSHA/Date track the implementation file(s) found heuristically by
-// grepping for `case "<name>":` and `Value == "<name>"` patterns. Stale
-// is true when source was touched after spec — a hint that Description
-// may be out of date.
-type entityCtx struct {
-	spec.Entity
-	SpecSHA     string
-	SpecDate    string
-	SourceSHA   string
-	SourceDate  string
-	SourceFiles []string
-	Stale       bool
-}
-
 func main() {
-	out := flag.String("o", "docs/devs/reference", "output directory")
-	checkStale := flag.Bool("check-stale", false, "exit 1 if any entity's source was touched after its spec")
+	out := flag.String("o", "docs", "output root directory (devs/reference and contributors/packages live under here)")
+	only := flag.String("only", "all", "what to generate: all|reference|packages")
+	checkStale := flag.Bool("check-stale", false, "exit 1 if any target's source was touched after its doc")
 	flag.Parse()
 
 	repoRoot = resolveRepoRoot()
@@ -66,205 +41,47 @@ func main() {
 		log.Fatalf("load templates: %v", err)
 	}
 
-	if err := os.MkdirAll(filepath.Join(*out, "keywords"), 0o750); err != nil {
-		log.Fatalf("mkdir keywords: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Join(*out, "attributes"), 0o750); err != nil {
-		log.Fatalf("mkdir attributes: %v", err)
-	}
-
-	keywords := spec.ByKind(spec.KindKeyword)
-	attributes := spec.ByKind(spec.KindAttribute)
-
-	augmentSeeAlso(keywords, attributes)
-
 	var stale []string
-	render := func(kind string, e spec.Entity) {
-		ctx := buildCtx(e)
-		if ctx.Stale {
-			stale = append(stale, fmt.Sprintf("%s %q (source %s on %s, spec %s on %s)",
-				kind, e.Name, ctx.SourceSHA, ctx.SourceDate, ctx.SpecSHA, ctx.SpecDate))
-		}
-		path := filepath.Join(*out, kind+"s", e.Name+".md")
-		if err := writeTemplate(tmpl, kind+".md.tmpl", path, ctx); err != nil {
-			log.Fatalf("render %s: %v", e.Name, err)
-		}
-		fmt.Println("wrote", path)
-	}
-	for _, e := range keywords {
-		render("keyword", e)
-	}
-	for _, e := range attributes {
-		render("attribute", e)
-	}
 
-	indexPath := filepath.Join(*out, "index.md")
-	idx := indexCtx{Keywords: keywords, Attributes: attributes}
-	if err := writeTemplate(tmpl, "index.md.tmpl", indexPath, idx); err != nil {
-		log.Fatalf("render index: %v", err)
+	switch *only {
+	case "all", "reference":
+		s, err := generateReference(filepath.Join(*out, "devs", "reference"), tmpl)
+		if err != nil {
+			log.Fatalf("reference: %v", err)
+		}
+		stale = append(stale, s...)
+		if *only == "reference" {
+			break
+		}
+		fallthrough
+	case "packages":
+		s, err := generatePackages(filepath.Join(*out, "contributors", "packages"), tmpl)
+		if err != nil {
+			log.Fatalf("packages: %v", err)
+		}
+		stale = append(stale, s...)
+	default:
+		log.Fatalf("unknown -only value %q (want all|reference|packages)", *only)
 	}
-	fmt.Println("wrote", indexPath)
 
 	if *checkStale && len(stale) > 0 {
-		fmt.Fprintln(os.Stderr, "stale entities (source touched after spec):")
+		fmt.Fprintln(os.Stderr, "stale entries (source touched after spec/doc):")
 		for _, line := range stale {
 			fmt.Fprintln(os.Stderr, "  -", line)
 		}
-		fmt.Fprintln(os.Stderr, "\nReview the description against current behavior and update the *_spec.go file.")
+		fmt.Fprintln(os.Stderr, "\nReview and update accordingly.")
 		os.Exit(1)
 	}
 }
 
-// augmentSeeAlso makes SeeAlso bidirectional: if A.SeeAlso contains B,
-// B's rendered page also lists A. Mutates the entries of the supplied
-// slices in place. Self-references and duplicates are filtered.
-func augmentSeeAlso(groups ...[]spec.Entity) {
-	reverse := map[string]map[string]bool{}
-	for _, g := range groups {
-		for _, e := range g {
-			for _, target := range e.SeeAlso {
-				if target == e.Name {
-					continue
-				}
-				if reverse[target] == nil {
-					reverse[target] = map[string]bool{}
-				}
-				reverse[target][e.Name] = true
-			}
-		}
-	}
-	for _, g := range groups {
-		for i := range g {
-			existing := map[string]bool{}
-			for _, s := range g[i].SeeAlso {
-				existing[s] = true
-			}
-			added := make([]string, 0, len(reverse[g[i].Name]))
-			for ref := range reverse[g[i].Name] {
-				if !existing[ref] {
-					added = append(added, ref)
-				}
-			}
-			if len(added) == 0 {
-				continue
-			}
-			sort.Strings(added)
-			g[i].SeeAlso = append(g[i].SeeAlso, added...)
-		}
-	}
-}
-
-// buildCtx enriches a spec.Entity with provenance: the commit that last
-// touched its spec registration and the commit that last touched its
-// implementation source. Falls back gracefully if not run inside a git
-// checkout (so external builds still produce docs).
-func buildCtx(e spec.Entity) entityCtx {
-	ctx := entityCtx{Entity: e}
-
-	if specFile := findSpecFile(e.Name); specFile != "" {
-		if rel, err := filepath.Rel(repoRoot, specFile); err == nil {
-			specFile = rel
-		}
-		ctx.SpecSHA, ctx.SpecDate = gitLastTouch([]string{specFile})
-	}
-
-	ctx.SourceFiles = findSourceFiles(e.Name)
-	if len(ctx.SourceFiles) > 0 {
-		ctx.SourceSHA, ctx.SourceDate = gitLastTouch(ctx.SourceFiles)
-	}
-
-	if ctx.SpecDate != "" && ctx.SourceDate != "" {
-		spec, err1 := time.Parse("2006-01-02", ctx.SpecDate)
-		src, err2 := time.Parse("2006-01-02", ctx.SourceDate)
-		if err1 == nil && err2 == nil && src.After(spec) {
-			ctx.Stale = true
-		}
-	}
-
-	return ctx
-}
-
-// findSpecFile locates the *_spec.go file that registers an entity by
-// grepping for its Name field. Returns "" if not found.
-func findSpecFile(name string) string {
-	pattern := fmt.Sprintf(`Name:\s*"%s"`, regexp.QuoteMeta(name))
-	matches := grepFiles(pattern, []string{filepath.Join(repoRoot, "internal", "parser")}, "_spec.go")
-	if len(matches) == 0 {
-		return ""
-	}
-	sort.Strings(matches)
-	return matches[0]
-}
-
-// findSourceFiles locates implementation files for an entity by grepping
-// for the dispatch patterns Kilnx uses to recognize keywords:
-//   - `case "<name>":` in switch statements
-//   - `Value == "<name>"` in token comparisons
-//   - `Value: "<name>"` in struct literals
-//
-// Excludes *_test.go and *_spec.go (those describe, not implement).
-func findSourceFiles(name string) []string {
-	q := regexp.QuoteMeta(name)
-	pattern := fmt.Sprintf(`case "%s":|Value == "%s"|Value: "%s"`, q, q, q)
-	matches := grepFiles(pattern, []string{filepath.Join(repoRoot, "internal")}, "")
-	out := make([]string, 0, len(matches))
-	for _, m := range matches {
-		if strings.HasSuffix(m, "_test.go") || strings.HasSuffix(m, "_spec.go") {
-			continue
-		}
-		rel, err := filepath.Rel(repoRoot, m)
-		if err == nil {
-			m = rel
-		}
-		out = append(out, m)
-	}
-	sort.Strings(out)
-	return out
-}
-
-// grepFiles returns absolute repo paths of .go files in roots whose
-// content matches the regex. Pure-Go scan keeps the gendocs binary
-// independent of grep flavor.
-func grepFiles(pattern string, roots []string, suffixFilter string) []string {
-	re, err := regexp.Compile(pattern)
-	if err != nil {
-		return nil
-	}
-	var out []string
-	for _, root := range roots {
-		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil
-			}
-			if !strings.HasSuffix(path, ".go") {
-				return nil
-			}
-			if suffixFilter != "" && !strings.HasSuffix(path, suffixFilter) {
-				return nil
-			}
-			b, err := os.ReadFile(path) //nolint:gosec // path comes from WalkDir over the repo root; gendocs is a build-time tool, not exposed to untrusted input
-			if err != nil {
-				return nil
-			}
-			if re.Match(b) {
-				out = append(out, path)
-			}
-			return nil
-		})
-	}
-	return out
-}
-
 // gitLastTouch returns the short SHA and committer date (YYYY-MM-DD) of
-// the most recent commit that modified any of the given paths. Paths
-// may be absolute or repo-relative. Returns empty strings if git fails
-// (e.g. running outside a checkout).
+// the most recent commit that modified any of the given paths.
 func gitLastTouch(paths []string) (sha, date string) {
 	if len(paths) == 0 || repoRoot == "" {
 		return "", ""
 	}
 	args := append([]string{"-C", repoRoot, "log", "-1", "--format=%h%x09%cs", "--"}, paths...)
-	cmd := exec.Command("git", args...) //nolint:gosec // args are repo-relative paths from spec/grep, not user input; gendocs is a build-time tool
+	cmd := exec.Command("git", args...) //nolint:gosec // args are repo-relative paths from spec/AST scan, not user input; gendocs is a build-time tool
 	cmd.Stderr = nil
 	out, err := cmd.Output()
 	if err != nil {
@@ -292,7 +109,7 @@ func resolveRepoRoot() string {
 
 func loadTemplates() (*template.Template, error) {
 	t := template.New("").Funcs(template.FuncMap{
-		"seeAlsoPath": seeAlsoPath, // alias for back-compat in templates
+		"seeAlsoPath": seeAlsoPath,
 		"entityPath":  seeAlsoPath,
 	})
 	entries, err := fs.ReadDir(templatesFS, "templates")
@@ -312,29 +129,10 @@ func loadTemplates() (*template.Template, error) {
 	return t, nil
 }
 
-// seeAlsoPath returns a relative markdown link target for a SeeAlso entry,
-// resolved against the directory of the document doing the linking.
-func seeAlsoPath(target, fromDir string) string {
-	e, ok := spec.Get(target)
-	if !ok {
-		return target + ".md"
-	}
-	var targetDir string
-	switch e.Kind {
-	case spec.KindKeyword:
-		targetDir = "keywords"
-	case spec.KindAttribute:
-		targetDir = "attributes"
-	default:
-		return target + ".md"
-	}
-	if targetDir == fromDir {
-		return target + ".md"
-	}
-	return "../" + targetDir + "/" + target + ".md"
-}
-
 func writeTemplate(tmpl *template.Template, name, path string, data any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
 	f, err := os.Create(path)
 	if err != nil {
 		return err

--- a/cmd/kilnx-gendocs/packages.go
+++ b/cmd/kilnx-gendocs/packages.go
@@ -100,24 +100,36 @@ func buildPackageCtx(name, outDir string) (packageCtx, error) {
 	importPath := "github.com/kilnx-org/kilnx/internal/" + name
 
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, pkgDir, func(fi os.FileInfo) bool {
-		n := fi.Name()
-		return strings.HasSuffix(n, ".go") && !strings.HasSuffix(n, "_test.go")
-	}, parser.ParseComments)
+	entries, err := os.ReadDir(pkgDir)
 	if err != nil {
-		return packageCtx{}, fmt.Errorf("parse: %w", err)
+		return packageCtx{}, fmt.Errorf("read dir: %w", err)
 	}
-	if len(pkgs) == 0 {
+	var files []*ast.File
+	filePaths := map[*ast.File]string{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		abs := filepath.Join(pkgDir, n)
+		f, err := parser.ParseFile(fset, abs, nil, parser.ParseComments)
+		if err != nil {
+			return packageCtx{}, fmt.Errorf("parse %s: %w", n, err)
+		}
+		files = append(files, f)
+		filePaths[f] = abs
+	}
+	if len(files) == 0 {
 		return packageCtx{}, fmt.Errorf("no go files in %s", pkgDir)
 	}
 
-	var astPkg *ast.Package
-	for _, p := range pkgs {
-		astPkg = p
-		break
+	docPkg, err := doc.NewFromFiles(fset, files, importPath, doc.AllDecls)
+	if err != nil {
+		return packageCtx{}, fmt.Errorf("doc: %w", err)
 	}
-
-	docPkg := doc.New(astPkg, importPath, doc.AllDecls)
 
 	ctx := packageCtx{
 		Name:       name,
@@ -126,7 +138,7 @@ func buildPackageCtx(name, outDir string) (packageCtx, error) {
 	}
 	ctx.Description = paragraphsAfterFirst(docPkg.Doc)
 
-	ctx.Files = collectFiles(astPkg, fset)
+	ctx.Files = collectFiles(files, filePaths)
 	ctx.Types = collectTypes(docPkg, fset)
 	ctx.Functions = collectFuncs(docPkg, fset)
 
@@ -157,9 +169,10 @@ func buildPackageCtx(name, outDir string) (packageCtx, error) {
 	return ctx, nil
 }
 
-func collectFiles(pkg *ast.Package, fset *token.FileSet) []fileSummary {
+func collectFiles(files []*ast.File, paths map[*ast.File]string) []fileSummary {
 	var out []fileSummary
-	for absPath, file := range pkg.Files {
+	for _, file := range files {
+		absPath := paths[file]
 		base := filepath.Base(absPath)
 		if base == "doc.go" {
 			continue

--- a/cmd/kilnx-gendocs/packages.go
+++ b/cmd/kilnx-gendocs/packages.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+)
+
+// pkgList enumerates which internal packages get autogen'd. Order
+// reflects the conceptual pipeline (lexer first, runtime/build last).
+var pkgList = []string{
+	"lexer", "parser", "analyzer", "optimizer", "spec",
+	"database", "pathutil", "pdf", "runtime", "build",
+}
+
+type packageCtx struct {
+	Name        string
+	ImportPath  string
+	Summary     string
+	Description string
+	Files       []fileSummary
+	Types       []typeSummary
+	Functions   []funcSummary
+	ManualNotes string
+
+	SourceSHA  string
+	SourceDate string
+	DocSHA     string
+	DocDate    string
+	Stale      bool
+}
+
+type fileSummary struct {
+	Name    string
+	Path    string
+	Summary string
+}
+
+type typeSummary struct {
+	Name string
+	Decl string
+	Doc  string
+}
+
+type funcSummary struct {
+	Name      string
+	Recv      string
+	Signature string
+	Doc       string
+}
+
+// generatePackages walks pkgList and writes one md file per package
+// to outDir, plus an index. Returns stale entries.
+func generatePackages(outDir string, tmpl *template.Template) ([]string, error) {
+	if err := os.MkdirAll(outDir, 0o750); err != nil {
+		return nil, fmt.Errorf("mkdir packages: %w", err)
+	}
+
+	var stale []string
+	var summaries []packageCtx
+
+	for _, name := range pkgList {
+		ctx, err := buildPackageCtx(name, outDir)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		path := filepath.Join(outDir, name+".md")
+		if err := writeTemplate(tmpl, "package.md.tmpl", path, ctx); err != nil {
+			return nil, fmt.Errorf("render %s: %w", name, err)
+		}
+		fmt.Println("wrote", path)
+		if ctx.Stale {
+			stale = append(stale, fmt.Sprintf("package %q (source %s on %s, doc %s on %s)",
+				name, ctx.SourceSHA, ctx.SourceDate, ctx.DocSHA, ctx.DocDate))
+		}
+		summaries = append(summaries, ctx)
+	}
+
+	indexPath := filepath.Join(outDir, "index.md")
+	if err := writeTemplate(tmpl, "package_index.md.tmpl", indexPath, summaries); err != nil {
+		return nil, fmt.Errorf("render package index: %w", err)
+	}
+	fmt.Println("wrote", indexPath)
+
+	return stale, nil
+}
+
+func buildPackageCtx(name, outDir string) (packageCtx, error) {
+	pkgDir := filepath.Join(repoRoot, "internal", name)
+	importPath := "github.com/kilnx-org/kilnx/internal/" + name
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, pkgDir, func(fi os.FileInfo) bool {
+		n := fi.Name()
+		return strings.HasSuffix(n, ".go") && !strings.HasSuffix(n, "_test.go")
+	}, parser.ParseComments)
+	if err != nil {
+		return packageCtx{}, fmt.Errorf("parse: %w", err)
+	}
+	if len(pkgs) == 0 {
+		return packageCtx{}, fmt.Errorf("no go files in %s", pkgDir)
+	}
+
+	var astPkg *ast.Package
+	for _, p := range pkgs {
+		astPkg = p
+		break
+	}
+
+	docPkg := doc.New(astPkg, importPath, doc.AllDecls)
+
+	ctx := packageCtx{
+		Name:       name,
+		ImportPath: importPath,
+		Summary:    firstSentence(docPkg.Doc),
+	}
+	ctx.Description = paragraphsAfterFirst(docPkg.Doc)
+
+	ctx.Files = collectFiles(astPkg, fset)
+	ctx.Types = collectTypes(docPkg, fset)
+	ctx.Functions = collectFuncs(docPkg, fset)
+
+	var sourcePaths []string
+	for _, f := range ctx.Files {
+		sourcePaths = append(sourcePaths, f.Path)
+	}
+	if len(sourcePaths) > 0 {
+		ctx.SourceSHA, ctx.SourceDate = gitLastTouch(sourcePaths)
+	}
+	if docFile := filepath.Join("internal", name, "doc.go"); fileExists(filepath.Join(repoRoot, docFile)) {
+		ctx.DocSHA, ctx.DocDate = gitLastTouch([]string{docFile})
+	}
+	if ctx.DocDate != "" && ctx.SourceDate != "" {
+		d, e1 := time.Parse("2006-01-02", ctx.DocDate)
+		s, e2 := time.Parse("2006-01-02", ctx.SourceDate)
+		if e1 == nil && e2 == nil && s.After(d) {
+			ctx.Stale = true
+		}
+	}
+
+	// Read manual notes from the canonical committed location, not outDir.
+	// CI regenerates to /tmp and diffs; if we read from outDir, notes would
+	// be lost on a fresh tmp run and the diff would always fail.
+	canonical := filepath.Join(repoRoot, "docs", "contributors", "packages", name+".md")
+	ctx.ManualNotes = extractManualNotes(canonical)
+
+	return ctx, nil
+}
+
+func collectFiles(pkg *ast.Package, fset *token.FileSet) []fileSummary {
+	var out []fileSummary
+	for absPath, file := range pkg.Files {
+		base := filepath.Base(absPath)
+		if base == "doc.go" {
+			continue
+		}
+		rel, err := filepath.Rel(repoRoot, absPath)
+		if err != nil {
+			rel = absPath
+		}
+		summary := ""
+		if file.Doc != nil {
+			summary = firstSentence(file.Doc.Text())
+		}
+		out = append(out, fileSummary{Name: base, Path: rel, Summary: summary})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func collectTypes(p *doc.Package, fset *token.FileSet) []typeSummary {
+	var out []typeSummary
+	for _, t := range p.Types {
+		decl := nodeToString(fset, t.Decl)
+		out = append(out, typeSummary{
+			Name: t.Name,
+			Decl: collapseDecl(decl),
+			Doc:  strings.TrimSpace(t.Doc),
+		})
+	}
+	return out
+}
+
+func collectFuncs(p *doc.Package, fset *token.FileSet) []funcSummary {
+	var out []funcSummary
+	for _, f := range p.Funcs {
+		out = append(out, funcSummary{
+			Name:      f.Name,
+			Signature: signatureOf(fset, f.Decl),
+			Doc:       strings.TrimSpace(f.Doc),
+		})
+	}
+	for _, t := range p.Types {
+		for _, f := range t.Funcs {
+			out = append(out, funcSummary{
+				Name:      f.Name,
+				Signature: signatureOf(fset, f.Decl),
+				Doc:       strings.TrimSpace(f.Doc),
+			})
+		}
+		for _, m := range t.Methods {
+			out = append(out, funcSummary{
+				Name:      m.Name,
+				Recv:      t.Name,
+				Signature: signatureOf(fset, m.Decl),
+				Doc:       strings.TrimSpace(m.Doc),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Recv != out[j].Recv {
+			return out[i].Recv < out[j].Recv
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func signatureOf(fset *token.FileSet, fn *ast.FuncDecl) string {
+	if fn == nil {
+		return ""
+	}
+	stripped := *fn
+	stripped.Body = nil
+	stripped.Doc = nil
+	return collapseDecl(nodeToString(fset, &stripped))
+}
+
+func nodeToString(fset *token.FileSet, n any) string {
+	var buf bytes.Buffer
+	if err := printer.Fprint(&buf, fset, n); err != nil {
+		return ""
+	}
+	return buf.String()
+}
+
+func collapseDecl(s string) string {
+	s = strings.TrimSpace(s)
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimRight(l, " \t")
+	}
+	return strings.Join(lines, "\n")
+}
+
+const (
+	manualStart = "<!-- MANUAL-NOTES START -->"
+	manualEnd   = "<!-- MANUAL-NOTES END -->"
+)
+
+// extractManualNotes reads an existing generated md file and returns the
+// content between manualStart and manualEnd markers. If the file does not
+// exist or the markers are absent, returns an empty string.
+func extractManualNotes(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	s := string(b)
+	i := strings.Index(s, manualStart)
+	if i < 0 {
+		return ""
+	}
+	j := strings.Index(s[i:], manualEnd)
+	if j < 0 {
+		return ""
+	}
+	body := s[i+len(manualStart) : i+j]
+	return strings.TrimSpace(body)
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// firstSentence returns the first sentence of doc.go-style text. Skips
+// false matches caused by abbreviations like "e.g." and "i.e." where the
+// period is preceded by a single lower-case letter following another
+// period or word boundary.
+func firstSentence(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Collapse first paragraph to single line.
+	if i := strings.Index(s, "\n\n"); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.Join(strings.Fields(s), " ")
+
+	// Walk and find a period that ends a sentence (followed by space + uppercase).
+	for i := 0; i < len(s); i++ {
+		if s[i] != '.' {
+			continue
+		}
+		// Skip abbreviations: ".g.", ".e.", ".i." and similar.
+		// Heuristic: if preceded by a letter and another period within 3 chars, abbrev.
+		if i >= 2 && s[i-2] == '.' {
+			continue
+		}
+		if i+2 >= len(s) {
+			return s
+		}
+		if s[i+1] == ' ' && s[i+2] >= 'A' && s[i+2] <= 'Z' {
+			return s[:i+1]
+		}
+	}
+	return s
+}
+
+// paragraphsAfterFirst returns everything after the first paragraph of
+// doc.go-style text. Used for the long-form Description section.
+func paragraphsAfterFirst(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.Index(s, "\n\n"); i >= 0 {
+		return strings.TrimSpace(s[i+2:])
+	}
+	return ""
+}

--- a/cmd/kilnx-gendocs/reference.go
+++ b/cmd/kilnx-gendocs/reference.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/kilnx-org/kilnx/internal/spec"
+
+	// Blank import to trigger init()-time entity registration.
+	_ "github.com/kilnx-org/kilnx/internal/parser"
+)
+
+type indexCtx struct {
+	Keywords   []spec.Entity
+	Attributes []spec.Entity
+}
+
+// entityCtx wraps a spec.Entity with provenance data sourced from `git log`.
+// SpecSHA/Date track the spec file (where the entity is registered);
+// SourceSHA/Date track the implementation file(s) found heuristically by
+// grepping for `case "<name>":` and `Value == "<name>"` patterns. Stale
+// is true when source was touched after spec, hinting Description may be
+// out of date.
+type entityCtx struct {
+	spec.Entity
+	SpecSHA     string
+	SpecDate    string
+	SourceSHA   string
+	SourceDate  string
+	SourceFiles []string
+	Stale       bool
+}
+
+// generateReference writes the language reference (keywords + attributes
+// + index) to outDir. Returns a list of stale entity descriptions.
+func generateReference(outDir string, tmpl *template.Template) ([]string, error) {
+	if err := os.MkdirAll(filepath.Join(outDir, "keywords"), 0o750); err != nil {
+		return nil, fmt.Errorf("mkdir keywords: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Join(outDir, "attributes"), 0o750); err != nil {
+		return nil, fmt.Errorf("mkdir attributes: %w", err)
+	}
+
+	keywords := spec.ByKind(spec.KindKeyword)
+	attributes := spec.ByKind(spec.KindAttribute)
+
+	augmentSeeAlso(keywords, attributes)
+
+	var stale []string
+	render := func(kind string, e spec.Entity) error {
+		ctx := buildEntityCtx(e)
+		if ctx.Stale {
+			stale = append(stale, fmt.Sprintf("%s %q (source %s on %s, spec %s on %s)",
+				kind, e.Name, ctx.SourceSHA, ctx.SourceDate, ctx.SpecSHA, ctx.SpecDate))
+		}
+		path := filepath.Join(outDir, kind+"s", e.Name+".md")
+		if err := writeTemplate(tmpl, kind+".md.tmpl", path, ctx); err != nil {
+			return fmt.Errorf("render %s: %w", e.Name, err)
+		}
+		fmt.Println("wrote", path)
+		return nil
+	}
+	for _, e := range keywords {
+		if err := render("keyword", e); err != nil {
+			return nil, err
+		}
+	}
+	for _, e := range attributes {
+		if err := render("attribute", e); err != nil {
+			return nil, err
+		}
+	}
+
+	indexPath := filepath.Join(outDir, "index.md")
+	idx := indexCtx{Keywords: keywords, Attributes: attributes}
+	if err := writeTemplate(tmpl, "index.md.tmpl", indexPath, idx); err != nil {
+		return nil, fmt.Errorf("render index: %w", err)
+	}
+	fmt.Println("wrote", indexPath)
+
+	return stale, nil
+}
+
+// augmentSeeAlso makes SeeAlso bidirectional: if A.SeeAlso contains B,
+// B's rendered page also lists A. Mutates in place. Self-references and
+// duplicates filtered.
+func augmentSeeAlso(groups ...[]spec.Entity) {
+	reverse := map[string]map[string]bool{}
+	for _, g := range groups {
+		for _, e := range g {
+			for _, target := range e.SeeAlso {
+				if target == e.Name {
+					continue
+				}
+				if reverse[target] == nil {
+					reverse[target] = map[string]bool{}
+				}
+				reverse[target][e.Name] = true
+			}
+		}
+	}
+	for _, g := range groups {
+		for i := range g {
+			existing := map[string]bool{}
+			for _, s := range g[i].SeeAlso {
+				existing[s] = true
+			}
+			added := make([]string, 0, len(reverse[g[i].Name]))
+			for ref := range reverse[g[i].Name] {
+				if !existing[ref] {
+					added = append(added, ref)
+				}
+			}
+			if len(added) == 0 {
+				continue
+			}
+			sort.Strings(added)
+			g[i].SeeAlso = append(g[i].SeeAlso, added...)
+		}
+	}
+}
+
+// buildEntityCtx enriches a spec.Entity with provenance.
+func buildEntityCtx(e spec.Entity) entityCtx {
+	ctx := entityCtx{Entity: e}
+
+	if specFile := findSpecFile(e.Name); specFile != "" {
+		if rel, err := filepath.Rel(repoRoot, specFile); err == nil {
+			specFile = rel
+		}
+		ctx.SpecSHA, ctx.SpecDate = gitLastTouch([]string{specFile})
+	}
+
+	ctx.SourceFiles = findSourceFiles(e.Name)
+	if len(ctx.SourceFiles) > 0 {
+		ctx.SourceSHA, ctx.SourceDate = gitLastTouch(ctx.SourceFiles)
+	}
+
+	if ctx.SpecDate != "" && ctx.SourceDate != "" {
+		spec, err1 := time.Parse("2006-01-02", ctx.SpecDate)
+		src, err2 := time.Parse("2006-01-02", ctx.SourceDate)
+		if err1 == nil && err2 == nil && src.After(spec) {
+			ctx.Stale = true
+		}
+	}
+
+	return ctx
+}
+
+func findSpecFile(name string) string {
+	pattern := fmt.Sprintf(`Name:\s*"%s"`, regexp.QuoteMeta(name))
+	matches := grepFiles(pattern, []string{filepath.Join(repoRoot, "internal", "parser")}, "_spec.go")
+	if len(matches) == 0 {
+		return ""
+	}
+	sort.Strings(matches)
+	return matches[0]
+}
+
+// findSourceFiles locates implementation files for an entity.
+// Excludes *_test.go and *_spec.go.
+func findSourceFiles(name string) []string {
+	q := regexp.QuoteMeta(name)
+	pattern := fmt.Sprintf(`case "%s":|Value == "%s"|Value: "%s"`, q, q, q)
+	matches := grepFiles(pattern, []string{filepath.Join(repoRoot, "internal")}, "")
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if strings.HasSuffix(m, "_test.go") || strings.HasSuffix(m, "_spec.go") {
+			continue
+		}
+		rel, err := filepath.Rel(repoRoot, m)
+		if err == nil {
+			m = rel
+		}
+		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// grepFiles returns absolute repo paths of .go files in roots whose
+// content matches the regex.
+func grepFiles(pattern string, roots []string, suffixFilter string) []string {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, root := range roots {
+		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			if suffixFilter != "" && !strings.HasSuffix(path, suffixFilter) {
+				return nil
+			}
+			b, err := os.ReadFile(path) //nolint:gosec // path comes from WalkDir over the repo root; gendocs is a build-time tool
+			if err != nil {
+				return nil
+			}
+			if re.Match(b) {
+				out = append(out, path)
+			}
+			return nil
+		})
+	}
+	return out
+}
+
+// seeAlsoPath returns a relative markdown link target for a SeeAlso entry,
+// resolved against the directory of the document doing the linking.
+func seeAlsoPath(target, fromDir string) string {
+	e, ok := spec.Get(target)
+	if !ok {
+		return target + ".md"
+	}
+	var targetDir string
+	switch e.Kind {
+	case spec.KindKeyword:
+		targetDir = "keywords"
+	case spec.KindAttribute:
+		targetDir = "attributes"
+	default:
+		return target + ".md"
+	}
+	if targetDir == fromDir {
+		return target + ".md"
+	}
+	return "../" + targetDir + "/" + target + ".md"
+}

--- a/cmd/kilnx-gendocs/templates/package.md.tmpl
+++ b/cmd/kilnx-gendocs/templates/package.md.tmpl
@@ -1,0 +1,58 @@
+# `internal/{{.Name}}`
+
+> {{.Summary}}
+
+| | |
+|---|---|
+| **Import path** | `{{.ImportPath}}` |
+{{- if .SourceSHA}}
+| **Source last touched** | `{{.SourceSHA}}` ({{.SourceDate}}) |
+{{- end}}
+{{- if .DocSHA}}
+| **Doc last touched** | `{{.DocSHA}}` ({{.DocDate}}) |
+{{- end}}
+
+{{if .Stale}}
+> **Implementation touched after doc.go.** Source changed on `{{.SourceDate}}`, but `doc.go` was last edited on `{{.DocDate}}`. The summary above may be out of date.
+{{end}}
+{{- if .Description}}
+## Overview
+
+{{.Description}}
+{{end}}
+## Files
+
+| File | Summary |
+|------|---------|
+{{range .Files}}| [`{{.Name}}`](../../../{{.Path}}) | {{if .Summary}}{{.Summary}}{{else}}_no file-level doc_{{end}} |
+{{end}}
+{{- if .Types}}
+## Types
+{{range .Types}}
+### `{{.Name}}`
+
+```go
+{{.Decl}}
+```
+{{- if .Doc}}
+
+{{.Doc}}
+{{end}}{{end}}{{end}}
+{{- if .Functions}}
+## Functions
+{{range .Functions}}
+### `{{if .Recv}}({{.Recv}}) {{end}}{{.Name}}`
+
+```go
+{{.Signature}}
+```
+{{- if .Doc}}
+
+{{.Doc}}
+{{end}}{{end}}{{end}}
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+{{if .ManualNotes}}{{.ManualNotes}}{{else}}_Add hand-written gotchas, lifecycle context, and cross-cutting concerns here. Content between the MANUAL-NOTES markers is preserved across regeneration._{{end}}
+<!-- MANUAL-NOTES END -->

--- a/cmd/kilnx-gendocs/templates/package_index.md.tmpl
+++ b/cmd/kilnx-gendocs/templates/package_index.md.tmpl
@@ -1,0 +1,8 @@
+# Internal Packages
+
+Generated from `internal/*` package source. Do not edit by hand. Run `go generate ./...` to regenerate.
+
+| Package | Summary |
+|---------|---------|
+{{range .}}| [`{{.Name}}`]({{.Name}}.md) | {{.Summary}} |
+{{end}}

--- a/docs/contributors/adding-a-keyword.md
+++ b/docs/contributors/adding-a-keyword.md
@@ -1,0 +1,211 @@
+# Adding a Keyword
+
+Worked example: how the `webhook` keyword was added end to end. Use this as a template when introducing a new top-level keyword (something that appears at indent 0 in a `.kilnx` file, like `page`, `action`, `model`, `webhook`, `socket`, `schedule`, `job`, `api`, `stream`, `auth`, `permissions`, `layout`, `config`, `log`, `translations`, `test`).
+
+This is the deep tutorial. The short checklist lives in [CONTRIBUTING.md](../../CONTRIBUTING.md) and the registry-side picture lives in [architecture/spec-registry.md](architecture/spec-registry.md).
+
+## 1. Register the keyword in the lexer
+
+Top-level keywords must be recognized by the tokenizer, otherwise they emit `TokenIdentifier` and the parser dispatch never fires.
+
+Edit [`internal/lexer/lexer.go`](../../internal/lexer/lexer.go) and add an entry to the `keywords` map:
+
+```go
+var keywords = map[string]bool{
+    "page": true, "action": true, "fragment": true,
+    // ...
+    "webhook": true,
+    // ...
+}
+```
+
+If the new keyword introduces a model field type, add it to `fieldTypes` instead and use [`IsFieldType`](../../internal/lexer/lexer.go) from the parser. If it introduces a model field constraint, add it to `fieldConstraints` and use [`IsFieldConstraint`](../../internal/lexer/lexer.go). Field-level keywords do not need to be in the top-level `keywords` map.
+
+## 2. Add the AST node
+
+All AST types live in [`internal/parser/parser.go`](../../internal/parser/parser.go) next to the parser. For `webhook`:
+
+```go
+// Webhook is a `webhook` declaration: an HTTP endpoint that receives
+// signed events from an external service and dispatches them by name.
+type Webhook struct {
+    Path      string
+    SecretEnv string
+    Events    []WebhookEvent
+}
+
+type WebhookEvent struct {
+    Name string
+    Body []Node
+}
+```
+
+Then add a slice on the root [`App`](../../internal/parser/parser.go) struct so the runtime can iterate it:
+
+```go
+type App struct {
+    // ...
+    Webhooks []Webhook
+    // ...
+}
+```
+
+## 3. Write the parse function
+
+Despite the file name suggested by some patterns elsewhere, all parser logic for top-level entities lives inside [`parser.go`](../../internal/parser/parser.go) as a method on `parserState`. Look at [`parseWebhook`](../../internal/parser/parser.go) at line 2505 for the canonical shape:
+
+```go
+func (p *parserState) parseWebhook() Webhook {
+    wh := Webhook{}
+    p.advance() // consume "webhook"
+
+    if p.current().Type == lexer.TokenPath {
+        wh.Path = p.advance().Value
+    }
+    if wh.Path == "" {
+        p.addError(fmt.Errorf("webhook path is required"))
+    }
+
+    // parse same-line modifiers (secret env VAR_NAME, ...)
+    // ...
+
+    // descend into the indented body
+    p.skipNewlines()
+    if p.current().Type == lexer.TokenIndent {
+        p.advance()
+        // parse children, leveraging p.parseBody() when the body is
+        // a generic node list, or a custom loop for keyword-specific
+        // sub-statements like `on event ...`.
+    }
+    return wh
+}
+```
+
+Reuse helpers already defined on `parserState`: [`p.advance`, `p.current`, `p.skipNewlines`, `p.skipToEndOfLine`, `p.parseBody`, `p.parseRequiresClauses`, `p.addError`, `p.synchronize`](../../internal/parser/parser.go). Custom logic should be the smallest delta on top of those.
+
+## 4. Wire the dispatch table
+
+[`Parse`](../../internal/parser/parser.go) walks the token stream and dispatches on `tok.Value` for each keyword. Add a `case` in the top-level switch (around line 413):
+
+```go
+switch tok.Value {
+case "model":
+    // ...
+case "webhook":
+    wh := p.parseWebhook()
+    app.Webhooks = append(app.Webhooks, wh)
+case "socket":
+    // ...
+}
+```
+
+If the parse function can fail, follow the error pattern used by `parseModel`, `parsePage`, and friends: return `(T, error)`, append to `p.addError`, then call `p.synchronize()` to skip to the next top-level entity.
+
+## 5. Write the spec registration
+
+Create [`internal/parser/<keyword>_spec.go`](../../internal/parser/) with an `init()` that calls `spec.Register`. For `webhook` see [`webhook_spec.go`](../../internal/parser/webhook_spec.go):
+
+```go
+package parser
+
+import "github.com/kilnx-org/kilnx/internal/spec"
+
+func init() {
+    spec.Register(spec.Entity{
+        Name:    "webhook",
+        Kind:    spec.KindKeyword,
+        Summary: "Receive external events at a path.",
+        Description: "A `webhook` is an HTTP POST endpoint that " +
+            "authenticates requests via a shared secret and dispatches " +
+            "to an `on event <name>` handler.",
+        Syntax: "webhook <path> [secret env <VAR>]",
+        Args: []spec.Arg{
+            {Name: "path", Type: "path", Required: true},
+        },
+        Children:   []string{"redirect"},
+        Repeatable: true,
+        Since:      "0.1.0",
+        Examples:   []spec.Example{ /* ... */ },
+        SeeAlso:    []string{"on", "fetch"},
+    })
+}
+```
+
+Required fields enforced by [`internal/parser/spec_test.go`](../../internal/parser/spec_test.go): `Summary`, `Syntax`, `Since`. Children and attributes wired here also have to be registered somewhere, see [`TestSpec_ChildrenAreRegistered`](../../internal/parser/spec_test.go).
+
+## 6. Add analyzer checks (optional but expected)
+
+If the keyword has security implications or invariants, add a check in [`internal/analyzer/`](../../internal/analyzer/). For `webhook` the analyzer warns when no signing secret is configured. See [`checkWebhookSecrets`](../../internal/analyzer/security.go) and [`Analyze`](../../internal/analyzer/security.go) which composes the checks:
+
+```go
+func checkWebhookSecrets(app *parser.App) []Diagnostic {
+    var diags []Diagnostic
+    for _, wh := range app.Webhooks {
+        if wh.SecretEnv == "" {
+            diags = append(diags, Diagnostic{
+                Severity: SeverityWarning,
+                Message:  "webhook has no secret configured",
+                Context:  fmt.Sprintf("webhook %s", wh.Path),
+            })
+        }
+    }
+    return diags
+}
+```
+
+Register the check by appending its result to `diags` inside [`Analyze`](../../internal/analyzer/security.go).
+
+## 7. Add runtime handling
+
+The runtime is an AST interpreter rooted in [`internal/runtime/server.go`](../../internal/runtime/server.go). For most new keywords you will:
+
+1. Add a slice scan inside the main HTTP handler. Webhooks live at lines 217 to 223:
+
+   ```go
+   for _, wh := range app.Webhooks {
+       if r.URL.Path == wh.Path {
+           s.handleWebhook(w, r, wh)
+           return
+       }
+   }
+   ```
+
+2. Add a per-keyword file with the handler. See [`internal/runtime/webhook.go`](../../internal/runtime/webhook.go) for `handleWebhook`. Background-only keywords (`schedule`, `job`) wire into [`scheduler.go`](../../internal/runtime/scheduler.go) instead of the HTTP handler.
+
+3. Reuse existing helpers when executing body nodes: [`s.executeBody`](../../internal/runtime/server.go), [`s.runQuery`](../../internal/runtime/server.go), and the param resolution machinery in [`expr.go`](../../internal/runtime/expr.go).
+
+## 8. Regenerate the reference docs
+
+```bash
+go generate ./...
+```
+
+This invokes the `go:generate` directive in [`internal/parser/doc.go`](../../internal/parser/doc.go) which runs [`cmd/kilnx-gendocs`](../../cmd/kilnx-gendocs/main.go) and writes `docs/devs/reference/keywords/<name>.md`. The pre-commit hook in `.githooks/pre-commit` runs the same command, and CI fails if the regenerated output differs from what is committed.
+
+Verify staleness is clean:
+
+```bash
+go run ./cmd/kilnx-gendocs -check-stale
+```
+
+## 9. Add tests at every layer
+
+Lexer recognition is exercised through parser tests, so usually you do not need a dedicated lexer test. Add:
+
+- A parser test in [`internal/parser/parser_test.go`](../../internal/parser/parser_test.go) using the `parse(t, src)` helper.
+- An analyzer test next to the check, e.g. [`security_test.go`](../../internal/analyzer/security_test.go).
+- A runtime test using `httptest`, e.g. [`webhook_test.go`](../../internal/runtime/webhook_test.go).
+- Optionally a smoke `.kilnx` file under [`smoke/`](../../smoke/) if the feature is small enough to live in a self-contained example.
+
+See [testing.md](testing.md) for conventions and patterns.
+
+## 10. Final checks
+
+```bash
+go vet ./...
+gofmt -l .
+go test -race ./...
+go run ./cmd/kilnx-gendocs -check-stale
+```
+
+Commit the spec change, the regenerated `docs/devs/reference/`, and the parser, analyzer, runtime, and test changes together.

--- a/docs/contributors/adding-an-attribute.md
+++ b/docs/contributors/adding-an-attribute.md
@@ -1,0 +1,155 @@
+# Adding an Attribute
+
+Worked example: how the `requires` attribute is wired across the parser, spec registry, analyzer, and runtime. Use this as a template when adding a new attribute (something that decorates a parent keyword, like `method`, `requires`, `title`, `redirect`, `default`, `unique`, `min`, `max`, `index`, `tenant`).
+
+The short checklist lives in [CONTRIBUTING.md](../../CONTRIBUTING.md). Here we walk every layer with concrete file pointers.
+
+## Where attributes live
+
+The Kilnx grammar has two flavors of attributes:
+
+1. **Inline attributes on a parent keyword line**, e.g. `page /admin requires admin method POST`. Spec and parser sit alongside the parent keywords.
+2. **Field-level constraints inside a `model` block**, e.g. `email: email required unique`. Spec lives in [`field_attrs_spec.go`](../../internal/parser/field_attrs_spec.go); parsing lives inside the model field loop in [`parser.go`](../../internal/parser/parser.go).
+
+The general-purpose registration file is [`internal/parser/attrs_spec.go`](../../internal/parser/attrs_spec.go) for attributes shared across multiple keywords. Attributes scoped to a single keyword belong in that keyword's `_spec.go`.
+
+## 1. Decide the parent scope
+
+An attribute lists every keyword it can appear under in `ParentScope`. This drives doc generation (`spec.ChildrenOf`, `spec.ParentsOf`) and powers the reverse lookup so the parent keyword does not need to enumerate the attribute in `Children`.
+
+`requires` is multi-parent, applying to `page`, `action`, `api`, and (since later versions) `socket` and `stream`. Its registration in [`attrs_spec.go`](../../internal/parser/attrs_spec.go):
+
+```go
+spec.Register(spec.Entity{
+    Name:        "requires",
+    Kind:        spec.KindAttribute,
+    Summary:     "Require authentication or a specific role/permission.",
+    Description: "Gates the parent endpoint behind authentication. " +
+        "Accepts `auth`, a role name, or a permission expression.",
+    Syntax:      "requires <clause>",
+    Args: []spec.Arg{
+        {Name: "clause", Type: "identifier", Required: true},
+    },
+    ParentScope: []string{"page", "action", "api"},
+    Repeatable:  true,
+    Since:       "0.1.0",
+    Examples:    []spec.Example{ /* ... */ },
+    SeeAlso:     []string{"method", "permissions"},
+})
+```
+
+For overloaded attributes (the same name under multiple parents with parent-specific semantics, like `requests` inside both `log` and `limit`), call `spec.Register` once per parent. The registry merges them: see the merge logic in [`spec.go`](../../internal/spec/spec.go) lines 70 to 115. New `Description` text is appended under a `When used in <parent>:` header, `ParentScope` is unioned, and examples are concatenated.
+
+## 2. Lex
+
+Most attributes do not need lexer changes. The lexer treats unknown words as `TokenIdentifier`, and the parser checks the value when scanning attribute lists. An attribute name only needs to be added to `keywords` in [`lexer.go`](../../internal/lexer/lexer.go) if it must be tokenized as `TokenKeyword` so the parser dispatch can rely on `tok.Type == lexer.TokenKeyword` checks. Look at the existing entries (`requires`, `method`, `title` are all in the `keywords` map) and follow the same convention if your attribute participates in the same parse loops.
+
+For field-level constraints (model body), add to `fieldConstraints` and rely on [`IsFieldConstraint`](../../internal/lexer/lexer.go).
+
+## 3. Wire the attribute parser
+
+Inline attributes are consumed inside the parent keyword's parse loop. `requires` is wired in three different parse loops because it appears under three keywords. The cleanest reference is the page parser, around line 1122 of [`parser.go`](../../internal/parser/parser.go):
+
+```go
+for !p.isEOF() && p.current().Type != lexer.TokenNewline {
+    tok := p.current()
+    if tok.Type == lexer.TokenKeyword {
+        switch tok.Value {
+        case "layout":
+            // ...
+        case "requires":
+            requiresLine := tok.Line
+            p.advance()
+            page.Auth = true
+            page.RequiresClauses = p.parseRequiresClauses(requiresLine)
+            page.RequiresRole = firstRoleValue(page.RequiresClauses)
+            p.skipRequiresClauses()
+        case "method":
+            p.advance()
+            if p.current().Type == lexer.TokenIdentifier {
+                page.Method = p.advance().Value
+            }
+        }
+    }
+}
+```
+
+The same `case "requires":` and `case "method":` blocks reappear inside `parseAction` (around line 1479) and `parseAPI` (around line 2051). Keep the three branches in sync, or extract a shared helper if your attribute starts to spread across parents.
+
+For field-level constraints, the dispatch is in the model-field loop (around line 1054):
+
+```go
+case "required":
+    field.Required = true
+case "unique":
+    field.Unique = true
+case "default":
+    p.advance()
+    field.Default = parseDefaultValue(p)
+case "min":
+    // ...
+case "max":
+    // ...
+```
+
+## 4. Attach to the AST
+
+Add the field on the parent's AST struct. For `requires`, the parent stores both the legacy single role and the full clause list:
+
+```go
+type Page struct {
+    Path            string
+    Auth            bool
+    RequiresRole    string
+    RequiresClauses []RequiresClause
+    // ...
+}
+```
+
+For richer attributes, model the parsed shape with a dedicated type the way [`RequiresClause`](../../internal/parser/parser.go) does. Simple boolean flags (`required`, `unique`) can sit directly on the field/parent.
+
+## 5. Add analyzer validation
+
+If an attribute makes some configurations illegal (or unsafe), add a check in [`internal/analyzer/`](../../internal/analyzer/). For `requires`, the analyzer cross-checks role names against declared `permissions` blocks and rejects unknown roles. Auth-related security checks live in [`security.go`](../../internal/analyzer/security.go); type-level checks live in [`analyzer.go`](../../internal/analyzer/analyzer.go).
+
+Each check emits [`Diagnostic`](../../internal/analyzer/types.go) values with severity, message, and context. Wire your check into [`Analyze`](../../internal/analyzer/analyzer.go) by appending to the diagnostics slice.
+
+## 6. Add runtime semantics
+
+Attribute semantics fire inside the request handler. For `requires`, the runtime is in [`internal/runtime/permissions.go`](../../internal/runtime/permissions.go) and the gating logic in [`requires_clauses_test.go`](../../internal/runtime/requires_clauses_test.go) covers role checks, auth checks, expression clauses, and superuser bypass. The handler in [`server.go`](../../internal/runtime/server.go) calls into the requires evaluator before invoking the page or action body.
+
+For trivial attributes, the runtime change can be one line: read the field off the AST node and branch on it.
+
+## 7. Regenerate the reference docs
+
+```bash
+go generate ./...
+```
+
+This regenerates `docs/devs/reference/attributes/<name>.md` via [`cmd/kilnx-gendocs`](../../cmd/kilnx-gendocs/main.go). Stale detection runs in CI; run it locally before committing:
+
+```bash
+go run ./cmd/kilnx-gendocs -check-stale
+```
+
+## 8. Tests
+
+Add coverage at the layers you touched:
+
+- Spec invariants: [`internal/parser/spec_test.go`](../../internal/parser/spec_test.go) already enforces `Summary`, `Syntax`, `Since`, parent registration, and children registration. New attributes inherit those checks for free.
+- Parser: an attribute test in [`parser_test.go`](../../internal/parser/parser_test.go) using the `parse(t, src)` helper, asserting the parsed AST shape.
+- Analyzer: a test in the matching `_test.go` next to the check.
+- Runtime: an integration test using `httptest`, e.g. [`requires_clauses_e2e_test.go`](../../internal/runtime/requires_clauses_e2e_test.go).
+
+See [testing.md](testing.md) for the conventions used across these files.
+
+## 9. Final checks
+
+```bash
+go vet ./...
+gofmt -l .
+go test -race ./...
+go run ./cmd/kilnx-gendocs -check-stale
+```
+
+Commit spec, parser, analyzer, runtime, regenerated docs, and tests in one PR.

--- a/docs/contributors/architecture/ast.md
+++ b/docs/contributors/architecture/ast.md
@@ -1,0 +1,90 @@
+# AST
+
+The parser produces a single `*parser.App` value rooted in [`internal/parser/parser.go`](../../../internal/parser/parser.go). Every later stage (analyzer, optimizer, runtime, build) consumes that struct.
+
+## App root
+
+[`parser.App`](../../../internal/parser/parser.go) holds slices and pointers per top-level declaration:
+
+| Field | Source keyword | Notes |
+|-------|----------------|-------|
+| `Models` | `model` | Tables, fields, indexes, custom field manifests, tenant scoping. |
+| `Pages` | `page` | GET routes that render HTML. |
+| `Actions` | `action` | POST/PUT/DELETE handlers. Same `Page` shape as pages. |
+| `Fragments` | `fragment` | Partial HTML responses. Path-based or component-style. |
+| `APIs` | `api` | JSON endpoints. |
+| `Streams` | `stream` | SSE endpoints driven by a polling SQL query. |
+| `Schedules` | `schedule` | Recurring tasks (interval or cron-like phrase). |
+| `Jobs` | `job` | Async background units invoked by `enqueue`. |
+| `Webhooks` | `webhook` | Signed HTTP receivers with `on <event>` dispatch. |
+| `Sockets` | `socket` | Bidirectional WebSocket endpoints. |
+| `RateLimits` | `limit` | Path-pattern throttles. |
+| `Config` | `config` | App-level settings (`*AppConfig`). |
+| `Auth` | `auth` | Built-in auth wiring (`*AuthConfig`). |
+| `Permissions` | `permissions` | Role-based access rules. |
+| `Layouts` | `layout` | Named HTML shells with `{page.title}` and `{page.content}` slots. |
+| `Tests` | `test` | Scripted end-to-end scenarios. |
+| `LogConfig` | `log` | Logging level and request/error toggles. |
+| `Translations` | `translations` | `lang -> key -> value`. |
+| `NamedQueries` | top-level `query <name>` | `name -> SQL`. Resolved into `Page.Body` after parse. |
+| `CustomManifests` | `*_fields.kilnx` files referenced by `custom` | Runtime-extensible fields per model. |
+
+Pages, actions, fragments, and APIs all share the [`parser.Page`](../../../internal/parser/parser.go) struct. They are distinguished by which slice they live on and which fields they use (`Method`, `FragmentArgs`, etc.).
+
+## Top-level dispatch
+
+The parse loop is a switch over the leading keyword of each top-level statement. See [`parser.Parse`](../../../internal/parser/parser.go) for the canonical list. Each case calls a `parseX` method that consumes its block and appends to the matching `App` slice. Errors are accumulated, then `synchronize()` skips to the next plausible top-level boundary so multiple errors surface in one pass.
+
+## `*_spec.go` files
+
+Each top-level keyword has both:
+
+- a `parseX` method on `parserState` that builds the AST node, and
+- a `<name>_spec.go` file that registers a [`spec.Entity`](../../../internal/spec/spec.go) describing the keyword for documentation generation.
+
+Examples:
+
+- [`parser/model_spec.go`](../../../internal/parser/model_spec.go) registers the `model` keyword (summary, syntax, allowed children, examples).
+- [`parser/page_spec.go`](../../../internal/parser/page_spec.go) registers `page`.
+- [`parser/action_spec.go`](../../../internal/parser/action_spec.go), [`api_spec.go`](../../../internal/parser/api_spec.go), [`fragment_spec.go`](../../../internal/parser/fragment_spec.go), [`stream_spec.go`](../../../internal/parser/stream_spec.go), [`schedule_spec.go`](../../../internal/parser/schedule_spec.go), [`job_spec.go`](../../../internal/parser/job_spec.go), [`webhook_spec.go`](../../../internal/parser/webhook_spec.go), [`socket_spec.go`](../../../internal/parser/socket_spec.go), [`limit_spec.go`](../../../internal/parser/limit_spec.go), [`config_spec.go`](../../../internal/parser/config_spec.go), [`auth_spec.go`](../../../internal/parser/auth_spec.go), [`permissions_spec.go`](../../../internal/parser/permissions_spec.go), [`layout_spec.go`](../../../internal/parser/layout_spec.go), [`log_spec.go`](../../../internal/parser/log_spec.go), [`translations_spec.go`](../../../internal/parser/translations_spec.go), [`query_spec.go`](../../../internal/parser/query_spec.go), [`test_spec.go`](../../../internal/parser/test_spec.go) cover the rest.
+- Attribute specs: [`attrs_spec.go`](../../../internal/parser/attrs_spec.go), [`field_attrs_spec.go`](../../../internal/parser/field_attrs_spec.go), [`body_nodes_spec.go`](../../../internal/parser/body_nodes_spec.go).
+
+A `spec.Register` call in `init()` populates the global registry. `cmd/kilnx-gendocs` imports `internal/parser` for its side effects, then renders Markdown from the registry. Adding a new keyword therefore means: add the `parseX`, add the AST struct, add a `<name>_spec.go` registration, regenerate docs. See [spec-registry.md](spec-registry.md) for details.
+
+## Body statements: `Node`
+
+The body of a `page`, `action`, `fragment`, `api`, `schedule`, `job`, `webhook` event handler, or `socket` handler is `[]parser.Node`. `Node.Type` is a `NodeType` enum and selects which other fields are meaningful. The full list lives in [`parser.go`](../../../internal/parser/parser.go):
+
+| `NodeType` | Keyword form | Active fields (selected) |
+|------------|--------------|--------------------------|
+| `NodeText` | template literal | `Value` |
+| `NodeQuery` | `query [name]: <SQL>` | `Name`, `SQL`, `SourceModel`, `Paginate` |
+| `NodeRedirect` | `redirect <path>` | `Value` |
+| `NodeValidate` | `validate { ... }` | `ModelName`, `Validations` |
+| `NodeRespond` | `respond <selector> [query: <SQL>]` | `RespondTarget`, `RespondSwap`, `QuerySQL`, `StatusCode` |
+| `NodeHTML` | `html { ... }` | `HTMLContent` |
+| `NodeSendEmail` | `send email to ...` | `EmailTo`, `EmailSubject`, `EmailTemplate`, `EmailAttach`, `Props` |
+| `NodeEnqueue` | `enqueue <job>` | `JobName`, `JobParams` |
+| `NodeOn` | `on success`, `on error`, `on not found` | `Props["condition"]`, `Children` |
+| `NodeBroadcast` | `broadcast to <room>` | `BroadcastRoom`, `BroadcastFrag` |
+| `NodeGeneratePDF` | `generate pdf from <template> data <query>` | `TemplateName`, `DataQueryName` |
+| `NodeFetch` | `fetch <name>: <method> <url>` | `FetchURL`, `FetchMethod`, `FetchHeaders`, `FetchBody` |
+| `NodeLLM` | `llm <name>: <model>` | `LLMModel`, `LLMSystem`, `LLMHistorySQL` |
+
+`Node.Children` holds nested nodes for `on` branching. `Props` is a generic key-value bag used by nodes whose fields do not warrant first-class struct members.
+
+## Models, fields, custom fields
+
+[`parser.Model`](../../../internal/parser/parser.go) carries `Fields`, `UniqueConstraints`, `Indexes`, `Tenant`, and the `custom` manifest references (`CustomFieldsFile`, `CustomFieldsFallback`, `DynamicFields`). [`parser.Field`](../../../internal/parser/parser.go) is one column with `Type` (a [`FieldType`](../../../internal/parser/parser.go) like `text`, `email`, `int`, `reference`, `option`, `computed`, ...), `Required`, `Unique`, `Default`, `Min`, `Max`, `Options`, `Reference`, `Computed`, `ComputedExpr`. Custom fields use [`CustomFieldDef`](../../../internal/parser/parser.go) and [`CustomFieldManifest`](../../../internal/parser/parser.go) and feed into the analyzer and runtime separately from declared fields.
+
+## Auth and access control
+
+- [`parser.AuthConfig`](../../../internal/parser/parser.go): paths and field names for the built-in auth subsystem.
+- [`parser.Permission`](../../../internal/parser/parser.go): role plus rule list (`all`, `read post`, `write post where author = current_user`, ...).
+- [`parser.RequiresClause`](../../../internal/parser/parser.go) and `RequiresClauseKind`: the comma-separated AND-list attached to a `page`, `action`, `api`, `stream`, or `socket`. Kinds include `Auth`, `Role`, `Expr`, `Superuser`, `Flag`, `RateLimit`. The runtime evaluates these in [`auth.go`](../../../internal/runtime/auth.go).
+
+## Notes for contributors
+
+- Adding a top-level keyword: extend the dispatch in `parser.Parse`, add a struct on `App`, add a `parseX` method, register a `spec.Entity` in a new `<name>_spec.go`.
+- Adding a body statement: add a `NodeType` constant, add the fields it needs to `Node`, parse it inside whichever block it belongs to, then teach analyzer, optimizer, and runtime to handle it.
+- Resist adding cross-cutting fields to `Node`. Prefer `Props` for one-off keys, struct fields when the analyzer or runtime relies on them.

--- a/docs/contributors/architecture/pipeline.md
+++ b/docs/contributors/architecture/pipeline.md
@@ -1,0 +1,96 @@
+# Pipeline
+
+A `.kilnx` source file flows through five stages before serving traffic. The same five stages run inside `kilnx run` (interpreted) and inside the `main.go` template emitted by `kilnx build` (AOT). The `runtime` stage is replaced by `build` only in the AOT path, and `build` itself re-uses the runtime: it just embeds the source so the compiled binary re-runs the pipeline at startup.
+
+## Flow
+
+```
+.kilnx source
+     |
+     v
+[lexer]      tokens
+     |
+     v
+[parser]     *parser.App (AST)
+     |
+     v
+[analyzer]   []Diagnostic   ----> reject on error
+     |
+     v
+[optimizer]  *parser.App (rewritten in place)
+     |
+     +----> [runtime]   kilnx run      net/http server
+     |
+     +----> [build]     kilnx build    standalone Go binary
+                                       (embeds source, runtime runs at start)
+```
+
+## Stages
+
+### Lexer
+
+- Package: [`internal/lexer`](../../../internal/lexer).
+- Entry: [`lexer.Tokenize`](../../../internal/lexer/lexer.go).
+- Input: raw source string (after `lexer.StripComments`).
+- Output: `[]lexer.Token` with `Type`, `Value`, `Line`, `Column`.
+- Responsibility: split source into tokens, track 1-based positions, emit `TokenIndent` and `TokenDedent` for the indentation-sensitive grammar, preserve full lines as `TokenRawLine` for SQL, HTML, and computed expression capture downstream.
+- Key files: [`lexer.go`](../../../internal/lexer/lexer.go), [`fuzz_test.go`](../../../internal/lexer/fuzz_test.go).
+
+### Parser
+
+- Package: [`internal/parser`](../../../internal/parser).
+- Entry: [`parser.Parse(tokens, source)`](../../../internal/parser/parser.go).
+- Input: token stream plus the original source (retained for line-based extraction of SQL, HTML, computed expressions, and error context).
+- Output: `*parser.App`, the root AST.
+- Responsibility: dispatch on top-level keyword (`model`, `page`, `action`, `fragment`, `api`, `stream`, `schedule`, `job`, `webhook`, `socket`, `limit`, `config`, `auth`, `permissions`, `layout`, `test`, `log`, `translations`, `query`), build typed nodes, resolve named queries into call sites, accumulate parse errors with `synchronize()` recovery between top-level entities.
+- Key files: [`parser.go`](../../../internal/parser/parser.go) (AST types and dispatch), `*_spec.go` (per-keyword `spec.Entity` registration, see [ast.md](ast.md) and [spec-registry.md](spec-registry.md)).
+
+### Analyzer
+
+- Package: [`internal/analyzer`](../../../internal/analyzer).
+- Entries: [`analyzer.Analyze(app)`](../../../internal/analyzer/analyzer.go), `analyzer.AnalyzeWithDB(app, db)` for live-DB cross-checks.
+- Input: `*parser.App`.
+- Output: `[]analyzer.Diagnostic` (each carries `Level`, `Message`, `Line`, `Context`).
+- Responsibility: derive a [`Schema`](../../../internal/analyzer/analyzer.go) from `app.Models` (with column-mode custom fields folded in), validate SQL against known tables and columns, check action attributes, fragment components, translation params, route uniqueness, security rules in [`security.go`](../../../internal/analyzer/security.go), and (with DB) reconcile against `INFORMATION_SCHEMA` in [`db_check.go`](../../../internal/analyzer/db_check.go).
+- Errors abort `kilnx run`, `kilnx build`, and `kilnx test`. Warnings are printed and execution continues. See [`cmd/kilnx/main.go`](../../../cmd/kilnx/main.go) for the gating logic.
+- Key files: [`analyzer.go`](../../../internal/analyzer/analyzer.go), [`types.go`](../../../internal/analyzer/types.go), [`security.go`](../../../internal/analyzer/security.go), [`db_check.go`](../../../internal/analyzer/db_check.go).
+
+### Optimizer
+
+- Package: [`internal/optimizer`](../../../internal/optimizer).
+- Entry: [`optimizer.Optimize(app)`](../../../internal/optimizer/optimizer.go).
+- Input: `*parser.App`. Mutated in place.
+- Output: same `*parser.App` with rewritten queries and stream candidates marked.
+- Responsibility:
+  - rewrite `SELECT *` to an explicit column list when all consumed fields are known from template usage,
+  - dedupe identical queries inside the same `Page`, `Fragment`, or `API` body,
+  - mark queries eligible to be served as SSE `stream` candidates via `markStreamCandidates`.
+- Optimizer is best-effort: it never changes semantics, only narrows what is fetched. Unsafe rewrites (e.g. queries with multiple unnamed `_last` aliases) are skipped.
+- Key files: [`optimizer.go`](../../../internal/optimizer/optimizer.go).
+
+### Runtime
+
+- Package: [`internal/runtime`](../../../internal/runtime).
+- Entry: [`runtime.NewServer(app, db, port).Start()`](../../../internal/runtime/server.go).
+- Input: `*parser.App`, a `database.Executor`, and a port.
+- Output: a running HTTP server.
+- Responsibility: bind `net/http` mux, serve embedded `htmx.min.js` and `sse.js`, route requests across webhooks, sockets, auth POST handlers, actions, streams, APIs, fragments, and pages, enforce auth and rate limits, render templates, run scheduler and job queue, manage sessions, log requests and slow queries.
+- Detailed walk: [runtime-execution.md](runtime-execution.md).
+- Key files: [`server.go`](../../../internal/runtime/server.go), [`auth.go`](../../../internal/runtime/auth.go), [`render.go`](../../../internal/runtime/render.go), [`permissions.go`](../../../internal/runtime/permissions.go), [`scheduler.go`](../../../internal/runtime/scheduler.go), [`ratelimit.go`](../../../internal/runtime/ratelimit.go).
+
+### Build (AOT)
+
+- Package: [`internal/build`](../../../internal/build).
+- Entry: [`build.Build(kilnxFile, outputPath)`](../../../internal/build/build.go).
+- Input: path to a `.kilnx` file and an optional output binary path.
+- Output: standalone Go binary that runs the same lexer, parser, analyzer, optimizer, runtime stack on startup against the embedded source.
+- Responsibility: locate the kilnx source tree, write a temporary `cmd/_build/main.go` that embeds the source as a backtick-escaped Go string, invoke `go build -o <output> ./cmd/_build/` with `CGO_ENABLED=0`, then clean up.
+- Build does not pre-resolve the AST. The embedded `main.go` re-runs the full pipeline at process start so behaviour matches `kilnx run` exactly.
+- Key files: [`build.go`](../../../internal/build/build.go).
+
+## Where each entry point wires the pipeline
+
+- `kilnx run`: [`cmdRun` in `cmd/kilnx/main.go`](../../../cmd/kilnx/main.go) calls `loadApp` (lexer plus parser), then `analyzer.Analyze`, then `optimizer.Optimize`, then `runtime.NewServer(...).Start()`.
+- `kilnx check`: [`cmdCheck`](../../../cmd/kilnx/main.go) stops after analyzer.
+- `kilnx test`: parser plus analyzer plus optimizer, then a runtime instance bound to port 9999 to drive `Test` blocks.
+- `kilnx build`: delegates to `internal/build` which generates the same call sequence inside the emitted `main.go`.

--- a/docs/contributors/architecture/runtime-execution.md
+++ b/docs/contributors/architecture/runtime-execution.md
@@ -1,0 +1,120 @@
+# Runtime Execution
+
+What happens between a TCP accept and a flushed response, inside [`internal/runtime`](../../../internal/runtime).
+
+## Server boot
+
+[`runtime.NewServer(app, db, port)`](../../../internal/runtime/server.go) wires the request-handling stack:
+
+- `SessionStore` ([`auth.go`](../../../internal/runtime/auth.go)). HMAC-signed session cookies, in-memory cache plus SQLite persistence, 24h expiry, background cleanup. Falls back to a random secret with a warning when `config.secret` is empty.
+- `JobQueue` ([`scheduler.go`](../../../internal/runtime/scheduler.go) and related). Background poller for `enqueue` work.
+- `RateLimiter` ([`ratelimit.go`](../../../internal/runtime/ratelimit.go)). Built from `app.RateLimits`.
+- `Logger` ([`logger.go`](../../../internal/runtime/logger.go)). Driven by `app.LogConfig`. Wired to `database.DB.OnSlowQuery` for slow query traces.
+- `TenantMap` ([`tenant.go`](../../../internal/runtime/tenant.go)). Models with a `tenant: <model>` directive.
+- `i18n` ([`i18n.go`](../../../internal/runtime/i18n.go)). Translation table plus optional Accept-Language detection.
+- `fragmentComponents`. Index of component-style fragments (those with `FragmentArgs`), keyed by `Path`, used for inline rendering.
+- `superuserIdentity`. From `auth.superuser`. Bypasses all role checks.
+
+[`Server.Start`](../../../internal/runtime/server.go) builds the `http.ServeMux` via `buildHandler`, wraps it in `Logger.LoggingMiddleware`, and calls `http.ListenAndServe`. Hot reload swaps the parsed app under a write lock via [`Server.Reload`](../../../internal/runtime/server.go).
+
+## Mux layout
+
+Three permanent routes are registered at boot:
+
+- `GET /_kilnx/htmx.min.js` and `GET /_kilnx/sse.js`. Embedded static assets via `embed.FS`.
+- `/_uploads/`. File server over `config.uploads_dir` with `X-Content-Type-Options: nosniff` and `Content-Disposition: attachment`.
+- `/_static/`. File server over `config.static_dir`. Resolved against absolute CWD; refused if it escapes CWD. `Cache-Control: no-store` when `KILNX_DEV=1`, otherwise `public, max-age=3600`.
+- `GET /healthz`. Static `{"status":"ok"}` JSON.
+
+Everything else is served by a single catch-all handler at `/` so route resolution honors hot reload.
+
+## Request lifecycle
+
+The catch-all in [`server.go`](../../../internal/runtime/server.go) walks routes in this fixed order. First match wins.
+
+1. Snapshot app under read lock: `s.getApp()`.
+2. Rate limit check: `RateLimiter.CheckWithRule`. On exceeded, write `429 Too Many Requests` with the rule's message and `Retry-After`.
+3. Webhooks. POST endpoints that bypass CSRF and verify a payload signature against `webhook.SecretEnv`. Handled by `handleWebhook`.
+4. WebSockets. Path-matched against `app.Sockets`. Handled by `handleSocket`.
+5. Auth POST endpoints. When `app.Auth != nil` and method is POST, paths matching `LoginPath`, `LogoutPath`, `RegisterPath`, `ForgotPath`, `ResetPath` go to `handleLogin`, `handleLogout`, `handleRegister`, `handleForgotPassword`, `handleResetPassword`. The runtime owns POST. GET falls through to user-declared pages; the analyzer enforces that each auth path has a page.
+6. Actions. POST, PUT, or DELETE. Path-matched against `app.Actions`. Declared `Method` is enforced. `requireAuth` runs first, then `handleAction`.
+7. Streams. Path-matched against `app.Streams`. `handleStream` issues SSE.
+8. APIs. Path-matched against `app.APIs`. `OPTIONS` always passes through for CORS preflight. Declared `Method` is enforced; mismatch defers a `405`. `requireAPIAuth` runs, then `handleAPI` returns JSON.
+9. Fragments. Path-matched against `app.Fragments`, skipping component-style fragments (`FragmentArgs != nil`). `requireAuth`, then `renderFragment`, write `text/html`.
+10. Pages. Path-matched against `app.Pages` (GET). `requireAuth`, then `renderPage`, write `text/html`.
+11. Fall-through. `404` rendered via `render404`.
+
+`matchPath` (in [`server.go`](../../../internal/runtime/server.go) helpers) handles literal segments and `:param` placeholders.
+
+## Auth and access control
+
+[`Server.requireAuth`](../../../internal/runtime/auth.go) gates pages, actions, and fragments. [`Server.requireAPIAuth`](../../../internal/runtime/auth.go) is the JSON twin (returns `401` or `403` JSON instead of an HTML redirect).
+
+Decision tree for `requireAuth`:
+
+- `page.Auth == false`. Allow.
+- `app.Auth == nil`. Allow (no auth subsystem configured).
+- No session. Redirect to `auth.login` with `?next=<path>`. For htmx (`HX-Request: true`), set `HX-Redirect` and `401`.
+- `RequiresClauses` non-empty. Evaluate the AND of all clauses via `evalRequiresClauses`. Fail renders `403` via `renderForbidden`.
+- Legacy `RequiresRole`. `auth` allows any logged-in user. A named role passes if `session.Role == role` or `hasPermission(session.Role, role, app.Permissions)` returns true. Otherwise `403`.
+
+`RequiresClauseKind` covers `Auth`, `Role`, `Expr`, `Superuser`, `Flag`, and `RateLimit`. The expression form is evaluated by [`expr.go`](../../../internal/runtime/expr.go) against the current session.
+
+## Permissions and SQL rewriting
+
+`app.Permissions` is a list of `Permission{Role, Rules}`. [`permissions.go`](../../../internal/runtime/permissions.go) builds a `PermissionMap` and exposes:
+
+- `CanAccess`, `CanRead`, `CanWrite`. Pre-flight checks per role and resource.
+- `ConditionForRead`, `ConditionForWrite`. Returns the row-level filter clause from rules like `read post where author = current_user`.
+- `RewritePermissionSQL`. Injects the per-role filter into a query as an extra `WHERE` predicate. Placeholder substitution is done by `resolvePermissionPlaceholders`.
+
+Pages, actions, and APIs that issue queries get their SQL rewritten through this layer before it reaches `database.Executor`.
+
+## Handler dispatch
+
+- `handlePage` and `handleAction` walk the body `[]parser.Node` in order. Each `NodeType` has a runtime case. Queries hit the database via the executor; `validate` builds form rules from `Validations`; `respond`, `redirect`, `send email`, `enqueue`, `broadcast`, `fetch`, `llm`, `generate pdf`, `on success/error/not found` all flow from the same loop.
+- `handleAction` enforces CSRF on the standard path. Webhooks and APIs are exempt by design (they have their own auth: signature verification or session/JSON 401).
+- `handleAPI` returns JSON shaped from query results. CORS headers come from `config.cors_origins`.
+- `handleStream` opens an SSE response and re-runs the stream's SQL on a tick.
+
+## Render
+
+[`renderPage`](../../../internal/runtime/server.go) builds a `renderContext` carrying:
+
+- `queries map[string][]database.Row`. Materialized query results, keyed by query name.
+- `paginate map[string]PaginateInfo`. Per-query pagination state.
+- `currentUser *Session`, `queryParams`, `request`, `i18n`.
+- `customManifests`. For list pages that bind to dynamic custom fields.
+- `eachStack`, `eachModels`, `currentRow`. State for `{{each}}` iteration and parent-scope resolution with `{^field}`.
+- `models`. All declared models, used to resolve computed fields at template time.
+- `fragmentArgs`, `fragmentDepth`, `fragmentComponents`. Component-fragment inlining with a recursion guard.
+- `actions`. All declared actions, for `action=` attribute expansion in HTML.
+
+Rendering supports the directives documented at the top of [`render.go`](../../../internal/runtime/render.go):
+
+- `{{each name}}...{{else}}...{{end}}`. Iterate query rows.
+- `{{if expr}}...{{else}}...{{end}}`. Conditional block.
+- `{name.field}`, `{name.count}`, `{field}`. Escaped value lookup.
+- `{field | raw}`. Unescaped (used for richtext).
+- `{field | filter1 | filter2: arg}`. Filter chain. Built-ins live in `builtinFilters` (`upcase`, `downcase`, `capitalize`, `truncate`, `default`, `raw`, ...).
+- `{csrf}`. CSRF token, regenerated per occurrence.
+- `{paginate.name.field}`. Pagination metadata.
+- `{params.key}`. URL query parameters.
+
+The page's content is then wrapped by its declared `Layout` (slots `{page.title}`, `{page.content}`, `{nav}`). Layout queries are merged into the same render context.
+
+## Side effects in a request
+
+- DB writes via `database.Executor` (transactional per-action when applicable).
+- Session mutation through `SessionStore` (cookie set/clear, in-memory map, SQLite row).
+- Job enqueue: `JobQueue.Enqueue`, picked up by the background poller.
+- Outbound: `send email` (`email.go`), `fetch` (`fetch.go`, hardened against SSRF), `llm` (`llm.go`), `broadcast` (`websocket.go`), `generate pdf` (`internal/pdf` via `pdf.go`).
+
+## Where to start reading
+
+- Routing top-to-bottom: [`server.go`](../../../internal/runtime/server.go).
+- Auth and sessions: [`auth.go`](../../../internal/runtime/auth.go).
+- Templates and filters: [`render.go`](../../../internal/runtime/render.go).
+- Permission rewriting: [`permissions.go`](../../../internal/runtime/permissions.go).
+- Background work: [`scheduler.go`](../../../internal/runtime/scheduler.go), `jobQueue` in [`server.go`](../../../internal/runtime/server.go).
+- Tenancy: [`tenant.go`](../../../internal/runtime/tenant.go).

--- a/docs/contributors/architecture/spec-registry.md
+++ b/docs/contributors/architecture/spec-registry.md
@@ -1,0 +1,91 @@
+# Spec Registry
+
+`internal/spec` is the canonical schema describing every Kilnx language entity (keyword or attribute). The registry is the single source of truth consumed by [`cmd/kilnx-gendocs`](../../../cmd/kilnx-gendocs) to emit user-facing reference Markdown under [`docs/devs/reference/`](../../devs/reference/).
+
+## Package shape
+
+[`internal/spec/spec.go`](../../../internal/spec/spec.go) defines:
+
+- [`Kind`](../../../internal/spec/spec.go): `KindKeyword` or `KindAttribute`.
+- [`Entity`](../../../internal/spec/spec.go): name, kind, summary, description, syntax, args, parent scope, children, repeatable, required, default, since, examples, see-also.
+- [`Arg`](../../../internal/spec/spec.go): one positional or named argument (`Name`, `Type`, `Required`, `Variadic`).
+- [`Example`](../../../internal/spec/spec.go): titled code snippet.
+- A package-level `entities` map and the API: [`Register`](../../../internal/spec/spec.go), [`All`](../../../internal/spec/spec.go), [`Get`](../../../internal/spec/spec.go), [`ByKind`](../../../internal/spec/spec.go), [`ChildrenOf`](../../../internal/spec/spec.go), [`ParentsOf`](../../../internal/spec/spec.go).
+
+The package itself declares no entities. By design.
+
+## Self-registration via `init()`
+
+Each language entity is declared next to the code that implements it. The implementing package adds a `<name>_spec.go` file that calls `spec.Register` from `init()`. Examples:
+
+- [`internal/parser/page_spec.go`](../../../internal/parser/page_spec.go) registers the `page` keyword.
+- [`internal/parser/model_spec.go`](../../../internal/parser/model_spec.go) registers `model`.
+- [`internal/parser/attrs_spec.go`](../../../internal/parser/attrs_spec.go) and [`internal/parser/field_attrs_spec.go`](../../../internal/parser/field_attrs_spec.go) register attributes (`required`, `unique`, `auto`, `default`, `min`, `max`, `index`, `tenant`, `requires`, `method`, `title`, `layout`, ...).
+- [`internal/parser/body_nodes_spec.go`](../../../internal/parser/body_nodes_spec.go) registers body statements (`query`, `redirect`, `validate`, `respond`, `html`, `send`, `enqueue`, `on`, `broadcast`, `fetch`, `llm`, ...).
+
+A typical registration looks like the `model` entry in [`model_spec.go`](../../../internal/parser/model_spec.go):
+
+```go
+func init() {
+    spec.Register(spec.Entity{
+        Name:    "model",
+        Kind:    spec.KindKeyword,
+        Summary: "Declare a database table with typed fields and constraints.",
+        Syntax:  "model <name>",
+        Args:    []spec.Arg{{Name: "name", Type: "identifier", Required: true}},
+        Children: []string{"required", "unique", "auto", "auto_update", "default",
+            "min", "max", "index", "tenant", "custom", "dynamic_fields"},
+        Repeatable: true,
+        Since:      "0.1.0",
+        Examples:   []spec.Example{ /* ... */ },
+        SeeAlso:    []string{"query", "auth"},
+    })
+}
+```
+
+## Overloaded attributes
+
+Some attribute names appear under multiple parents (for example `requests` inside both `log` and `limit`). `Register` permits re-registering an attribute with the same `Name` and merges:
+
+- `ParentScope` is unioned.
+- New `Description` text is appended under a `When used in <parent>:` header.
+- First non-empty `Summary`, `Syntax`, `Default`, `Args` win. Examples are concatenated.
+
+Re-registering a keyword (`KindKeyword`) panics. Mixing kinds for the same name panics. See the merge logic in [`spec.go`](../../../internal/spec/spec.go).
+
+## Lookup and traversal
+
+- `spec.ByKind(spec.KindKeyword)` returns all keywords sorted by name. Used by [`cmd/kilnx-gendocs/main.go`](../../../cmd/kilnx-gendocs/main.go) to drive the index page.
+- `spec.ChildrenOf(parent)` returns the union of `parent.Children` and entities whose `ParentScope` includes `parent`, deduped and sorted. The reverse lookup means a child can opt in by setting `ParentScope` without editing the parent's `Children` list.
+- `spec.ParentsOf(attr)` returns the parents of an attribute via `ParentScope`.
+
+## Doc generation
+
+[`cmd/kilnx-gendocs`](../../../cmd/kilnx-gendocs/main.go) is a thin renderer:
+
+1. Blank-import packages that register entities. Today this is `internal/parser`. The blank import triggers each `<name>_spec.go` `init()`, which populates `spec.entities`.
+2. Pull keywords and attributes via `spec.ByKind`.
+3. Augment `SeeAlso` with reverse links.
+4. Resolve provenance from `git log`: SHA and date for the spec file, plus the implementation file(s) discovered by grepping the parser for `case "<name>":` and `Value == "<name>"` patterns. Mark entities `Stale` when the implementation was touched after the spec.
+5. Render the embedded templates ([`cmd/kilnx-gendocs/templates`](../../../cmd/kilnx-gendocs/templates)) into `docs/devs/reference/keywords/<name>.md` and `docs/devs/reference/attributes/<name>.md`.
+
+Run it locally:
+
+```bash
+go run ./cmd/kilnx-gendocs            # writes to docs/devs/reference
+go run ./cmd/kilnx-gendocs -o /tmp    # writes to /tmp/devs/reference
+go run ./cmd/kilnx-gendocs -check-stale
+```
+
+`-check-stale` exits non-zero when any entity's implementation is newer than its spec. Wire it into CI to catch undocumented behaviour drift.
+
+## Adding a new entity
+
+1. Implement parsing and AST in `internal/parser` (see [ast.md](ast.md)).
+2. Create `<name>_spec.go` in the same package. Populate `Name`, `Kind`, `Summary`, `Description`, `Syntax`, `Args`, `ParentScope` (for attributes), `Children` (for keywords), `Examples`, `Since`, `SeeAlso`.
+3. Run `go run ./cmd/kilnx-gendocs` and commit the generated Markdown.
+4. Run `go run ./cmd/kilnx-gendocs -check-stale` to confirm the new entity is not flagged.
+
+## Why init-time registration
+
+Co-locating the spec with the implementation keeps the two from drifting. Reviewers see DSL surface changes in the same diff as the parser change, and the staleness detector catches the rest.

--- a/docs/contributors/go-primer.md
+++ b/docs/contributors/go-primer.md
@@ -1,0 +1,214 @@
+# Go Primer for Kilnx Contributors
+
+A short tour of the Go idioms that recur across the Kilnx codebase, aimed at contributors fluent in another statically typed language. The goal is not to teach Go from scratch but to flatten the ramp into this specific repo. Every example below is grounded in a real file you can open.
+
+## Package layout
+
+A package is a directory of `.go` files declaring `package <name>` on the first non-comment line. Files in the same directory share the package and see each other's exported and unexported identifiers without imports.
+
+Kilnx splits the compiler and runtime under [`internal/`](../../internal/), which Go treats specially: identifiers exported from `internal/X` are only importable by code under the same parent (`github.com/kilnx-org/kilnx/...`). The CLI binary lives under [`cmd/kilnx`](../../cmd/kilnx/main.go); a second binary, [`cmd/kilnx-gendocs`](../../cmd/kilnx-gendocs/main.go), generates reference Markdown.
+
+Naming convention in this repo: capitalized identifiers (`Tokenize`, `Parse`, `App`, `Server`) are exported and stable; lowercase ones (`parserState`, `entities`, `dispatchToken`) are package-private and may change without notice.
+
+## Package doc comments
+
+A doc comment immediately above the `package` clause is the package's public documentation. [`internal/parser/doc.go`](../../internal/parser/doc.go) is the canonical example:
+
+```go
+// Package parser builds the Kilnx AST from a token stream produced by
+// internal/lexer. ...
+package parser
+```
+
+Package docs are the first thing to read when entering a new directory. Most Kilnx packages have one.
+
+## Interfaces
+
+Interfaces in Go are structural: a type satisfies an interface by having the right methods, no `implements` keyword required. The runtime relies on this for dependency inversion.
+
+[`database.Executor`](../../internal/database/interfaces.go) defines the surface the runtime needs:
+
+```go
+type Executor interface {
+    QueryRows(sqlStr string) ([]Row, error)
+    QueryRowsWithParams(sqlStr string, params map[string]string) ([]Row, error)
+    ExecWithParams(sqlStr string, params map[string]string) error
+    BeginTxHandle() (*TxHandle, error)
+    Dialect() Dialect
+}
+```
+
+The real implementation is `*database.DB` in [`database.go`](../../internal/database/database.go), backed by `database/sql`. Tests substitute fakes that implement the same method set. The runtime never names the concrete type beyond `New*` constructors.
+
+When you see a function take `db database.Executor`, the contract is: "this needs SQL execution, the caller picks the implementation." This is the standard Go pattern for testability.
+
+## Struct embedding
+
+Go has no inheritance. Composition is achieved by declaring a field with no name:
+
+```go
+type Logger struct { ... }
+
+type Server struct {
+    logger *Logger
+    // ... other fields
+}
+```
+
+The runtime prefers explicit fields over embedding to keep ownership obvious. [`Server`](../../internal/runtime/server.go) holds named pointers to `*SessionStore`, `*JobQueue`, `*RateLimiter`, `*Logger`, and `*I18n` rather than embedding them.
+
+## Errors
+
+Go errors are values. Functions return `(T, error)`. The caller checks the error with an `if err != nil` block. This codebase wraps errors with context using `fmt.Errorf` and the `%w` verb so callers can unwrap with `errors.Is` or `errors.As` if needed:
+
+```go
+// internal/database/database.go
+return nil, fmt.Errorf("opening database %s: %w", url, err)
+```
+
+The analyzer takes a different shape because it produces multiple diagnostics rather than a single error: it returns `[]analyzer.Diagnostic`, where each carries `Level` ("error" or "warning"), `Message`, `Line`, and `Context`. The CLI in [`printDiagnostics`](../../cmd/kilnx/main.go) formats them and decides whether to abort.
+
+The parser collects errors via `addError` on `parserState` and recovers with `synchronize()`, so a single `Parse` call can report many syntax errors at once.
+
+## Goroutines and channels
+
+A `goroutine` is a lightweight thread launched with the `go` keyword. Channels are typed pipes used to coordinate them.
+
+The scheduler in [`scheduler.go`](../../internal/runtime/scheduler.go) launches one goroutine per `schedule` block, with a `stop` channel for shutdown:
+
+```go
+stop := make(chan struct{})
+go s.runSchedule(sched, stop)
+```
+
+`runSchedule` uses `time.NewTicker` and `select` to wait on whichever event fires first:
+
+```go
+ticker := time.NewTicker(interval)
+defer ticker.Stop()
+for {
+    select {
+    case <-ticker.C:
+        s.executeScheduleBody(sched)
+    case <-stop:
+        return
+    }
+}
+```
+
+`chan struct{}` is the idiomatic shutdown signal: it carries no data, only the closure event. Closing the channel broadcasts to every receiver. The job queue in the same file uses an analogous polling pattern.
+
+The hot-reload watcher in [`watcher.go`](../../internal/runtime/watcher.go) is a goroutine launched by `WatchAndServe` that polls file mtime on a 500ms interval and calls `Server.Reload` when the source changes.
+
+## Synchronization
+
+Concurrent access to shared state is guarded with `sync.Mutex` or `sync.RWMutex`. [`Server`](../../internal/runtime/server.go) uses an `sync.RWMutex` to protect the parsed app pointer during hot reload:
+
+```go
+func (s *Server) getApp() *parser.App {
+    s.mu.RLock()
+    defer s.mu.RUnlock()
+    return s.app
+}
+```
+
+`RLock` allows many concurrent readers but no writers; `Lock` is exclusive. The `defer` keyword schedules `Unlock` to run when the function returns, no matter the path.
+
+Other concurrency primitives in the runtime: `sync.Once` (one-shot warnings), `sync.Map` (manifest cache in [`server.go`](../../internal/runtime/server.go)), `chan struct{}` for shutdown.
+
+## `defer`
+
+`defer` schedules a call to run when the surrounding function returns. The runtime uses it heavily for cleanup that must happen on every exit path:
+
+```go
+tx, err := s.db.BeginTxHandle()
+if err != nil { ... }
+defer tx.Rollback() // no-op if already committed
+```
+
+Multiple deferred calls run in LIFO order. Defer is the right tool for `Close`, `Unlock`, `Rollback`, `Stop`.
+
+## Slices and maps
+
+`[]T` is a slice (dynamic array). `map[K]V` is a hash map. Both are reference types: passing them into a function shares the underlying storage. The parser appends to slices on `App` (`app.Pages = append(app.Pages, page)`); the rendering layer keys per-query results on a `map[string][]database.Row`.
+
+The zero value of a slice is `nil`, which is a valid empty slice. The zero value of a map is also `nil` but is read-only; you must `make(map[K]V)` before assigning.
+
+## `database/sql`
+
+[`internal/database/database.go`](../../internal/database/database.go) wraps Go's standard `database/sql` package. The driver is `mattn/go-sqlite3` (CGO-free with `modernc.org/sqlite` when `CGO_ENABLED=0`). `*sql.DB` is a connection pool, safe for concurrent use. Transactions are obtained with `Begin`; the Kilnx wrapper exposes them as `*TxHandle` with `QueryRowsWithParams`, `ExecWithParams`, `Commit`, `Rollback`. Action handlers wrap their body in a transaction so failures roll back partial mutations.
+
+## `go generate`
+
+`go generate` runs commands embedded in source files as `//go:generate` comments. [`internal/parser/doc.go`](../../internal/parser/doc.go) holds:
+
+```go
+//go:generate go run ../../cmd/kilnx-gendocs -o ../../docs/devs/reference
+```
+
+Running `go generate ./internal/parser/...` invokes that command. We use it to regenerate the language reference Markdown after touching any `*_spec.go` file. There is no commit hook; reviewers run it manually or rely on `go run ./cmd/kilnx-gendocs -check-stale` in CI.
+
+## `init()`
+
+A function named `init()` (no args, no return) runs once per package, before `main`, in dependency-import order. Kilnx uses `init()` to populate the spec registry without touching parser code at every site:
+
+```go
+// internal/parser/page_spec.go
+func init() {
+    spec.Register(spec.Entity{Name: "page", Kind: spec.KindKeyword, ...})
+}
+```
+
+The `cmd/kilnx-gendocs` binary blank-imports `internal/parser` (`_ "github.com/kilnx-org/kilnx/internal/parser"`) purely to trigger these `init()` calls. See [architecture/spec-registry.md](architecture/spec-registry.md).
+
+## Testing conventions
+
+Test files live next to the code under test as `*_test.go`. Package `foo` ships its tests under `package foo` (white-box) or `package foo_test` (black-box). Kilnx mostly uses white-box tests so they can reach unexported helpers.
+
+A test function takes `*testing.T`:
+
+```go
+func TestRequireAuth(t *testing.T) {
+    if !ok {
+        t.Errorf("expected auth gate to allow request: got %v", err)
+    }
+}
+```
+
+Run all tests:
+
+```bash
+go test ./...
+```
+
+One package, with verbose output:
+
+```bash
+go test -v ./internal/runtime/...
+```
+
+Race detector (recommended for runtime work):
+
+```bash
+go test -race ./internal/runtime/...
+```
+
+Several packages also ship `_test.go` files using subtests via `t.Run(name, ...)` and table-driven tests, both standard Go idioms.
+
+## What we don't use
+
+To save you searching:
+
+- No generics in hot paths. The codebase predates Go 1.18 in spirit; concrete types win when types are simple.
+- No reflection in the parser or runtime hot path. The analyzer reflects over models in a few targeted places only.
+- No third-party logging library. The runtime's [`Logger`](../../internal/runtime/logger.go) wraps `log` from the standard library.
+- No DI container. Wiring is explicit in `NewServer` and friends.
+- No build tags besides the standard ones. `CGO_ENABLED=0` is set by [`build.Build`](../../internal/build/build.go) and respected by the SQLite driver selection in [`database`](../../internal/database/).
+
+## Where to read more
+
+- The Go tour: [https://go.dev/tour](https://go.dev/tour).
+- Effective Go: [https://go.dev/doc/effective_go](https://go.dev/doc/effective_go).
+- For `database/sql` patterns specifically, [http://go-database-sql.org/](http://go-database-sql.org/) is the canonical primer.
+
+When in doubt, the answer is usually the `_test.go` file next to the code you are trying to understand. Tests are how this repo documents its public API.

--- a/docs/contributors/index.md
+++ b/docs/contributors/index.md
@@ -1,0 +1,134 @@
+# Contributor Docs
+
+Internals reference for [Kilnx](../../README.md). For Go programmers contributing to the compiler, runtime, or tooling, and for readers reverse-engineering the codebase.
+
+## Audience
+
+- Contributors patching the lexer, parser, analyzer, optimizer, runtime, or `cmd/`.
+- Reviewers grading PRs that touch language semantics or runtime behavior.
+- Curious Go developers reading Kilnx as a worked example of a small declarative DSL hosted on `net/http` and SQLite.
+
+User-facing language reference lives under [docs/devs/](../devs/) and is generated from the `internal/spec` registry. See [spec-registry.md](architecture/spec-registry.md) for how that works.
+
+## What Kilnx is
+
+A `.kilnx` file declares models, pages, actions, fragments, APIs, jobs, schedules, sockets, streams, and webhooks. The toolchain reads that file, validates it, and either serves it directly (`kilnx run`) or produces a standalone Go binary (`kilnx build`). One file, one binary. No template language separate from the DSL, no migration tool separate from the model declaration.
+
+## The compile pipeline
+
+Every command (`run`, `check`, `build`, `migrate`, `test`) shares the same front end:
+
+```
+.kilnx source
+     |
+     v
+[lexer]      indent-sensitive tokenizer       internal/lexer
+     |
+     v
+[parser]     token stream -> AST              internal/parser
+     |
+     v
+[analyzer]   diagnostics, schema check        internal/analyzer
+     |
+     v
+[optimizer]  SELECT * expansion, JOIN prune,  internal/optimizer
+             query dedup
+     |
+     +----> [runtime]   in-process HTTP server  internal/runtime
+     |                  used by `kilnx run`
+     |
+     +----> [build]     emit cmd/_build/main.go internal/build
+                        go build -o app
+                        used by `kilnx build`
+```
+
+Both `kilnx run` and `kilnx build` execute the same five compile stages. They differ only in how source is loaded and where the runtime is invoked: `kilnx run` reads the file from disk via [`runtime.WatchAndServe`](../../internal/runtime/watcher.go) and watches it for hot reload; `kilnx build` calls [`build.Build`](../../internal/build/build.go) which writes a temporary `cmd/_build/main.go` embedding the source as a Go `const` and shells out to `go build` with `CGO_ENABLED=0`. The compiled binary then re-runs the full pipeline at startup against the embedded source.
+
+See [architecture/pipeline.md](architecture/pipeline.md) for stage-by-stage detail.
+
+## Where to read next
+
+| If you want to                                | Read                                                                              |
+| --------------------------------------------- | --------------------------------------------------------------------------------- |
+| Stage-by-stage pipeline depth                 | [architecture/pipeline.md](architecture/pipeline.md)                              |
+| AST shape, node types, field attachment       | [architecture/ast.md](architecture/ast.md)                                        |
+| HTTP request lifecycle and routing order      | [architecture/runtime-execution.md](architecture/runtime-execution.md)            |
+| Add a new keyword or attribute                | [architecture/spec-registry.md](architecture/spec-registry.md)                    |
+| Catch up on Go idioms used in the codebase    | [go-primer.md](go-primer.md)                                                      |
+| Work on a specific package                    | [packages/](packages/)                                                            |
+
+## Repository layout
+
+```
+cmd/
+  kilnx/             CLI entry point: run, check, build, migrate, test
+  kilnx-gendocs/     reads internal/spec registry, emits docs/devs/reference
+  _build/            transient. Created by `kilnx build`, deleted on exit.
+internal/
+  lexer/             tokenizer, INDENT/DEDENT, raw-line capture
+  parser/            AST + per-entity *_spec.go registrations
+  analyzer/          diagnostics, schema check, optional DB cross-check
+  optimizer/         SELECT * expansion, JOIN prune, query dedup
+  runtime/           HTTP server, auth, forms, scheduler, jobs, sockets
+  build/             generates cmd/_build/main.go and runs go build
+  database/          sql.DB wrapper, Executor interface, migrations
+  spec/              registry consumed by kilnx-gendocs
+docs/
+  devs/              app-author documentation (generated reference under reference/)
+  contributors/      this section
+```
+
+## Building and testing locally
+
+You need a Go toolchain matching `go.mod`. There is no Makefile.
+
+Run the full suite:
+
+```bash
+go test ./...
+```
+
+One package:
+
+```bash
+go test ./internal/runtime/...
+```
+
+Build the CLI:
+
+```bash
+go build ./cmd/kilnx
+```
+
+Regenerate the reference docs after touching any `*_spec.go`:
+
+```bash
+go generate ./internal/parser/...
+```
+
+The generator is wired through [`internal/parser/doc.go`](../../internal/parser/doc.go), which holds a `//go:generate` directive pointing at [`cmd/kilnx-gendocs`](../../cmd/kilnx-gendocs/main.go). Output lands in [`docs/devs/reference/`](../devs/reference/). Run `go run ./cmd/kilnx-gendocs -check-stale` to confirm no implementation file is newer than its spec.
+
+Smoke-test against an example:
+
+```bash
+go run ./cmd/kilnx run examples/blog.kilnx
+```
+
+The server prints discovered routes, schedules, jobs, sockets, and rate limits at startup. See [`printRoutes`](../../internal/runtime/watcher.go) for the format.
+
+## Conventions
+
+- The DSL is the source of truth. Anything declared in `.kilnx` should not need a second declaration in Go. The exception is the `*_spec.go` doc registration, which exists only so that human-readable reference docs can be generated.
+- No em-dash or en-dash in docs. Use comma, period, or rewrite.
+- Reference real paths. Example: [`internal/runtime/server.go`](../../internal/runtime/server.go).
+- Errors flow up. Lexer and parser collect errors with line numbers from the original source. The analyzer emits typed `Diagnostic` values with a `Level` of `error` or `warning`. Runtime errors flow through [`Logger`](../../internal/runtime/logger.go).
+- The runtime never blocks on disk for routing. Source watching runs in a goroutine in [`watcher.go`](../../internal/runtime/watcher.go) and swaps the AST under a write lock via `Server.Reload`.
+- Schedulers and the job queue are started by the runtime, not the CLI. See [`scheduler.go`](../../internal/runtime/scheduler.go).
+
+## Asking questions
+
+If a piece of code is unclear, the answer is usually in:
+
+1. The package doc comment of the file you are reading.
+2. The corresponding `*_spec.go` next to it (for parser entities).
+3. A `_test.go` file in the same package, which exercises the public API by example.

--- a/docs/contributors/packages/analyzer.md
+++ b/docs/contributors/packages/analyzer.md
@@ -1,0 +1,798 @@
+# `internal/analyzer`
+
+> Package analyzer performs static analysis on the parser AST: type checking of field constraints, validation of route templates, permission/role checks, dead-link detection, and security audits.
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/analyzer` |
+| **Source last touched** | `b738d30` (2026-05-05) |
+| **Doc last touched** | `5da8498` (2026-05-08) |
+
+
+## Overview
+
+The analyzer runs after parsing and before optimization or runtime
+execution. It is also the implementation behind `kilnx check`. Errors
+and warnings are returned as structured diagnostics so callers (CLI,
+CI) can format them.
+
+Public surface centers on Analyze, which takes a parser.App and
+returns a slice of diagnostics. Subordinate checks live in
+db_check.go (database/SQL coherence) and security.go (auth/CSRF).
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`analyzer.go`](../../../internal/analyzer/analyzer.go) | _no file-level doc_ |
+| [`db_check.go`](../../../internal/analyzer/db_check.go) | _no file-level doc_ |
+| [`security.go`](../../../internal/analyzer/security.go) | _no file-level doc_ |
+| [`types.go`](../../../internal/analyzer/types.go) | _no file-level doc_ |
+
+## Types
+
+### `ColumnInfo`
+
+```go
+type ColumnInfo struct {
+	FieldType parser.FieldType
+}
+```
+
+ColumnInfo holds the inferred type for a single database column.
+
+### `Diagnostic`
+
+```go
+type Diagnostic struct {
+	Level	string	// "error" or "warning"
+	Message	string
+	Line	int	// source line (0 if unknown)
+	Context	string	// location, e.g. "page /users"
+}
+```
+
+Diagnostic represents a compile-time finding from static analysis.
+
+### `ExprType`
+
+```go
+type ExprType struct {
+	Category	TypeCategory
+	Source		string	// description for error messages
+}
+```
+
+ExprType represents the inferred type of a SQL expression.
+
+### `ModelFieldInfo`
+
+```go
+type ModelFieldInfo struct {
+	FormFields	map[string]bool		// field names as sent by HTML forms
+	FieldToColumn	map[string]string	// form field name -> DB column name
+	ColumnToField	map[string]string	// DB column name -> form field name
+}
+```
+
+ModelFieldInfo holds the form-level field names for a model.
+This maps model field names (what HTML forms send) to DB column names.
+
+### `Schema`
+
+```go
+type Schema struct {
+	Tables		map[string]*TableInfo
+	ModelFields	map[string]*ModelFieldInfo
+}
+```
+
+Schema is the compile-time view of the database derived from model declarations.
+
+### `TableInfo`
+
+```go
+type TableInfo struct {
+	Name	string
+	Columns	map[string]*ColumnInfo
+}
+```
+
+TableInfo holds the known columns and their types for a model-derived table.
+
+### `TypeCategory`
+
+```go
+type TypeCategory int
+```
+
+TypeCategory groups field types for compatibility checking.
+
+### `columnRef`
+
+```go
+type columnRef struct {
+	table	string
+	column	string
+}
+```
+### `eachBlock`
+
+```go
+type eachBlock struct {
+	start		int
+	end		int
+	queryName	string
+}
+```
+
+eachBlock represents a single {{each queryName}}...{{end}} span in HTML.
+
+### `sqlComparison`
+
+```go
+type sqlComparison struct {
+	left		sqlToken
+	right		sqlToken
+	leftTable	string
+	rightTable	string
+	op		string
+}
+```
+
+sqlComparison represents a binary comparison in a WHERE clause.
+
+### `sqlToken`
+
+```go
+type sqlToken struct {
+	typ	int
+	value	string
+	lower	string
+}
+```
+### `tableRef`
+
+```go
+type tableRef struct {
+	name	string
+	alias	string
+}
+```
+## Functions
+
+### `Analyze`
+
+```go
+func Analyze(app *parser.App) []Diagnostic
+```
+
+Analyze performs static analysis on a parsed Kilnx app, checking SQL
+references against declared models and type compatibility.
+
+### `AnalyzeWithDB`
+
+```go
+func AnalyzeWithDB(app *parser.App, db *database.DB) []Diagnostic
+```
+
+AnalyzeWithDB runs the standard Analyze pass plus a DB-connected pass that
+validates {q.custom.fieldName} references against the actual _field_defs tables.
+db may be nil, in which case this is equivalent to Analyze.
+
+### `BuildSchema`
+
+```go
+func BuildSchema(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) *Schema
+```
+
+BuildSchema creates a compile-time view of the database from model declarations.
+Pass app.CustomManifests as the optional second argument to include column-mode
+custom fields as real schema columns.
+
+### `analyzeNodes`
+
+```go
+func analyzeNodes(nodes []parser.Node, schema *Schema, context string) []Diagnostic
+```
+### `analyzeSQL`
+
+```go
+func analyzeSQL(sql string, schema *Schema, context string) []Diagnostic
+```
+### `categoryName`
+
+```go
+func categoryName(c TypeCategory) string
+```
+### `categoryOf`
+
+```go
+func categoryOf(ft parser.FieldType) TypeCategory
+```
+### `checkActionAttributes`
+
+```go
+func checkActionAttributes(app *parser.App) []Diagnostic
+```
+
+checkActionAttributes validates that action="/path" attributes on
+<button>, <a> and <input> elements reference an existing action block
+(or page route, for forms posting to a page). The regex is anchored to
+these tag names so native <form action="..."> never trips this check.
+
+### `checkActionParams`
+
+```go
+func checkActionParams(action parser.Page, modelName string, schema *Schema, context string) []Diagnostic
+```
+### `checkActionParamsNodes`
+
+```go
+func checkActionParamsNodes(nodes []parser.Node, path string, modelName string, schema *Schema, context string) []Diagnostic
+```
+### `checkAllSQL`
+
+```go
+func checkAllSQL(app *parser.App, schema *Schema) []Diagnostic
+```
+### `checkAuthPages`
+
+```go
+func checkAuthPages(app *parser.App) []Diagnostic
+```
+
+checkAuthPages ensures that an app declaring an `auth` block also
+declares the four auth entry pages. The runtime only owns the POST
+side of those routes; the GET side (form, error display, token
+validation UI) must live in user-declared pages so the app controls
+branding and i18n. Catching this at compile time prevents a runtime
+404 on an otherwise working-looking app.
+
+### `checkAuthRef`
+
+```go
+func checkAuthRef(app *parser.App, schema *Schema) []Diagnostic
+```
+### `checkAuthWithoutPermissions`
+
+```go
+func checkAuthWithoutPermissions(app *parser.App) []Diagnostic
+```
+
+checkAuthWithoutPermissions warns when auth is configured but no permissions are defined.
+
+### `checkCSRFProtection`
+
+```go
+func checkCSRFProtection(app *parser.App) []Diagnostic
+```
+
+checkCSRFProtection warns when a page has a raw HTML form targeting a
+mutating action instead of using the Kilnx form keyword (which auto-adds
+a CSRF token). Only pages whose path matches an action's path are checked.
+
+### `checkCustomFieldRefs`
+
+```go
+func checkCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic
+```
+
+checkCustomFieldRefs validates {q.custom.fieldName} template references
+against the corresponding model's custom field manifest.
+
+### `checkCustomManifestRefs`
+
+```go
+func checkCustomManifestRefs(app *parser.App) []Diagnostic
+```
+
+checkCustomManifestRefs validates that kind: reference targets in manifests refer to known models.
+
+### `checkDynamicFieldRefsWithDB`
+
+```go
+func checkDynamicFieldRefsWithDB(app *parser.App, db *database.DB) []Diagnostic
+```
+
+checkDynamicFieldRefsWithDB queries each _<model>_field_defs table and
+validates hardcoded {q.custom.X} references against the actual field names.
+
+### `checkFragmentComponents`
+
+```go
+func checkFragmentComponents(app *parser.App) []Diagnostic
+```
+
+checkFragmentComponents validates component fragment call sites in NodeHTML bodies.
+It checks that every {{name arg=expr}} references a known component, provides all
+required arguments, and does not pass unknown arguments.
+
+### `checkIndexes`
+
+```go
+func checkIndexes(app *parser.App) []Diagnostic
+```
+
+checkIndexes validates each `index (a, b, ...)` directive the same way
+as checkUniqueConstraints: declared field names exist on the model, no
+repeats within a group, no duplicated groups.
+
+### `checkInsertValueTypes`
+
+```go
+func checkInsertValueTypes(tokens []sqlToken, table string, schema *Schema, context string) []Diagnostic
+```
+
+checkInsertValueTypes validates that INSERT literal values match column types.
+
+### `checkModelDefaults`
+
+```go
+func checkModelDefaults(models []parser.Model) []Diagnostic
+```
+### `checkModelMinMax`
+
+```go
+func checkModelMinMax(models []parser.Model) []Diagnostic
+```
+### `checkModelRefs`
+
+```go
+func checkModelRefs(app *parser.App, schema *Schema) []Diagnostic
+```
+### `checkNamedParams`
+
+```go
+func checkNamedParams(sql string, tokens []sqlToken, path string, modelName string, schema *Schema, context string) []Diagnostic
+```
+### `checkNamedParamsExtra`
+
+```go
+func checkNamedParamsExtra(sql string, tokens []sqlToken, path string, modelName string, schema *Schema, context string, extra map[string]bool) []Diagnostic
+```
+### `checkNodesForPasswordExposure`
+
+```go
+func checkNodesForPasswordExposure(nodes []parser.Node, passwordTables map[string][]string, schema *Schema, context string) []Diagnostic
+```
+
+checkNodesForPasswordExposure checks if query nodes expose password columns.
+
+### `checkPasswordExposure`
+
+```go
+func checkPasswordExposure(app *parser.App, schema *Schema) []Diagnostic
+```
+
+checkPasswordExposure warns when queries in public-facing endpoints
+select password fields from the auth table.
+
+### `checkSQLCustomFieldRefs`
+
+```go
+func checkSQLCustomFieldRefs(app *parser.App, schema *Schema) []Diagnostic
+```
+
+checkSQLCustomFieldRefs validates json_extract(custom, '$.field') and
+custom->>'field' patterns in SQL query nodes against the custom field manifest.
+
+### `checkSecurity`
+
+```go
+func checkSecurity(app *parser.App, schema *Schema) []Diagnostic
+```
+
+checkSecurity performs security gap analysis on the app.
+It detects missing auth, exposed sensitive fields, unprotected webhooks,
+and other common security misconfigurations.
+
+### `checkSelectColumns`
+
+```go
+func checkSelectColumns(tokens []sqlToken, tableRefs []tableRef, aliasToTable map[string]string, schema *Schema, context string) []Diagnostic
+```
+### `checkTemplateInterpolations`
+
+```go
+func checkTemplateInterpolations(app *parser.App, schema *Schema) []Diagnostic
+```
+
+checkTemplateInterpolations validates {queryName.field}, {^field}, and bare {field}
+references inside HTML content of pages, fragments, and layouts against the schema.
+
+### `checkTenantRefs`
+
+```go
+func checkTenantRefs(app *parser.App, schema *Schema) []Diagnostic
+```
+
+checkTenantRefs makes sure every `tenant: <model>` directive points
+at an actual model in the app, and that a model does not set itself
+as its own tenant.
+
+### `checkTranslationParams`
+
+```go
+func checkTranslationParams(app *parser.App) []Diagnostic
+```
+
+checkTranslationParams validates that:
+1. Every {name} placeholder in a translation value is supplied at call sites
+2. Parameter placeholders are consistent across locales
+
+### `checkUnauthAPIs`
+
+```go
+func checkUnauthAPIs(app *parser.App) []Diagnostic
+```
+
+checkUnauthAPIs warns when API endpoints that write data don't require auth.
+
+### `checkUnauthActions`
+
+```go
+func checkUnauthActions(app *parser.App) []Diagnostic
+```
+
+checkUnauthActions warns when actions (POST/PUT/DELETE) don't require auth.
+
+### `checkUnauthSockets`
+
+```go
+func checkUnauthSockets(app *parser.App) []Diagnostic
+```
+
+checkUnauthSockets warns when sockets don't require auth.
+
+### `checkUnauthStreams`
+
+```go
+func checkUnauthStreams(app *parser.App) []Diagnostic
+```
+
+checkUnauthStreams warns when streams don't require auth.
+
+### `checkUniqueConstraints`
+
+```go
+func checkUniqueConstraints(app *parser.App) []Diagnostic
+```
+
+checkUniqueConstraints validates that every field named inside a
+`unique (a, b, ...)` directive exists on its model, that no field is
+repeated within a single group, and that no two groups are identical.
+
+### `checkUpdateSetTypes`
+
+```go
+func checkUpdateSetTypes(tokens []sqlToken, table string, schema *Schema, context string) []Diagnostic
+```
+
+checkUpdateSetTypes validates that UPDATE SET literal values match column types.
+
+### `checkWebhookSecrets`
+
+```go
+func checkWebhookSecrets(app *parser.App) []Diagnostic
+```
+
+checkWebhookSecrets warns when webhooks don't have a secret configured.
+
+### `checkWhereTypes`
+
+```go
+func checkWhereTypes(tokens []sqlToken, tableRefs []tableRef, aliasToTable map[string]string, schema *Schema, context string) []Diagnostic
+```
+
+checkWhereTypes validates type compatibility in WHERE clause comparisons.
+
+### `countEachEnclosing`
+
+```go
+func countEachEnclosing(pos int, blocks []eachBlock) []string
+```
+
+countEachEnclosing returns the names of {{each}} blocks that enclose the given position.
+
+### `customKindToFieldType`
+
+```go
+func customKindToFieldType(kind parser.CustomFieldKind) parser.FieldType
+```
+
+customKindToFieldType maps a manifest field kind to a parser FieldType for schema purposes.
+
+### `editDistance`
+
+```go
+func editDistance(a, b string) int
+```
+### `extractInsertColumns`
+
+```go
+func extractInsertColumns(tokens []sqlToken) (string, []string)
+```
+### `extractNamedParams`
+
+```go
+func extractNamedParams(tokens []sqlToken) []string
+```
+### `extractSelectAliases`
+
+```go
+func extractSelectAliases(tokens []sqlToken) map[string]bool
+```
+
+checkTableColumnRefs validates that columns declared in table components
+exist in the model referenced by the table's query.
+extractSelectAliases returns the set of AS aliases defined in a SELECT query.
+For example, "SELECT count(*) as total, c.name as contact FROM ..." returns {"total", "contact"}.
+
+### `extractSelectColumns`
+
+```go
+func extractSelectColumns(tokens []sqlToken) []columnRef
+```
+### `extractSubqueries`
+
+```go
+func extractSubqueries(tokens []sqlToken) []string
+```
+
+extractSubqueries finds inner SELECT statements inside WHERE ... IN (SELECT ...) clauses
+and returns them as raw SQL strings for independent validation.
+
+### `extractTableRefs`
+
+```go
+func extractTableRefs(tokens []sqlToken) []tableRef
+```
+### `extractURLParams`
+
+```go
+func extractURLParams(path string) map[string]bool
+```
+### `extractUpdateColumns`
+
+```go
+func extractUpdateColumns(tokens []sqlToken) (string, []string)
+```
+### `extractWhereComparisons`
+
+```go
+func extractWhereComparisons(tokens []sqlToken) []sqlComparison
+```
+
+extractWhereComparisons extracts simple col op value comparisons from WHERE clauses.
+
+### `findActionModel`
+
+```go
+func findActionModel(action parser.Page, app *parser.App) string
+```
+### `findClosestMatch`
+
+```go
+func findClosestMatch(target string, candidates map[string]bool) string
+```
+### `findEachBlocks`
+
+```go
+func findEachBlocks(text string) []eachBlock
+```
+
+findEachBlocks returns all {{each}} blocks in the given text, including nested ones.
+
+### `findMatchingEnd`
+
+```go
+func findMatchingEnd(content string) (body, elseBody string, endPos int)
+```
+
+checkTemplateInterpolations validates {queryName.field} references inside
+HTML content of pages, fragments, and layouts against the schema.
+findMatchingEnd finds the body, else body, and position after {{end}} for a block,
+accounting for nested {{each}}/{{if}} blocks.
+
+### `hasMutatingSQL`
+
+```go
+func hasMutatingSQL(nodes []parser.Node) bool
+```
+
+hasMutatingSQL checks if any nodes contain INSERT, UPDATE, or DELETE queries.
+
+### `hasRawHTMLForm`
+
+```go
+func hasRawHTMLForm(nodes []parser.Node) bool
+```
+
+hasRawHTMLForm checks if any NodeHTML in the tree contains a <form tag.
+
+### `inferTokenType`
+
+```go
+func inferTokenType(tok sqlToken, tableName string, aliasToTable map[string]string, schema *Schema) *ExprType
+```
+
+inferTokenType determines the type category of a SQL token based on schema.
+
+### `isClauseKeyword`
+
+```go
+func isClauseKeyword(s string) bool
+```
+### `isDBDynamic`
+
+```go
+func isDBDynamic(app *parser.App, modelName string) bool
+```
+
+isDBDynamic reports whether a model opts into DB-backed runtime field definitions.
+
+### `isDynamicManifest`
+
+```go
+func isDynamicManifest(app *parser.App, modelName string) bool
+```
+
+isDynamicManifest reports whether a model uses a dynamic manifest path or dynamic DB fields.
+
+### `populateSourceModels`
+
+```go
+func populateSourceModels(app *parser.App)
+```
+
+populateSourceModels sets Node.SourceModel on all query nodes by extracting
+the primary table name from each query's SQL FROM clause.
+
+### `queryModelMap`
+
+```go
+func queryModelMap(pages []parser.Page, fragments []parser.Page, apis []parser.Page) map[string]string
+```
+
+queryModelMap builds a mapping from query name to the primary table (model)
+referenced in that query's SQL, by scanning all nodes in the given slices.
+
+### `splitArgStr`
+
+```go
+func splitArgStr(s string) []string
+```
+
+splitArgStr tokenizes a fragment call argument string into space-separated
+tokens, respecting single and double quoted substrings. Whitespace inside
+quotes is preserved within the token (e.g. title="Hello World").
+
+Duplicated in internal/runtime/render.go to keep the analyzer free of
+runtime imports; they share the same semantics.
+
+### `tokenizeSQL`
+
+```go
+func tokenizeSQL(sql string) []sqlToken
+```
+### `typesCompatible`
+
+```go
+func typesCompatible(a, b TypeCategory) bool
+```
+
+typesCompatible checks if two type categories can be compared.
+Bool is compatible with numeric because SQLite stores bools as INTEGER.
+
+### `validateMinMax`
+
+```go
+func validateMinMax(val string, ft parser.FieldType) error
+```
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# Package `internal/analyzer`
+
+Source: [analyzer.go](../../../internal/analyzer/analyzer.go), [db_check.go](../../../internal/analyzer/db_check.go), [security.go](../../../internal/analyzer/security.go), [types.go](../../../internal/analyzer/types.go), [doc.go](../../../internal/analyzer/doc.go).
+
+## Purpose
+
+Run static analysis on the parser AST: type checking of field constraints, validation of route templates, permission and role checks, dead link detection, SQL coherence against declared models, and a security audit (CSRF, password exposure, missing auth on mutating endpoints). The analyzer powers `kilnx check` and is also called as part of `kilnx run` and `kilnx build`.
+
+## Pipeline position
+
+```
+parser.App -> analyzer.Analyze -> []Diagnostic -> CLI/CI
+              optionally analyzer.AnalyzeWithDB(app, db) for live DB checks
+```
+
+The analyzer runs after parsing and before the optimizer or runtime. It does not mutate the AST except to populate `Node.SourceModel` via `populateSourceModels`, which the optimizer and runtime consult.
+
+## Public API
+
+```go
+type Diagnostic struct {
+    Level   string // "error" or "warning"
+    Message string
+    Line    int    // source line, 0 if unknown
+    Context string // e.g. "page /users"
+}
+
+type TableInfo struct {
+    Name    string
+    Columns map[string]*ColumnInfo
+}
+
+type ColumnInfo struct {
+    FieldType parser.FieldType
+}
+
+type ModelFieldInfo struct {
+    FormFields    map[string]bool
+    FieldToColumn map[string]string
+    ColumnToField map[string]string
+}
+
+type Schema struct {
+    Tables      map[string]*TableInfo
+    ModelFields map[string]*ModelFieldInfo
+}
+
+func Analyze(app *parser.App) []Diagnostic
+func AnalyzeWithDB(app *parser.App, db *database.DB) []Diagnostic
+func BuildSchema(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) *Schema
+```
+
+`Diagnostic.Level` is a string, not an enum: it is either `"error"` or `"warning"`. Callers filter on the literal.
+
+`Analyze` runs every check unconditionally and returns all findings concatenated. `AnalyzeWithDB` runs the same checks then, if `db` is not nil, adds `checkDynamicFieldRefsWithDB`, which queries each `_<model>_field_defs` table to validate hardcoded `{q.custom.X}` template references against the live runtime field definitions.
+
+`BuildSchema` constructs the compile time view of the database from declared models. It synthesises an `id` column, rewrites `reference` fields to their `<name>_id` columns, and (when manifests are passed) materialises column mode custom fields as real columns.
+
+## Sub checks
+
+Dispatched in order from `Analyze`:
+
+- **Model defaults and ranges**: `checkModelDefaults`, `checkModelMinMax` validate `default`, `min`, `max` literals against the declared field type.
+- **Auth references**: `checkAuthRef`, `checkAuthPages` verify the `auth` block points at a real model and that `login`, `register`, and similar paths are reachable.
+- **Model and tenant references**: `checkModelRefs`, `checkTenantRefs` ensure `reference` fields and `tenant: model` directives resolve.
+- **Constraint coherence**: `checkUniqueConstraints`, `checkIndexes` validate column groups against model fields.
+- **SQL analysis**: `checkAllSQL` walks every `NodeQuery` body, tokenises the SQL via `tokenizeSQL`, extracts table refs, named params, INSERT and UPDATE column lists, and flags unknown tables, unknown columns, missing parameters, and incompatible WHERE comparisons (`checkWhereTypes`, `checkInsertValueTypes`, `checkUpdateSetTypes`).
+- **Template interpolation**: `checkTemplateInterpolations` resolves `{q.field}` and `{^field}` references inside HTML and text bodies against the SELECT alias set, including `{{each}}` enclosure depth tracking.
+- **Custom fields**: `checkCustomFieldRefs`, `checkSQLCustomFieldRefs`, `checkCustomManifestRefs` validate manifest backed and dynamic field references.
+- **Fragment components**: `checkFragmentComponents` validates component invocations and required argument coverage.
+- **Translations**: `checkTranslationParams` cross checks `{tr key}` calls.
+- **Action attributes**: `checkActionAttributes` flags unsupported attribute combinations.
+- **Security** (in [security.go](../../../internal/analyzer/security.go)): `checkUnauthActions`, `checkUnauthAPIs`, `checkUnauthStreams`, `checkUnauthSockets`, `checkWebhookSecrets`, `checkPasswordExposure`, `checkAuthWithoutPermissions`, `checkCSRFProtection`. Mutating endpoints without `requires` raise warnings; password columns leaking into SELECT lists raise errors; raw HTML forms posting to actions without CSRF tokens are flagged.
+- **DB coherence** (in [db_check.go](../../../internal/analyzer/db_check.go)): `AnalyzeWithDB` adds `checkDynamicFieldRefsWithDB`, which compares hardcoded `{q.custom.X}` to the actual `_<model>_field_defs` rows.
+
+## File map
+
+- [`analyzer.go`](../../../internal/analyzer/analyzer.go): `Analyze`, schema construction, model and SQL checks, fragment and translation checks, SQL tokeniser, named param extraction.
+- [`types.go`](../../../internal/analyzer/types.go): `ColumnInfo`, `TypeCategory`, default/min/max validators, WHERE/INSERT/UPDATE type checks, `{{each}}` aware template interpolation checker, custom field reference checks.
+- [`security.go`](../../../internal/analyzer/security.go): all `checkUnauth*`, `checkWebhookSecrets`, `checkPasswordExposure`, `checkAuthWithoutPermissions`, `checkCSRFProtection`, mutating SQL detection.
+- [`db_check.go`](../../../internal/analyzer/db_check.go): `AnalyzeWithDB` plus DB backed `_field_defs` validation.
+- [`doc.go`](../../../internal/analyzer/doc.go): package doc.
+- Test files (`analyzer_test.go`, `security_test.go`, `action_attribute_test.go`, `fragment_component_test.go`, `translation_params_test.go`, `bench_test.go`) cover the corresponding checks.
+
+## Key behaviors and gotchas
+
+**Severity is by string literal.** `"error"` blocks `kilnx run` and `kilnx build`; `"warning"` is informational only. There is no separate `Info` level.
+
+**Schema is a compile time projection, not the live DB.** `BuildSchema` does not connect to the database. It is built solely from `parser.Model`. This is why dynamic field validation against `_field_defs` rows requires `AnalyzeWithDB` plus a `*database.DB` handle.
+
+**Reference fields surface twice.** A `reference` field named `author` produces both an `author` form field (mapped via `ModelFieldInfo`) and an `author_id` column (in `TableInfo`). SQL checks see the `_id` column; form and template checks see the bare name. Mismatches between the two are a frequent source of analyzer findings.
+
+**Tenant columns are synthesised.** A model with `tenant: org` is not a parse error if it omits an `org_id` field: `BuildSchema` and the runtime add it. The analyzer accepts `WHERE org_id = :org_id` style queries against such tables.
+
+**SQL tokeniser is hand rolled.** `tokenizeSQL` in [analyzer.go](../../../internal/analyzer/analyzer.go) understands strings, identifiers, numbers, named params (`:name`), and SQL operators. It is approximate: extremely exotic SQL may parse incorrectly. When that happens the relevant check usually returns no diagnostic rather than a false positive.
+
+**Interpolation analysis is `{{each}}` aware.** `findEachBlocks` and `countEachEnclosing` (in [types.go](../../../internal/analyzer/types.go)) build the same enclosure model the optimizer uses for `{^field}` resolution. Modifying one side requires keeping the other in step.
+
+**`populateSourceModels` mutates the AST.** It sets `Node.SourceModel` on every `NodeQuery` so the analyzer (and downstream optimizer and runtime) can answer "which model owns this query" without re-parsing the SQL. This is the only side effect `Analyze` produces on the AST.
+
+**Custom manifest checks tolerate absence.** `checkCustomManifestRefs` short circuits when `app.CustomManifests` is empty, so models without `*_fields.kilnx` files do not generate spurious findings.
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/packages/build.md
+++ b/docs/contributors/packages/build.md
@@ -1,0 +1,125 @@
+# `internal/build`
+
+> Package build compiles a .kilnx source file into a standalone Go binary by emitting Go source that embeds the AST and a minimal runtime, then invoking `go build`.
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/build` |
+| **Source last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `5da8498` (2026-05-08) |
+
+
+## Overview
+
+Used by the `kilnx build` CLI command. Build output is a self-contained
+executable: no kilnx CLI is required at runtime, only the resulting
+binary. The build process writes a temporary Go module under a build
+directory, copies in the embedded runtime, and shells out to the host
+Go toolchain.
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`build.go`](../../../internal/build/build.go) | _no file-level doc_ |
+
+## Functions
+
+### `Build`
+
+```go
+func Build(kilnxFile, outputPath string) error
+```
+
+Build compiles a .kilnx file into a standalone binary.
+It creates a temporary main.go inside the kilnx source tree
+(cmd/_build/) that embeds the .kilnx source, then compiles it.
+Requires the kilnx source tree to be present (development, CI, or Docker).
+
+### `findKilnxRoot`
+
+```go
+func findKilnxRoot() string
+```
+### `generateMainGo`
+
+```go
+func generateMainGo(source string) string
+```
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# `internal/build`
+
+Compiles a `.kilnx` source file into a single standalone Go binary. Single-file package.
+
+## Purpose
+
+`kilnx build app.kilnx -o myapp` shells out to the Go toolchain. The resulting binary embeds the original `.kilnx` source as a string constant, parses and serves it at runtime, and has no dependency on the `kilnx` CLI itself. This is how Kilnx apps deploy to PaaS targets like Railway, Fly.io, Render, Cloud Run.
+
+## File map
+
+- [`build.go`](../../../internal/build/build.go): everything. Public `Build` function, `generateMainGo` template, `findKilnxRoot` lookup.
+- [`doc.go`](../../../internal/build/doc.go): package doc comment.
+
+## Public surface
+
+```go
+func Build(kilnxFile, outputPath string) error
+```
+
+Reads `kilnxFile`, derives `outputPath` from the filename if empty (stripping the extension), generates a `main.go` that embeds the source, and runs `go build` to produce the binary.
+
+## How it works
+
+1. **Locate the kilnx source tree**: `findKilnxRoot` walks up from both the executable path and the current working directory looking for a `go.mod` whose module path contains `kilnx-org/kilnx`. The build needs the runtime's Go source to be reachable on disk because it links against it. Returns `""` when nothing is found, in which case `Build` errors with a hint to run inside the kilnx repo or use Docker.
+
+2. **Stage a temporary main package**: creates `<kilnxRoot>/cmd/_build/` (mode `0o750`), writes a synthesized `main.go` (mode `0o600`) into it. The directory is removed via `defer os.RemoveAll`.
+
+3. **Embed the .kilnx source**: `generateMainGo` returns a Go source string containing a `const embeddedSource = ` raw-string literal. Backticks in the source are escaped via `` `+ "`" + ` `` concatenation so the raw literal stays valid.
+
+4. **Compile**: runs `go build -o <absOutput> ./cmd/_build/` with `cmd.Dir = kilnxRoot` and `CGO_ENABLED=0` appended to the environment. Stdout and stderr stream straight through, so the user sees Go compiler errors verbatim.
+
+5. **Report size**: stats the resulting file and prints `Built: <path> (<MB>)`.
+
+## What the embedded `main.go` does at runtime
+
+The generated entrypoint pipelines the same boot sequence as `kilnx run`, just against an in-memory source string:
+
+1. `lexer.StripComments` → `lexer.Tokenize` → `parser.Parse`.
+2. `analyzer.Analyze`. Errors print to stderr and abort, warnings print and continue.
+3. `optimizer.Optimize`.
+4. Resolve port: `app.Config.Port`, then `PORT` env var (PaaS convention; rejected if non-numeric or out of range), then `--port` flag.
+5. Resolve database URL: `app.Config.Database`, then `--db` flag. Defaults to `app.db`.
+6. `database.Open`, `db.MigrateInternal` (sessions, jobs, etc.), `db.Migrate(app.Models, app.CustomManifests)`.
+7. `runtime.NewServer`, `srv.StartScheduler`, `srv.StartJobQueue`, `srv.Start`.
+
+The PORT handling is intentional: PaaS platforms inject `PORT`, so the binary respects it without flags.
+
+## Build-dir layout
+
+```
+<kilnxRoot>/
+  cmd/
+    _build/             <- created and removed by Build
+      main.go           <- synthesized, embeds .kilnx source
+```
+
+The `_build` name (with leading underscore) is a Go convention for a directory the toolchain treats as part of a parent module but that build tools or test helpers can recognise as transient. `defer os.RemoveAll(buildDir)` runs even when `go build` fails.
+
+## Gotchas
+
+- **Requires the kilnx source tree on disk**. There is no precompiled runtime archive. Distributing `kilnx build` to users who don't have the repo means shipping the repo too, or going through Docker. The error message points to a `Dockerfile` flow.
+- **Concurrent builds collide**. Two `Build` calls running at the same time both write to `cmd/_build/main.go` and both try to remove the directory on exit. The function is not goroutine-safe across processes either. Serialize at the caller.
+- **Module path check is substring-based**: `findKilnxRoot` matches any `go.mod` containing `kilnx-org/kilnx`. A fork with that string in a comment would also match.
+- **CGO disabled**. The produced binary is statically linked. SQLite goes through `modernc.org/sqlite` (pure Go), Postgres through `pgx`. No OS-level deps.
+- **Backtick escaping is naive but correct**: each `` ` `` in the source becomes `` `+ "`" + ` ``. There is no other transformation, so any other Go-string-breaking sequence inside the `.kilnx` file is irrelevant; only backticks matter inside a raw string literal.
+- **Output path**: when `outputPath` is empty, the binary is named after the `.kilnx` file with the extension stripped. The path is then resolved with `filepath.Abs` before being passed to `go build`, so relative outputs land where the user invoked `kilnx build`, not inside `kilnxRoot`.
+
+## When to touch this file
+
+- Adjusting the boot sequence baked into the binary (new flag, new init step) means editing `generateMainGo`.
+- Changing how the runtime is located means editing `findKilnxRoot`.
+- Changing the emitted binary's behavior in any way that the runtime can't infer from the AST goes here, because the analyzer and optimizer otherwise see the same input as `kilnx run`.
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/packages/database.md
+++ b/docs/contributors/packages/database.md
@@ -1,0 +1,913 @@
+# `internal/database`
+
+> Package database provides the persistence layer for the Kilnx runtime: connection management, schema migration, and dialect-aware query execution against SQLite or PostgreSQL.
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/database` |
+| **Source last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `5da8498` (2026-05-08) |
+
+
+## Overview
+
+The package is organized around three concerns:
+
+  - Driver (driver.go, driver_postgres.go): opens connections from a
+    DATABASE_URL and exposes a *sql.DB.
+  - Dialect (dialect.go, dialect_sqlite.go, dialect_postgres.go):
+    emits dialect-specific SQL for CREATE TABLE, ALTER, parameter
+    binding, and identifier quoting.
+  - Migration (database.go): derives the target schema from the
+    parser AST, diffs it against the live schema, and applies the
+    necessary CREATE/ALTER statements transactionally. Migration
+    history is recorded in a kilnx-managed metadata table.
+
+Query execution helpers live in query.go. Public types in
+interfaces.go define what the runtime depends on so tests can
+substitute fakes.
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`database.go`](../../../internal/database/database.go) | _no file-level doc_ |
+| [`dialect.go`](../../../internal/database/dialect.go) | _no file-level doc_ |
+| [`dialect_postgres.go`](../../../internal/database/dialect_postgres.go) | _no file-level doc_ |
+| [`dialect_sqlite.go`](../../../internal/database/dialect_sqlite.go) | _no file-level doc_ |
+| [`driver.go`](../../../internal/database/driver.go) | _no file-level doc_ |
+| [`driver_postgres.go`](../../../internal/database/driver_postgres.go) | _no file-level doc_ |
+| [`interfaces.go`](../../../internal/database/interfaces.go) | _no file-level doc_ |
+| [`query.go`](../../../internal/database/query.go) | _no file-level doc_ |
+
+## Types
+
+### `DB`
+
+```go
+type DB struct {
+	conn		*sql.DB
+	dialect		Dialect
+	OnSlowQuery	func(sql string, d time.Duration)	// optional callback for slow query logging
+}
+```
+
+DB is a thin wrapper around *sql.DB that selects between SQLite and Postgres
+at runtime via a Dialect. It also exposes named-parameter execution helpers
+and an optional slow-query callback.
+
+### `DataLossRisk`
+
+```go
+type DataLossRisk struct {
+	TableName	string
+	RowCount	int
+	Suggestion	string	// human-readable hint, e.g. an ALTER TABLE RENAME statement
+}
+```
+
+DataLossRisk describes a table in the database that is no longer represented
+by any model in the current schema. If it contains rows, the migration may
+leave data behind.
+
+### `Dialect`
+
+```go
+type Dialect interface {
+	// DriverName returns the Go sql.Open driver name (e.g. "sqlite", "pgx").
+	DriverName() string
+
+	// DSN transforms a user-provided URL into a driver-specific DSN.
+	// For SQLite: strips "sqlite://" prefix.
+	// For PostgreSQL: passes through as-is.
+	DSN(url string) string
+
+	// InitStatements returns SQL statements to run immediately after connecting.
+	// SQLite: PRAGMA journal_mode=WAL, PRAGMA foreign_keys=ON.
+	// PostgreSQL: (none needed).
+	InitStatements() []string
+
+	// Placeholder returns the parameter placeholder for the given 1-based index.
+	// SQLite: always "?".
+	// PostgreSQL: "$1", "$2", etc.
+	Placeholder(index int) string
+
+	// TableExistsSQL returns a query that yields a count > 0 if the table exists.
+	// The single ? / $1 parameter is the table name.
+	TableExistsSQL() string
+
+	// ListTablesSQL returns a query that yields (name TEXT) rows for all user
+	// tables in the database. Internal tables (starting with _kilnx_ and
+	// _<model>_field_defs) must be excluded by the query itself.
+	ListTablesSQL() string
+
+	// ColumnsSQL returns a query that yields (column_name TEXT) rows for a table.
+	// Receives the table name as a literal (not a parameter) for PRAGMA compat.
+	ColumnsSQL(table string) string
+
+	// AutoIncrementPK returns the PRIMARY KEY column definition for an
+	// auto-incrementing integer id.
+	// SQLite: "id INTEGER PRIMARY KEY AUTOINCREMENT"
+	// PostgreSQL: "id BIGSERIAL PRIMARY KEY"
+	AutoIncrementPK() string
+
+	// FieldToSQLType maps a Kilnx field type to a SQL column type.
+	FieldToSQLType(f parser.Field) string
+
+	// FieldToDefault returns the DEFAULT clause for a field.
+	FieldToDefault(f parser.Field) string
+
+	// BoolTrue returns the SQL literal for true (1 for SQLite, TRUE for PG).
+	BoolTrue() string
+
+	// BoolFalse returns the SQL literal for false (0 for SQLite, FALSE for PG).
+	BoolFalse() string
+
+	// InternalTableDDL returns CREATE TABLE IF NOT EXISTS statements
+	// for Kilnx internal tables (sessions, password_resets, migrations, jobs).
+	InternalTableDDL() []string
+
+	// AutoUpdateTriggerDDL returns statements that create a trigger to
+	// automatically update the given field to the current timestamp on UPDATE.
+	AutoUpdateTriggerDDL(table, field string) []string
+}
+```
+
+Dialect abstracts database-specific SQL generation and introspection.
+Each supported database (SQLite, PostgreSQL) implements this interface.
+
+### `Executor`
+
+```go
+type Executor interface {
+	QueryRows(sqlStr string) ([]Row, error)
+	QueryRowsWithParams(sqlStr string, params map[string]string) ([]Row, error)
+	ExecWithParams(sqlStr string, params map[string]string) error
+	BeginTxHandle() (*TxHandle, error)
+	Dialect() Dialect
+}
+```
+
+Executor is the interface used by the runtime to execute SQL.
+It allows the runtime to work with a real database or a test fake.
+
+### `MigrationRecord`
+
+```go
+type MigrationRecord struct {
+	ID		int
+	SchemaHash	string
+	Statements	string
+	AppliedAt	string
+}
+```
+
+MigrationRecord represents a recorded migration entry
+
+### `PostgresDialect`
+
+```go
+type PostgresDialect struct{}
+```
+
+PostgresDialect implements Dialect for PostgreSQL via pgx.
+
+### `Row`
+
+```go
+type Row map[string]string
+```
+
+Row is a single result row as a map of column name to string value.
+All values are stringified via fmt for uniform consumption by the runtime;
+NULL columns become "".
+
+### `SqliteDialect`
+
+```go
+type SqliteDialect struct{}
+```
+
+SqliteDialect implements Dialect for SQLite via modernc.org/sqlite.
+
+### `TxHandle`
+
+```go
+type TxHandle struct {
+	tx		*sql.Tx
+	dialect		Dialect
+	committed	bool
+}
+```
+
+TxHandle wraps a *sql.Tx with named-parameter execution and idempotent
+commit/rollback. It is created by [DB.BeginTxHandle].
+
+### `querier`
+
+```go
+type querier interface {
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+}
+```
+
+querier abstracts *sql.DB and *sql.Tx for shared query logic
+
+## Functions
+
+### `DetectDialect`
+
+```go
+func DetectDialect(url string) Dialect
+```
+
+DetectDialect returns the appropriate Dialect for a database URL.
+URLs starting with "postgres://" or "postgresql://" use PostgreSQL.
+Everything else defaults to SQLite.
+
+### `ExecWithParamsTx`
+
+```go
+func ExecWithParamsTx(tx *sql.Tx, dialect Dialect, sqlStr string, params map[string]string) error
+```
+
+ExecWithParamsTx executes a mutation within a transaction
+
+### `IsValidIdentifier`
+
+```go
+func IsValidIdentifier(name string) bool
+```
+
+IsValidIdentifier reports whether name is a safe SQL identifier.
+
+### `Open`
+
+```go
+func Open(url string) (*DB, error)
+```
+
+Open connects to the database identified by url.
+The driver is auto-detected from the URL scheme:
+  - postgres://... or postgresql://... -> PostgreSQL (pgx)
+  - sqlite://... or file:... or bare path -> SQLite
+
+### `QueryRowsWithParamsTx`
+
+```go
+func QueryRowsWithParamsTx(tx *sql.Tx, dialect Dialect, sqlStr string, params map[string]string) ([]Row, error)
+```
+
+QueryRowsWithParamsTx executes a SELECT within a transaction
+
+### `RewriteCustomFieldShorthand`
+
+```go
+func RewriteCustomFieldShorthand(sqlStr string, isPostgres bool) string
+```
+
+RewriteCustomFieldShorthand rewrites the "custom.fieldName" shorthand to the
+dialect-appropriate JSON extraction syntax. Only call for models with custom fields.
+SQLite: custom.field -> json_extract("custom", '$.field')
+PostgreSQL: custom.field -> "custom"->>'field'
+
+### `bindParams`
+
+```go
+func bindParams(dialect Dialect, sqlStr string, params map[string]string) (string, []interface{})
+```
+### `customKindToSQL`
+
+```go
+func customKindToSQL(kind parser.CustomFieldKind, isPostgres bool) string
+```
+
+customKindToSQL maps a manifest field kind to a SQL column type.
+
+### `fieldDefsTableDDL`
+
+```go
+func fieldDefsTableDDL(modelName string, isPostgres bool) string
+```
+
+fieldDefsTableDDL returns the CREATE TABLE IF NOT EXISTS for _<model>_field_defs.
+
+### `fieldToColumnName`
+
+```go
+func fieldToColumnName(f parser.Field) string
+```
+### `indexDDLs`
+
+```go
+func indexDDLs(model parser.Model) []string
+```
+
+indexDDLs emits `CREATE INDEX IF NOT EXISTS` statements for each
+non-unique `index (...)` group declared on the model. Index names
+are prefixed with `ix_` to stay distinguishable from composite
+UNIQUE indexes (`uq_`). Groups referencing unknown fields are
+skipped; the analyzer surfaces the error.
+
+### `isValidIdentifier`
+
+```go
+func isValidIdentifier(name string) bool
+```
+### `queryRowsInternal`
+
+```go
+func queryRowsInternal(q querier, query string, args ...interface{}) ([]Row, error)
+```
+### `scanRows`
+
+```go
+func scanRows(rows *sql.Rows) ([]Row, error)
+```
+### `schemaHash`
+
+```go
+func schemaHash(models []parser.Model) string
+```
+### `uniqueIndexDDLs`
+
+```go
+func uniqueIndexDDLs(model parser.Model) []string
+```
+
+uniqueIndexDDLs emits `CREATE UNIQUE INDEX IF NOT EXISTS` statements for
+each composite UNIQUE group declared on the model. Field names are
+resolved to their DB column names via fieldToColumnName (so references
+map to their `<name>_id` columns). Groups that reference unknown fields
+are skipped, the analyzer surfaces the error.
+
+### `(DB) BeginTxHandle`
+
+```go
+func (db *DB) BeginTxHandle() (*TxHandle, error)
+```
+
+BeginTxHandle starts a new transaction wrapped in a TxHandle
+
+### `(DB) Close`
+
+```go
+func (db *DB) Close() error
+```
+
+Close closes the underlying *sql.DB connection pool.
+
+### `(DB) Conn`
+
+```go
+func (db *DB) Conn() *sql.DB
+```
+
+Conn returns the underlying *sql.DB for callers that need direct access
+(e.g. to start raw transactions or run driver-specific queries).
+
+### `(DB) DetectDataLossRisk`
+
+```go
+func (db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error)
+```
+
+DetectDataLossRisk inspects the database for tables that do not correspond
+to any model in the provided slice and contain data. It returns a slice of
+risks and any error encountered during introspection.
+
+### `(DB) Dialect`
+
+```go
+func (db *DB) Dialect() Dialect
+```
+
+Dialect returns the dialect used by this database connection.
+
+### `(DB) ExecWithParams`
+
+```go
+func (db *DB) ExecWithParams(sqlStr string, params map[string]string) error
+```
+
+ExecWithParams executes a SQL statement with named parameters from a map.
+Named params like :name, :email are replaced with dialect-specific placeholders.
+
+### `(DB) Migrate`
+
+```go
+func (db *DB) Migrate(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]string, error)
+```
+
+Migrate compares models with the current database state and applies changes.
+Pass a CustomManifests map as the optional second argument to include
+column-mode custom field columns.
+
+### `(DB) MigrateInternal`
+
+```go
+func (db *DB) MigrateInternal() error
+```
+
+MigrateInternal creates internal kilnx tables for sessions and jobs
+
+### `(DB) MigrationHistory`
+
+```go
+func (db *DB) MigrationHistory() ([]MigrationRecord, error)
+```
+
+MigrationHistory returns all recorded migrations
+
+### `(DB) PlanMigration`
+
+```go
+func (db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]string, error)
+```
+
+PlanMigration compares models with the current database state and returns
+the SQL statements that would be executed, without applying them.
+Pass a CustomManifests map as the optional second argument to include
+column-mode custom field columns in the plan.
+
+### `(DB) QueryRows`
+
+```go
+func (db *DB) QueryRows(sqlStr string) ([]Row, error)
+```
+
+QueryRows executes a SELECT query and returns all rows as maps
+
+### `(DB) QueryRowsWithParams`
+
+```go
+func (db *DB) QueryRowsWithParams(sqlStr string, params map[string]string) ([]Row, error)
+```
+
+QueryRowsWithParams executes a SELECT with named params
+
+### `(DB) fieldToColumnDef`
+
+```go
+func (db *DB) fieldToColumnDef(f parser.Field) string
+```
+### `(DB) generateCreateTable`
+
+```go
+func (db *DB) generateCreateTable(model parser.Model, cm map[string]*parser.CustomFieldManifest) string
+```
+### `(DB) getColumns`
+
+```go
+func (db *DB) getColumns(table string) (map[string]bool, error)
+```
+### `(DB) planExistingTable`
+
+```go
+func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.CustomFieldManifest) ([]string, error)
+```
+### `(DB) recordMigration`
+
+```go
+func (db *DB) recordMigration(hash, stmts string)
+```
+### `(DB) tableExists`
+
+```go
+func (db *DB) tableExists(name string) (bool, error)
+```
+### `(PostgresDialect) AutoIncrementPK`
+
+```go
+func (PostgresDialect) AutoIncrementPK() string
+```
+
+AutoIncrementPK returns the PostgreSQL BIGSERIAL primary key definition.
+
+### `(PostgresDialect) AutoUpdateTriggerDDL`
+
+```go
+func (PostgresDialect) AutoUpdateTriggerDDL(table, field string) []string
+```
+
+AutoUpdateTriggerDDL returns a CREATE FUNCTION + CREATE TRIGGER pair that sets
+the given field to NOW() before each UPDATE on the given table.
+
+### `(PostgresDialect) BoolFalse`
+
+```go
+func (PostgresDialect) BoolFalse() string
+```
+
+BoolFalse returns the SQL literal "FALSE".
+
+### `(PostgresDialect) BoolTrue`
+
+```go
+func (PostgresDialect) BoolTrue() string
+```
+
+BoolTrue returns the SQL literal "TRUE".
+
+### `(PostgresDialect) ColumnsSQL`
+
+```go
+func (PostgresDialect) ColumnsSQL(table string) string
+```
+
+ColumnsSQL returns a query for the column names of the given public-schema
+table, ordered by ordinal position. The table name is interpolated literally,
+so callers must validate it.
+
+### `(PostgresDialect) DSN`
+
+```go
+func (PostgresDialect) DSN(url string) string
+```
+
+DSN passes the URL through unchanged; pgx accepts postgres:// URLs directly.
+
+### `(PostgresDialect) DriverName`
+
+```go
+func (PostgresDialect) DriverName() string
+```
+
+DriverName returns "pgx".
+
+### `(PostgresDialect) FieldToDefault`
+
+```go
+func (d PostgresDialect) FieldToDefault(f parser.Field) string
+```
+
+FieldToDefault returns a " DEFAULT ..." clause for the field, or "" if none.
+Auto fields use NOW(), CURRENT_DATE, gen_random_uuid(), or FALSE depending on type.
+
+### `(PostgresDialect) FieldToSQLType`
+
+```go
+func (d PostgresDialect) FieldToSQLType(f parser.Field) string
+```
+
+FieldToSQLType maps a parser.Field type to a PostgreSQL column type.
+
+### `(PostgresDialect) InitStatements`
+
+```go
+func (PostgresDialect) InitStatements() []string
+```
+
+InitStatements returns nil; PostgreSQL needs no per-connection setup.
+
+### `(PostgresDialect) InternalTableDDL`
+
+```go
+func (PostgresDialect) InternalTableDDL() []string
+```
+
+InternalTableDDL returns the CREATE TABLE IF NOT EXISTS statements for
+kilnx-managed tables (sessions, password resets, migrations, jobs, flags,
+rate limits) using PostgreSQL types.
+
+### `(PostgresDialect) ListTablesSQL`
+
+```go
+func (PostgresDialect) ListTablesSQL() string
+```
+
+ListTablesSQL returns a query for user tables in the public schema,
+excluding kilnx-internal tables.
+
+### `(PostgresDialect) Placeholder`
+
+```go
+func (PostgresDialect) Placeholder(index int) string
+```
+
+Placeholder returns "$N" for the given 1-based index.
+
+### `(PostgresDialect) TableExistsSQL`
+
+```go
+func (PostgresDialect) TableExistsSQL() string
+```
+
+TableExistsSQL returns a query that counts matching rows in
+information_schema.tables for the public schema.
+
+### `(SqliteDialect) AutoIncrementPK`
+
+```go
+func (SqliteDialect) AutoIncrementPK() string
+```
+
+AutoIncrementPK returns the SQLite INTEGER PRIMARY KEY AUTOINCREMENT
+definition.
+
+### `(SqliteDialect) AutoUpdateTriggerDDL`
+
+```go
+func (SqliteDialect) AutoUpdateTriggerDDL(table, field string) []string
+```
+
+AutoUpdateTriggerDDL returns a CREATE TRIGGER IF NOT EXISTS statement that
+updates the given field to CURRENT_TIMESTAMP after each UPDATE on the table.
+
+### `(SqliteDialect) BoolFalse`
+
+```go
+func (SqliteDialect) BoolFalse() string
+```
+
+BoolFalse returns the SQL literal "0".
+
+### `(SqliteDialect) BoolTrue`
+
+```go
+func (SqliteDialect) BoolTrue() string
+```
+
+BoolTrue returns the SQL literal "1".
+
+### `(SqliteDialect) ColumnsSQL`
+
+```go
+func (SqliteDialect) ColumnsSQL(table string) string
+```
+
+ColumnsSQL returns a query for column names of the given table via
+pragma_table_info. The table name is interpolated literally; callers must
+validate it.
+
+### `(SqliteDialect) DSN`
+
+```go
+func (SqliteDialect) DSN(url string) string
+```
+
+DSN strips the "sqlite://" or "file:" prefix from url to get the file path.
+
+### `(SqliteDialect) DriverName`
+
+```go
+func (SqliteDialect) DriverName() string
+```
+
+DriverName returns "sqlite".
+
+### `(SqliteDialect) FieldToDefault`
+
+```go
+func (d SqliteDialect) FieldToDefault(f parser.Field) string
+```
+
+FieldToDefault returns a " DEFAULT ..." clause for the field, or "" if none.
+Auto fields use CURRENT_TIMESTAMP, date('now'), a synthesized UUID expression,
+or 0, depending on type.
+
+### `(SqliteDialect) FieldToSQLType`
+
+```go
+func (d SqliteDialect) FieldToSQLType(f parser.Field) string
+```
+
+FieldToSQLType maps a parser.Field type to a SQLite column type.
+
+### `(SqliteDialect) InitStatements`
+
+```go
+func (SqliteDialect) InitStatements() []string
+```
+
+InitStatements returns PRAGMA statements that enable WAL journaling and
+foreign keys; both are run on every new connection.
+
+### `(SqliteDialect) InternalTableDDL`
+
+```go
+func (SqliteDialect) InternalTableDDL() []string
+```
+
+InternalTableDDL returns the CREATE TABLE IF NOT EXISTS statements for
+kilnx-managed tables (sessions, password resets, migrations, jobs, flags,
+rate limits) using SQLite types.
+
+### `(SqliteDialect) ListTablesSQL`
+
+```go
+func (SqliteDialect) ListTablesSQL() string
+```
+
+ListTablesSQL returns a query for user tables, excluding kilnx-internal
+tables and SQLite's own metadata tables.
+
+### `(SqliteDialect) Placeholder`
+
+```go
+func (SqliteDialect) Placeholder(_ int) string
+```
+
+Placeholder always returns "?" for SQLite.
+
+### `(SqliteDialect) TableExistsSQL`
+
+```go
+func (SqliteDialect) TableExistsSQL() string
+```
+
+TableExistsSQL returns a query that counts entries in sqlite_master
+matching the given table name.
+
+### `(TxHandle) Commit`
+
+```go
+func (th *TxHandle) Commit() error
+```
+
+Commit commits the transaction
+
+### `(TxHandle) ExecWithParams`
+
+```go
+func (th *TxHandle) ExecWithParams(sqlStr string, params map[string]string) error
+```
+
+ExecWithParams executes a mutation within the transaction
+
+### `(TxHandle) QueryRowsWithParams`
+
+```go
+func (th *TxHandle) QueryRowsWithParams(sqlStr string, params map[string]string) ([]Row, error)
+```
+
+QueryRowsWithParams executes a SELECT within the transaction
+
+### `(TxHandle) Rollback`
+
+```go
+func (th *TxHandle) Rollback() error
+```
+
+Rollback rolls back the transaction (no-op if already committed)
+
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# `internal/database`
+
+Persistence layer: connection management, schema migration, dialect-aware query execution. Backs every SQL operation the runtime performs.
+
+## Purpose
+
+Kilnx apps target either SQLite (default, for dev and small deployments) or PostgreSQL (for production scale). The runtime should not care which one is in use. This package abstracts that choice behind a `Dialect` interface and a `database.DB` wrapper, and owns the migration that maps the parsed model AST to live schema.
+
+## Three-way split
+
+The package is organized around three concerns that match the three groups of files:
+
+1. **Driver**: opens a `*sql.DB` from a `DATABASE_URL`. Files: [`driver.go`](../../../internal/database/driver.go), [`driver_postgres.go`](../../../internal/database/driver_postgres.go). Each file is a single blank-import line that pulls in the underlying driver (`modernc.org/sqlite` for SQLite, `github.com/jackc/pgx/v5/stdlib` for Postgres). Splitting them lets build tags, in principle, exclude one or the other; today both are always linked.
+
+2. **Dialect**: emits SQL that varies between databases. Interface in [`dialect.go`](../../../internal/database/dialect.go), implementations in [`dialect_sqlite.go`](../../../internal/database/dialect_sqlite.go) and [`dialect_postgres.go`](../../../internal/database/dialect_postgres.go).
+
+3. **Migration**: derives the target schema from `parser.Model` values, diffs it against the live schema, and applies the necessary `CREATE`/`ALTER` statements. Lives in [`database.go`](../../../internal/database/database.go).
+
+Query execution helpers live in [`query.go`](../../../internal/database/query.go). Public types in [`interfaces.go`](../../../internal/database/interfaces.go) define what the runtime depends on so tests can substitute fakes.
+
+## File map
+
+- [`database.go`](../../../internal/database/database.go): `DB` struct, `Open`, `DetectDialect`, `BeginTxHandle`, `TxHandle`, `MigrateInternal`, `PlanMigration`, `Migrate`, `MigrationHistory`, `DetectDataLossRisk`, `IsValidIdentifier`, `schemaHash`, `customKindToSQL`, `fieldDefsTableDDL`, index/unique-index DDL builders.
+- [`dialect.go`](../../../internal/database/dialect.go): the `Dialect` interface (driver name, DSN, init statements, placeholder syntax, table/column introspection SQL, type mappings, default-value clauses, bool literals, internal table DDL, auto-update trigger DDL).
+- [`dialect_sqlite.go`](../../../internal/database/dialect_sqlite.go): SQLite implementation. Uses `?` placeholders, `pragma_table_info` for column introspection, `sqlite_master` for table listing, an `AFTER UPDATE` trigger for `auto_update`, WAL + foreign-keys pragmas on connect.
+- [`dialect_postgres.go`](../../../internal/database/dialect_postgres.go): Postgres implementation. Uses `$N` placeholders, `information_schema.tables` and `information_schema.columns` for introspection, a `BEFORE UPDATE` trigger backed by a `plpgsql` function for `auto_update`, no init statements (FKs and WAL are defaults).
+- [`driver.go`](../../../internal/database/driver.go), [`driver_postgres.go`](../../../internal/database/driver_postgres.go): blank-import the SQL drivers.
+- [`query.go`](../../../internal/database/query.go): `Row` type (`map[string]string`), `QueryRows`, `QueryRowsWithParams`, `ExecWithParams`, transactional variants, `bindParams` (named `:name` params to dialect placeholders), `RewriteCustomFieldShorthand` (`custom.field` to `json_extract` or `->>`), slow-query callback hook.
+- [`interfaces.go`](../../../internal/database/interfaces.go): `Executor` interface used by the runtime. `*DB` implements it; tests fake it.
+- [`doc.go`](../../../internal/database/doc.go): package doc.
+
+## Public surface
+
+```go
+func Open(url string) (*DB, error)
+func DetectDialect(url string) Dialect
+
+(db *DB) Close() error
+(db *DB) Conn() *sql.DB
+(db *DB) Dialect() Dialect
+
+(db *DB) QueryRows(sql string) ([]Row, error)
+(db *DB) QueryRowsWithParams(sql string, params map[string]string) ([]Row, error)
+(db *DB) ExecWithParams(sql string, params map[string]string) error
+(db *DB) BeginTxHandle() (*TxHandle, error)
+
+(db *DB) MigrateInternal() error
+(db *DB) Migrate(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]string, error)
+(db *DB) PlanMigration(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]string, error)
+(db *DB) MigrationHistory() ([]MigrationRecord, error)
+(db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error)
+
+OnSlowQuery func(sql string, d time.Duration)   // optional callback set by the runtime logger
+```
+
+`TxHandle` exposes `ExecWithParams`, `QueryRowsWithParams`, `Commit`, `Rollback`. Commit and rollback are idempotent.
+
+## Driver selection
+
+`Open(url)` calls `DetectDialect(url)`:
+
+- `postgres://...` or `postgresql://...` (case-insensitive): `PostgresDialect{}` with driver name `"pgx"`.
+- Anything else: `SqliteDialect{}` with driver name `"sqlite"`. The `sqlite://` and `file:` prefixes are stripped from the DSN.
+
+After `sql.Open`, every statement returned by `dialect.InitStatements()` is executed against the new connection. SQLite uses this to enable WAL journaling and foreign keys.
+
+## Dialect abstraction
+
+The interface is intentionally thin. Each method has a single, narrow purpose, so a third dialect (MySQL, e.g.) would be a single new file. The implementations differ in:
+
+| Concern | SQLite | Postgres |
+|---|---|---|
+| Placeholder | `?` | `$1`, `$2`, ... |
+| Auto PK | `INTEGER PRIMARY KEY AUTOINCREMENT` | `BIGSERIAL PRIMARY KEY` |
+| Bool storage | `INTEGER` (0/1) | `BOOLEAN` |
+| JSON storage | `TEXT` | `JSONB` |
+| Timestamps | `DATETIME`, `CURRENT_TIMESTAMP` | `TIMESTAMP`, `NOW()` |
+| Auto UUID default | hex-randomblob expression | `gen_random_uuid()` |
+| Auto-update trigger | `AFTER UPDATE` SQL trigger | `BEFORE UPDATE` plpgsql trigger |
+| Table introspection | `sqlite_master` | `information_schema.tables` |
+| Column introspection | `pragma_table_info` | `information_schema.columns` |
+
+`ColumnsSQL(table)` interpolates the table name as a literal (because PRAGMA does not accept parameters). The migration code calls `IsValidIdentifier` on the table name first; callers outside that path must do the same.
+
+## Migration
+
+`Migrate(models)` calls `PlanMigration(models)` and applies each statement via `db.conn.Exec`. The plan, per model:
+
+1. Validate the model name as a SQL identifier. Refuse anything that does not match `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+2. Probe `tableExists`. If absent, emit a single `CREATE TABLE` (`generateCreateTable`).
+3. If present, list existing columns (`getColumns`) and emit `ALTER TABLE ... ADD COLUMN` for each declared field that is missing. Computed fields are skipped (they are evaluated in the runtime, not stored).
+4. If the model uses custom fields (`custom <file>` or `dynamic_fields`), ensure the `custom` column exists (`TEXT` for SQLite, `JSONB` for Postgres) and add real columns for any column-mode fields declared in the manifest.
+5. If the model has `dynamic_fields`, emit `CREATE TABLE IF NOT EXISTS _<model>_field_defs` (`fieldDefsTableDDL`).
+6. For each `auto_update` field, emit `dialect.AutoUpdateTriggerDDL`.
+7. Emit `CREATE UNIQUE INDEX IF NOT EXISTS uq_<model>_<cols>` for each composite UNIQUE group (`uniqueIndexDDLs`).
+8. Emit `CREATE INDEX IF NOT EXISTS ix_<model>_<cols>` for each non-unique index group (`indexDDLs`).
+
+Index names have distinct prefixes (`uq_` vs `ix_`) so they are easy to grep. Groups that reference unknown fields are silently skipped, the analyzer surfaces those errors upstream.
+
+After successful application, `recordMigration` inserts a row into `_kilnx_migrations` with a `schemaHash` (SHA-256 of a normalized model description, truncated to 8 bytes hex) and the joined SQL. `MigrationHistory()` reads it back ordered by id.
+
+## Kilnx-managed metadata tables
+
+`MigrateInternal` creates the per-runtime tables that are not derived from user models. Both dialects emit equivalent DDL through `dialect.InternalTableDDL()`:
+
+- `_kilnx_sessions`: token, user_id, identity, role, data (JSON blob), expires_at.
+- `_kilnx_password_resets`: token, email, expires_at.
+- `_kilnx_migrations`: id, schema_hash, statements, applied_at.
+- `_kilnx_jobs`: id, name, params, state, attempts, max_attempts, scheduled_at, started_at, completed_at, last_error.
+- `_kilnx_flags`: name, enabled.
+- `_kilnx_rate_limits`: scope_key, limit_period, window_start, request_count (composite PK).
+
+All names start with `_kilnx_` so the user-table introspection queries can `LIKE '\_kilnx\_%' ESCAPE '\\'` exclude them. The `_<model>_field_defs` tables follow the same exclusion pattern.
+
+## Named parameter binding
+
+`ExecWithParams` and `QueryRowsWithParams` accept SQL with `:name` placeholders and a `map[string]string`. `bindParams` rewrites each match to `dialect.Placeholder(idx)` and appends the value to a positional args slice. Names not found in the map are left as-is, this lets `:memory:` and similar SQL-keyword colon usages survive untouched.
+
+`Row` is a `map[string]string`. All scanned values are stringified with `fmt.Sprintf("%v", val)`, NULLs become `""`. The runtime is string-first end-to-end (because the `.kilnx` DSL is), so this matches the templating model.
+
+## Custom field shorthand
+
+`RewriteCustomFieldShorthand(sql, isPostgres)` rewrites `custom.fieldName` references to dialect-appropriate JSON extraction:
+
+- SQLite: `json_extract("custom", '$.fieldName')`.
+- Postgres: `"custom"->>'fieldName'`.
+
+Only call it for models that have custom fields. The runtime checks `modelHasCustomFields` before invoking it.
+
+## Data-loss detection
+
+`DetectDataLossRisk(models)` lists every user table and reports any that are not represented by a model in the new schema and contain rows. For each risk it suggests an `ALTER TABLE ... RENAME TO ...` if a similarly-named model exists (singular/plural variants). The CLI shows this before applying a destructive migration.
+
+## Slow-query callback
+
+`DB.OnSlowQuery` is a `func(sql string, d time.Duration)`. The runtime wires it to `Logger.LogSlowQuery` from [`internal/runtime/server.go`](../../../internal/runtime/server.go) when `db` is a real `*database.DB`. Tests using a fake `Executor` skip the wiring.
+
+## Gotchas
+
+- **No down migrations**. `Migrate` is forward-only. Removing a field from a model leaves the column in place. Renaming is not detected; you get an add-and-orphan. `DetectDataLossRisk` exists to surface that case.
+- **Identifier validation is fail-closed but narrow**. `isValidIdentifier` only accepts `[a-zA-Z_][a-zA-Z0-9_]*`. Quoted identifiers, schema-qualified names, and Unicode are all rejected. The migration relies on this to interpolate names directly into DDL strings.
+- **`Row` values are always strings**. There is no typed scan path. If you need typed access, do it at the runtime layer.
+- **`ColumnsSQL` interpolates the table name**. The validation contract belongs to the caller. Anything outside `PlanMigration`/`getColumns` that asks for column lists must validate first.
+- **Migration history is best-effort**. `recordMigration` ignores the insert error. A migration that succeeds but fails to record itself still leaves the schema in the new state.
+- **Postgres `gen_random_uuid()` requires `pgcrypto`**. On a fresh database without the extension, `auto` UUID fields will fail at insert time. Document this for ops, the package does not enable extensions.
+- **SQLite UUID default is verbose**. The hex-randomblob expression in `dialect_sqlite.go` is correct UUID v4 shape, just hard to read. Do not "simplify" it without re-checking the variant nibble (`8`/`9`/`a`/`b` at position 13).
+- **Schema hash is informational, not authoritative**. The migration applies actual diffs computed from live introspection. Two schemas with the same hash but different live state still get migrated correctly, the hash exists for the audit trail.
+- **Internal table names are exclusion-fragile**. The `LIKE '\_kilnx\_%'` patterns assume nobody else creates tables starting with `_kilnx_`. The user-facing analyzer should reject model names with that prefix.
+
+## When to touch this package
+
+- Adding a new field type: extend `parser.FieldType`, then both `FieldToSQLType` and `FieldToDefault` in each dialect.
+- Adding a new dialect: implement `Dialect`, register a detection branch in `DetectDialect`, add a blank-import file for the driver.
+- Changing migration semantics: edit `PlanMigration` and `database_test.go`. The plan/apply split exists so callers can preview, preserve it.
+- Adding kilnx-managed tables: extend `InternalTableDDL` in both dialects.
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/packages/index.md
+++ b/docs/contributors/packages/index.md
@@ -1,0 +1,17 @@
+# Internal Packages
+
+Generated from `internal/*` package source. Do not edit by hand. Run `go generate ./...` to regenerate.
+
+| Package | Summary |
+|---------|---------|
+| [`lexer`](lexer.md) | Package lexer transforms .kilnx source text into a token stream consumed by internal/parser. |
+| [`parser`](parser.md) | Package parser builds the Kilnx AST from a token stream produced by internal/lexer. |
+| [`analyzer`](analyzer.md) | Package analyzer performs static analysis on the parser AST: type checking of field constraints, validation of route templates, permission/role checks, dead-link detection, and security audits. |
+| [`optimizer`](optimizer.md) | Package optimizer rewrites the parser AST so the runtime can execute it efficiently. |
+| [`spec`](spec.md) | Package spec is the canonical schema for Kilnx language entities (keywords and attributes). |
+| [`database`](database.md) | Package database provides the persistence layer for the Kilnx runtime: connection management, schema migration, and dialect-aware query execution against SQLite or PostgreSQL. |
+| [`pathutil`](pathutil.md) | Package pathutil provides helpers for matching declarative route templates (e.g. "/tasks/:id/delete") against concrete request paths (e.g. "/tasks/123/delete"). |
+| [`pdf`](pdf.md) | Package pdf is a minimal, dependency-free PDF writer used by the runtime to render reports and printable views from .kilnx pages. |
+| [`runtime`](runtime.md) | Package runtime is the HTTP server and AST interpreter that backs `kilnx run` and the binaries produced by `kilnx build`. |
+| [`build`](build.md) | Package build compiles a .kilnx source file into a standalone Go binary by emitting Go source that embeds the AST and a minimal runtime, then invoking `go build`. |
+

--- a/docs/contributors/packages/lexer.md
+++ b/docs/contributors/packages/lexer.md
@@ -1,0 +1,219 @@
+# `internal/lexer`
+
+> Package lexer transforms .kilnx source text into a token stream consumed by internal/parser.
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/lexer` |
+| **Source last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `5da8498` (2026-05-08) |
+
+
+## Overview
+
+The lexer is indent-significant: leading whitespace at the start of a
+logical line determines block structure, and INDENT/DEDENT tokens are
+emitted when the indentation level changes (modeled after Python's
+tokenize module). Inline comments starting with '#' are stripped
+before tokenization.
+
+Top-level entry point is [Tokenize]. Helpers IsFieldType and
+IsFieldConstraint expose the lexer's keyword tables to the parser
+and analyzer.
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`lexer.go`](../../../internal/lexer/lexer.go) | _no file-level doc_ |
+
+## Types
+
+### `Token`
+
+```go
+type Token struct {
+	Type	TokenType
+	Value	string
+	Line	int
+	Column	int
+}
+```
+
+Token is a single lexical unit emitted by [Tokenize]. Line and Column
+are 1-based positions in the original source.
+
+### `TokenType`
+
+```go
+type TokenType int
+```
+
+TokenType identifies the lexical category of a Token (keyword, string,
+indent, etc.). Values are defined as the Token* constants below.
+
+## Functions
+
+### `IsFieldConstraint`
+
+```go
+func IsFieldConstraint(s string) bool
+```
+
+IsFieldConstraint reports whether s is a recognized field constraint
+keyword (e.g. required, unique, default, min, max).
+
+### `IsFieldType`
+
+```go
+func IsFieldType(s string) bool
+```
+
+IsFieldType reports whether s is a recognized model field type keyword
+(e.g. text, int, timestamp, reference).
+
+### `StripComments`
+
+```go
+func StripComments(source string) string
+```
+
+StripComments removes # comments from source code.
+Full-line comments (lines starting with #) are replaced with blank lines to preserve line numbers.
+Inline comments (# after code) are stripped, respecting quoted strings.
+Lines inside html blocks are never stripped (they may contain CSS hex colors like #fff).
+
+### `Tokenize`
+
+```go
+func Tokenize(source string) []Token
+```
+
+Tokenize transforms .kilnx source text into a token stream. Leading
+whitespace drives INDENT/DEDENT tokens, and a trailing TokenEOF is
+always appended. Run [StripComments] on the source first to remove
+'#' comments.
+
+### `countIndent`
+
+```go
+func countIndent(line string) int
+```
+### `tokenizeLine`
+
+```go
+func tokenizeLine(line string, lineNum int) []Token
+```
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# Package `internal/lexer`
+
+Source: [lexer.go](../../../internal/lexer/lexer.go), [doc.go](../../../internal/lexer/doc.go).
+
+## Purpose
+
+Transform `.kilnx` source text into a flat token stream consumed by [`internal/parser`](../../../internal/parser). The lexer is indent significant: leading whitespace at the start of each logical line drives `INDENT` and `DEDENT` tokens, modeled after Python's `tokenize` module. Inline `#` comments are stripped before tokenization.
+
+## Pipeline position
+
+```
+source bytes -> StripComments -> Tokenize -> []Token -> parser.Parse
+```
+
+1. CLI reads `app.kilnx` from disk.
+2. [`StripComments`](../../../internal/lexer/lexer.go) erases `#` comments while keeping line numbers intact.
+3. [`Tokenize`](../../../internal/lexer/lexer.go) emits the token stream.
+4. The parser consumes tokens; it never sees raw indentation or comments.
+
+## Public API
+
+```go
+type TokenType int
+
+const (
+    TokenKeyword TokenType = iota
+    TokenPath
+    TokenString
+    TokenIdentifier
+    TokenNumber
+    TokenColon
+    TokenComma
+    TokenBracketOpen
+    TokenBracketClose
+    TokenParenOpen
+    TokenParenClose
+    TokenAssign
+    TokenNewline
+    TokenIndent
+    TokenDedent
+    TokenRawLine
+    TokenEOF
+)
+
+type Token struct {
+    Type   TokenType
+    Value  string
+    Line   int // 1-based
+    Column int // 1-based
+}
+
+func StripComments(source string) string
+func Tokenize(source string) []Token
+func IsFieldType(s string) bool
+func IsFieldConstraint(s string) bool
+```
+
+`Tokenize` always appends a trailing `TokenEOF`. There is no error return: malformed input degrades to whatever tokens the scanner can salvage. Run `StripComments` first.
+
+`IsFieldType` exposes the model field type table: `text`, `email`, `bool`, `timestamp`, `richtext`, `option`, `int`, `float`, `password`, `image`, `phone`, `reference`, `date`, `url`, `decimal`, `file`, `tags`, `json`, `uuid`, `bigint`.
+
+`IsFieldConstraint` exposes the field constraint table: `required`, `unique`, `default`, `auto`, `min`, `max`, `auto_update`.
+
+The keyword set recognised at the top of a line is `page`, `action`, `fragment`, `stream`, `socket`, `api`, `webhook`, `schedule`, `job`, `model`, `config`, `auth`, `permissions`, `layout`, `query`, `validate`, `redirect`, `on`, `limit`, `log`, `test`, `translations`, `enqueue`, `broadcast`, `send`, `requires`, `method`, `fetch`, `llm`, `title`. Anything else that starts with a letter or underscore becomes `TokenIdentifier`.
+
+## File map
+
+- [`lexer.go`](../../../internal/lexer/lexer.go): the entire scanner, comment stripper, keyword and constraint tables, helpers.
+- [`doc.go`](../../../internal/lexer/doc.go): package-level Go doc.
+- [`lexer_test.go`](../../../internal/lexer/lexer_test.go): unit tests.
+- [`bench_test.go`](../../../internal/lexer/bench_test.go): benchmarks.
+- [`fuzz_test.go`](../../../internal/lexer/fuzz_test.go): fuzz harness.
+
+## Key behaviors and gotchas
+
+**INDENT/DEDENT emission.** `Tokenize` keeps an `indentStack` initialised to `{0}`. When a line's indent exceeds the top of the stack it pushes the new column and emits a single `TokenIndent`. When the indent drops, it pops one column at a time, emitting a `TokenDedent` per pop, until the stack head matches. At EOF the lexer flushes any remaining open levels with synthetic `TokenDedent` tokens so the parser sees a balanced stream.
+
+**Tab handling.** `countIndent` treats `\t` as 2 columns. A file that mixes tabs and spaces will be measured against this fixed conversion.
+
+**Comment stripping respects HTML blocks.** Full line `#` comments collapse to empty lines (preserving line numbers for diagnostics). Inline `#` is removed but quoted strings short circuit the scan (`#` inside `"..."` is kept). Inside an `html` block, comment stripping is suspended until indentation drops back to the `html` keyword's column. This keeps CSS hex colours like `#fff` safe.
+
+**Unclosed string tolerance.** `tokenizeLine` walks until the next `"`; if the closing quote is missing it consumes to end of line and produces a `TokenString` whose value is everything after the opening quote.
+
+**Path tokens.** A line position starting with `/` produces a single `TokenPath` running until the next whitespace, including segments such as `/users/:id/edit`.
+
+**Number scanning.** Digits and a single `.` form a `TokenNumber`. The lexer does not validate numeric syntax; the parser converts via `strconv` and surfaces errors there.
+
+**Empty lines are invisible.** Lines whose trim is empty contribute no tokens at all: no newline, no indent change. Indentation is only sampled on non blank lines.
+
+**Identifiers may contain hyphens.** The word scanner accepts `[A-Za-z_][A-Za-z0-9_-]*`. Hyphenated identifiers (`generate-report`, `forgot-password`) flow through as `TokenIdentifier` unless they appear in the keyword table.
+
+**No semantic validation.** The lexer never rejects nonsense like a stray `]`. Such characters are silently skipped by the fall through `i++` at the end of `tokenizeLine`. Higher layers detect structural problems.
+
+**Column numbers are byte offsets.** The `Column` field is set from the byte index inside the trimmed line, not from the original column in the file. Diagnostics that need precise file columns must reconstruct from `Line` plus the original source.
+
+**Indent stack invariants.** The stack starts at `{0}` and never has its base popped. Every push is matched by zero or more pops as the file walks back out. Mixed indentation that increases then decreases to a level not present on the stack does not error in the lexer; the parser detects the resulting structure mismatch.
+
+**`TokenRawLine` is reserved.** The constant exists for callers that want to capture an entire raw line (originally intended for inline SQL). The current scanner does not emit it directly; SQL extraction happens in the parser by indexing back into the original source text via `parserState.lines`.
+
+**No keyword promotion mid line.** A keyword token is emitted only when the matched word equals an entry in the keyword table. Words like `email` or `text` are never keywords at the lexical level: they become `TokenIdentifier` and are interpreted as field types only by the model parser, which calls `IsFieldType`.
+
+**Stable across re-runs.** `Tokenize` is deterministic and stateless. Two calls with the same input produce byte identical token slices; this is exercised by `bench_test.go` and `fuzz_test.go`.
+
+## Testing entry points
+
+- Round trip and shape tests: [`lexer_test.go`](../../../internal/lexer/lexer_test.go).
+- Hot path benchmarks: [`bench_test.go`](../../../internal/lexer/bench_test.go).
+- Fuzz harness exercising arbitrary byte input: [`fuzz_test.go`](../../../internal/lexer/fuzz_test.go).
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/packages/optimizer.md
+++ b/docs/contributors/packages/optimizer.md
@@ -1,0 +1,330 @@
+# `internal/optimizer`
+
+> Package optimizer rewrites the parser AST so the runtime can execute it efficiently.
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/optimizer` |
+| **Source last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `5da8498` (2026-05-08) |
+
+
+## Overview
+
+Named-query reference resolution ({queryName.field}, {^field},
+{^^field}, bare {field}) is performed earlier, by parser.Parse, before
+the optimizer runs. This package consumes those interpolations to
+drive its own rewrites.
+
+Current responsibilities:
+
+  - SELECT * rewriting: when consumer interpolations reveal exactly
+    which columns a page/fragment/api uses, rewrite "SELECT *" to an
+    explicit projection (optimizePage in optimizer.go).
+  - JOIN pruning: drop joins whose tables are not referenced by any
+    interpolation or by remaining SQL.
+  - Query deduplication: merge identical queries within a single
+    page/fragment/api body (deduplicateQueries).
+  - Stream candidacy: tag scheduled tasks that can be served as SSE
+    streams without extra work (markStreamCandidates).
+
+The optimizer is purely AST-to-AST and never returns errors: callers
+invoke Optimize(app) after parsing/analysis and use the same *App.
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`optimizer.go`](../../../internal/optimizer/optimizer.go) | _no file-level doc_ |
+
+## Types
+
+### `eachBlock`
+
+```go
+type eachBlock struct {
+	start		int
+	end		int
+	queryName	string
+}
+```
+
+eachBlock represents a single {{each queryName}}...{{end}} span.
+
+### `fieldSet`
+
+```go
+type fieldSet struct {
+	fields	[]string
+	seen	map[string]bool
+}
+```
+
+fieldSet is an ordered set of field names.
+
+### `queryEntry`
+
+```go
+type queryEntry struct {
+	name	string
+	sql	string
+	index	int	// index in page.Body (-1 if nested)
+}
+```
+## Functions
+
+### `Optimize`
+
+```go
+func Optimize(app *parser.App)
+```
+
+Optimize performs domain-aware query optimization on a parsed Kilnx app.
+
+### `addInterpolatedFields`
+
+```go
+func addInterpolatedFields(result map[string]*fieldSet, text string)
+```
+
+addInterpolatedFields extracts {queryName.field} and {^field} references from text
+and adds the fields to the appropriate query's field set.
+
+### `collectNamedQueries`
+
+```go
+func collectNamedQueries(nodes []parser.Node, entries *[]queryEntry, baseIndex int)
+```
+### `collectUsedFields`
+
+```go
+func collectUsedFields(nodes []parser.Node) map[string]*fieldSet
+```
+
+collectUsedFields walks all nodes in a page body and collects which fields
+each query name needs. Returns nil for a query if field usage can't be
+fully determined (e.g. table with no explicit columns).
+
+### `countEachEnclosing`
+
+```go
+func countEachEnclosing(pos int, blocks []eachBlock) []string
+```
+
+countEachEnclosing returns the names of {{each}} blocks that enclose the given position.
+
+### `countUnnamedQueries`
+
+```go
+func countUnnamedQueries(nodes []parser.Node) int
+```
+### `deduplicateQueries`
+
+```go
+func deduplicateQueries(page *parser.Page)
+```
+### `extractPathParams`
+
+```go
+func extractPathParams(path string) []string
+```
+
+extractPathParams pulls :param names from a URL path like /users/:id/edit.
+
+### `findEachBlocks`
+
+```go
+func findEachBlocks(text string) []eachBlock
+```
+
+findEachBlocks returns all {{each}} blocks in the given text, including nested ones.
+
+### `findJoinClauseEnd`
+
+```go
+func findJoinClauseEnd(sql string, start int) int
+```
+### `findMatchingEnd`
+
+```go
+func findMatchingEnd(content string) (body, elseBody string, endPos int)
+```
+
+findMatchingEnd finds the body, else body, and position after {{end}} for a block,
+accounting for nested {{each}}/{{if}} blocks.
+
+### `hasKey`
+
+```go
+func hasKey(m map[string]*fieldSet, key string) bool
+```
+### `markStreamCandidates`
+
+```go
+func markStreamCandidates(app *parser.App)
+```
+
+markStreamCandidates marks stream queries with aggregate functions as
+materialization candidates by prepending a hint comment.
+
+### `newFieldSet`
+
+```go
+func newFieldSet() *fieldSet
+```
+### `normalizeSQL`
+
+```go
+func normalizeSQL(sql string) string
+```
+
+deduplicateQueries finds named queries with identical SQL on the same page
+and removes duplicates, rewriting consumer references to point to the original.
+normalizeSQL returns a canonical form of a SQL string for deduplication.
+It trims whitespace, collapses multiple spaces, and uppercases keywords.
+
+### `optimizePage`
+
+```go
+func optimizePage(page *parser.Page)
+```
+### `pruneUnusedJoins`
+
+```go
+func pruneUnusedJoins(sql string, fields *fieldSet) string
+```
+
+pruneUnusedJoins removes JOIN clauses when no columns from the joined table
+are consumed by any component. Skips if any consumed field uses plain names
+(no dot notation) since we can't determine which table owns the column.
+
+### `renameConsumerRefs`
+
+```go
+func renameConsumerRefs(nodes []parser.Node, oldName, newName string)
+```
+### `rewriteSelectStar`
+
+```go
+func rewriteSelectStar(sql string, fields *fieldSet) string
+```
+
+rewriteSelectStar replaces SELECT * FROM with SELECT col1, col2, ... FROM
+only if the SQL starts with SELECT [DISTINCT] * FROM.
+
+### `(fieldSet) add`
+
+```go
+func (fs *fieldSet) add(field string)
+```
+### `(fieldSet) sorted`
+
+```go
+func (fs *fieldSet) sorted() []string
+```
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# Package `internal/optimizer`
+
+Source: [optimizer.go](../../../internal/optimizer/optimizer.go), [doc.go](../../../internal/optimizer/doc.go).
+
+## Purpose
+
+Rewrite the parser AST so the runtime can execute it efficiently. Current passes:
+
+- Replace `SELECT *` with the explicit column set actually consumed by the page or fragment, derived from `{queryName.field}` and `{^field}` interpolations in HTML and text bodies.
+- Prune `JOIN` clauses whose joined alias is never referenced by any consumer.
+- Deduplicate named queries on the same page that share identical SQL, rewriting consumers to point at the surviving query.
+- Mark `stream` queries that contain aggregate functions with a `kilnx:materialize-candidate` hint comment so the runtime can opt them into materialised storage.
+
+## Pipeline position
+
+```
+parser.App (named queries already resolved)
+  -> analyzer.Analyze (errors gate this stage)
+  -> optimizer.Optimize  (mutates AST in place)
+  -> runtime
+```
+
+The optimizer is purely AST to AST. It assumes the parser has already substituted bare named query references and the analyzer has populated `Node.SourceModel`. It does not connect to the database.
+
+## Public API
+
+```go
+func Optimize(app *parser.App)
+```
+
+`Optimize` mutates `app` in place. There is no return value: pages, fragments, APIs, and streams are rewritten directly. Calling it twice is safe; the stream materialise hint check skips queries already prefixed with the marker comment.
+
+For each page, fragment, and API the optimizer:
+
+1. Walks the body to build a `map[queryName]*fieldSet` of fields each query is observed to need.
+2. Counts unnamed queries to avoid the unsafe `_last` rewrite when more than one is present.
+3. Rewrites `SELECT * FROM ...` and `SELECT DISTINCT * FROM ...` for each named query whose consumed field set is fully known.
+4. Prunes JOINs whose alias is not referenced by any qualified field.
+5. Deduplicates identical SQL across named queries on the same page.
+
+After the page level passes, `markStreamCandidates` walks `app.Streams` and prepends `/* kilnx:materialize-candidate */` to any SQL that matches `(?i)\b(COUNT|SUM|AVG|MIN|MAX)\s*\(` and has a positive `IntervalSecs`.
+
+## File map
+
+- [`optimizer.go`](../../../internal/optimizer/optimizer.go): `Optimize`, field collection, `SELECT *` rewriting, JOIN pruning, named query deduplication, stream materialisation hints, all helpers (`fieldSet`, `findEachBlocks`, `countEachEnclosing`, `normalizeSQL`, `renameConsumerRefs`, `findJoinClauseEnd`).
+- [`doc.go`](../../../internal/optimizer/doc.go): package level documentation.
+- [`optimizer_test.go`](../../../internal/optimizer/optimizer_test.go): unit tests for each pass.
+
+## Named query reference syntax
+
+The interpolation regex is `\{(\^*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\}`. The optimizer recognises three patterns inside `NodeText` and `NodeHTML` content:
+
+**`{queryName.field}`**: a qualified reference. Records that `field` is consumed from the result set named `queryName`. The collector accepts arbitrary identifiers on the left, including dot chains; only the first segment is treated as the query name. The literal `.count` is ignored because it is a built in aggregate, not a real column.
+
+**`{^field}`**: a parent scope reference, valid only inside an enclosing `{{each queryName}}...{{end}}` block. The optimizer counts the leading `^` characters: depth `1` (`{^field}`) refers to the immediately enclosing `each`, depth `2` (`{^^field}`) refers to its parent, and so on. `findEachBlocks` builds the spanning list of `each` enclosures for the current position; the resolved query name is `eachNames[len(eachNames)-depth-1]`. If `depth` exceeds the available enclosing scopes the reference is ignored.
+
+**`{field}`**: a bare reference with no dot, used inside a single `{{each}}` to access the current row's column directly. The optimizer cannot attribute it to a specific query, so it does not contribute to field collection. The runtime resolves it from the loop's row.
+
+This is consumed only for consumer to query field tracking. The literal `SELECT *` text in source SQL is what gets rewritten; the interpolation patterns themselves are left intact in the template, where the runtime resolves them at render time.
+
+## Key behaviors and gotchas
+
+**Named query *substitution* is not here.** The parser is responsible for rewriting `query: someName` body nodes to the SQL stored in `app.NamedQueries`. The optimizer assumes this has already run. See [parser.md](./parser.md).
+
+**`SELECT *` rewriting is conservative.** It runs only when the consumed field set is fully known. If any consumer uses a bare `{field}` reference (no dot, no `^`), the field set is left nil for that query and the rewrite is skipped. The same applies when more than one unnamed query appears on the same page: they all share the implicit `_last` slot, so the optimizer cannot tell whose columns are being referenced.
+
+**JOIN pruning is conservative too.** `pruneUnusedJoins` aborts as soon as it finds a single unqualified field in the consumed set, because it cannot decide which joined table owns the column. When every consumed field uses an `alias.column` form, JOINs whose alias is unused are removed by walking `joinRe` matches in reverse and snipping out the `JOIN ... ON ...` span up to the next clause boundary.
+
+**Deduplication compares normalised SQL.** `normalizeSQL` trims and collapses whitespace; it does not touch case or comments. Two queries with identical text but different leading or trailing whitespace are treated as duplicates. The duplicate's `SQL` field is cleared (`""`) and `renameConsumerRefs` rewrites `{old.` and `{{each old}}` references in sibling text and HTML nodes to point at the surviving name.
+
+**Stream materialisation is a hint only.** Prepending the comment does not rewrite the query; it tags it for the runtime to consider materialising. Already tagged queries are skipped on re-runs of `Optimize`.
+
+**`NodeOn` recursion.** Field collection descends into `NodeOn.Children` so branching bodies contribute to the field set. The deduplication pass also walks `NodeOn` children but flags nested entries with `index = -1` so they are not eligible for SQL clearing (only the top level node owns its slot in `page.Body`).
+
+**No errors from this pass.** All branches degrade to "no rewrite" rather than failing. Any source level problems should be caught earlier by the analyzer.
+
+**Field set ordering is insertion order.** `fieldSet.sorted()` returns fields in the order they were first observed, not alphabetically. Output is deterministic for a given input but may surprise authors expecting sorted column lists.
+
+**`{{each}}` block discovery is recursive.** `findEachBlocks` walks nested `{{each ...}}{{end}}` and `{{if ...}}{{end}}` pairs by maintaining a `depth` counter inside `findMatchingEnd`. Misnested blocks (missing `{{end}}`, mismatched depth) cause the discovery to bail out, after which any `{^field}` references inside the broken span fall through without contributing to the field set.
+
+**The optimizer never queries the database.** Materialisation candidate marking is purely textual; the runtime decides whether the hint is worth honouring based on its own caching policy.
+
+**Page deduplication is intra page only.** Two pages with identical SQL each retain their own copy. Cross page deduplication would require a runtime cache rather than an AST pass.
+
+**`SELECT DISTINCT *` is also rewritten.** `selectStarRe` accepts `SELECT *` and `SELECT DISTINCT *`. Other forms (`SELECT t.*`, `SELECT a, *`) are left untouched.
+
+**Leading whitespace is preserved.** `rewriteSelectStar` captures the leading whitespace of the original SQL string and prefixes it back onto the rewritten query so error messages and logs that index into the SQL string keep the same column positions.
+
+**`renameConsumerRefs` is text level.** It does string replace on `{old.` and `{{each old}}` patterns inside `NodeText` and `NodeHTML`. Field expressions buried inside attribute values, JSON literals, or multiline strings are still rewritten because the substitution is unconditional. This is intentional: every interpolation site that the parser captured into one of these node types should be redirected.
+
+**JOIN clause boundaries are keyword based.** `findJoinClauseEnd` ends a JOIN span at the next of `JOIN`, `LEFT`, `RIGHT`, `INNER`, `OUTER`, `CROSS`, `FULL`, `WHERE`, `ORDER`, `GROUP`, `HAVING`, `LIMIT`, `UNION`. Subqueries inside `ON` clauses are tolerated via depth counting on parentheses.
+
+**Aggregate detection is keyword based.** `aggregateRe` matches `COUNT(`, `SUM(`, `AVG(`, `MIN(`, `MAX(` case insensitively. A custom aggregate or an aliased aggregate like `cnt(...)` will not be marked. This is conservative: false negatives are preferable to applying materialisation to queries the runtime cannot safely cache.
+
+**The `_last` slot is fragile by design.** When a body has exactly one unnamed `query`, the optimizer treats it as having the implicit name `_last`. When two or more unnamed queries coexist, the optimizer aborts the rewrite for them: it cannot prove which query each interpolation refers to. Authors who want `SELECT *` rewriting should give their queries names.
+
+**Idempotence.** Running `Optimize` twice on the same `App` is safe. Already rewritten `SELECT` clauses no longer match `selectStarRe`; deduplicated queries already have empty SQL and are skipped; the materialisation comment short circuits its own re-application.
+
+## Testing entry points
+
+- Per pass tests covering `SELECT *` rewriting, JOIN pruning, deduplication, and stream marking: [`optimizer_test.go`](../../../internal/optimizer/optimizer_test.go).
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/packages/optimizer.md
+++ b/docs/contributors/packages/optimizer.md
@@ -6,7 +6,7 @@
 |---|---|
 | **Import path** | `github.com/kilnx-org/kilnx/internal/optimizer` |
 | **Source last touched** | `5da8498` (2026-05-08) |
-| **Doc last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `d2d0978` (2026-05-08) |
 
 
 ## Overview

--- a/docs/contributors/packages/parser.md
+++ b/docs/contributors/packages/parser.md
@@ -1,0 +1,1361 @@
+# `internal/parser`
+
+> Package parser builds the Kilnx AST from a token stream produced by internal/lexer.
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/parser` |
+| **Source last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `5da8498` (2026-05-08) |
+
+
+## Overview
+
+To regenerate the reference documentation under docs/devs/reference
+after editing any *_spec.go file, run:
+
+	go generate ./...
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`action_spec.go`](../../../internal/parser/action_spec.go) | _no file-level doc_ |
+| [`api_spec.go`](../../../internal/parser/api_spec.go) | _no file-level doc_ |
+| [`attrs_spec.go`](../../../internal/parser/attrs_spec.go) | _no file-level doc_ |
+| [`auth_spec.go`](../../../internal/parser/auth_spec.go) | _no file-level doc_ |
+| [`body_nodes_spec.go`](../../../internal/parser/body_nodes_spec.go) | _no file-level doc_ |
+| [`config_spec.go`](../../../internal/parser/config_spec.go) | _no file-level doc_ |
+| [`field_attrs_spec.go`](../../../internal/parser/field_attrs_spec.go) | _no file-level doc_ |
+| [`fragment_spec.go`](../../../internal/parser/fragment_spec.go) | _no file-level doc_ |
+| [`job_spec.go`](../../../internal/parser/job_spec.go) | _no file-level doc_ |
+| [`layout_spec.go`](../../../internal/parser/layout_spec.go) | _no file-level doc_ |
+| [`limit_spec.go`](../../../internal/parser/limit_spec.go) | _no file-level doc_ |
+| [`log_spec.go`](../../../internal/parser/log_spec.go) | _no file-level doc_ |
+| [`model_spec.go`](../../../internal/parser/model_spec.go) | _no file-level doc_ |
+| [`page_spec.go`](../../../internal/parser/page_spec.go) | _no file-level doc_ |
+| [`parser.go`](../../../internal/parser/parser.go) | _no file-level doc_ |
+| [`permissions_spec.go`](../../../internal/parser/permissions_spec.go) | _no file-level doc_ |
+| [`query_spec.go`](../../../internal/parser/query_spec.go) | _no file-level doc_ |
+| [`schedule_spec.go`](../../../internal/parser/schedule_spec.go) | _no file-level doc_ |
+| [`socket_spec.go`](../../../internal/parser/socket_spec.go) | _no file-level doc_ |
+| [`stream_spec.go`](../../../internal/parser/stream_spec.go) | _no file-level doc_ |
+| [`test_spec.go`](../../../internal/parser/test_spec.go) | _no file-level doc_ |
+| [`translations_spec.go`](../../../internal/parser/translations_spec.go) | _no file-level doc_ |
+| [`webhook_spec.go`](../../../internal/parser/webhook_spec.go) | _no file-level doc_ |
+
+## Types
+
+### `App`
+
+```go
+type App struct {
+	Models		[]Model
+	Pages		[]Page
+	Actions		[]Page		// actions share the same structure as pages but handle POST/PUT/DELETE
+	Fragments	[]Page		// fragments return partial HTML (no page wrapper)
+	APIs		[]Page		// api endpoints return JSON instead of HTML
+	Streams		[]Stream	// SSE stream endpoints
+	Schedules	[]Schedule	// timed tasks
+	Jobs		[]Job		// async background jobs
+	Webhooks	[]Webhook	// external event receivers
+	Sockets		[]Socket	// bidirectional websockets
+	RateLimits	[]RateLimit	// rate limiting rules
+	Config		*AppConfig	// nil if no config block defined
+	Auth		*AuthConfig	// nil if no auth block defined
+	Permissions	[]Permission	// role-based access rules
+	Layouts		[]Layout
+	Tests		[]Test
+	LogConfig	*LogConfig
+	Translations	map[string]map[string]string	// lang -> key -> value
+	NamedQueries	map[string]string		// name -> SQL
+	CustomManifests	map[string]*CustomFieldManifest	// model name -> custom field definitions
+}
+```
+
+App is the root AST node holding every top-level declaration parsed
+from a .kilnx source file.
+
+### `AppConfig`
+
+```go
+type AppConfig struct {
+	Name		string		// app display name for the topbar
+	Database	string		// env var or default path
+	Port		int		// server port (default 8080)
+	Secret		string		// env var for session secret
+	StaticDir	string		// static files directory (served at /_static/)
+	UploadsDir	string		// upload directory
+	UploadsMaxMB	int		// max upload size in MB
+	DefaultLanguage	string		// default i18n language
+	DetectLanguage	string		// "header accept-language" or empty
+	CORSOrigins	[]string	// allowed CORS origins (empty = same-origin only)
+}
+```
+
+AppConfig holds top-level application settings from a `config` block.
+
+### `AuthConfig`
+
+```go
+type AuthConfig struct {
+	Table		string	// user table name (default: "user")
+	Identity	string	// identity field (default: "email")
+	Password	string	// password field (default: "password")
+	LoginPath	string	// login page path (default: "/login")
+	LogoutPath	string	// logout POST path (default: "/logout")
+	RegisterPath	string	// registration page path (default: "/register")
+	ForgotPath	string	// forgot-password page path (default: "/forgot-password")
+	ResetPath	string	// reset-password page path (default: "/reset-password")
+	AfterLogin	string	// redirect after login (default: "/")
+	Superuser	string	// identity of the platform operator (bypasses all role checks)
+}
+```
+
+AuthConfig configures the built-in authentication subsystem from an
+`auth` block. All fields have defaults if left empty.
+
+### `CustomFieldDef`
+
+```go
+type CustomFieldDef struct {
+	Name		string
+	Kind		CustomFieldKind
+	Label		string
+	Required	bool
+	Options		[]string
+	Mode		CustomFieldMode	// "" = JSON, "column" = dedicated column
+	Reference	string		// target model name for kind: reference
+}
+```
+
+CustomFieldDef describes a single custom field from a manifest file.
+
+### `CustomFieldKind`
+
+```go
+type CustomFieldKind string
+```
+
+CustomFieldKind is the type of a runtime-extensible custom field.
+
+### `CustomFieldManifest`
+
+```go
+type CustomFieldManifest struct {
+	ModelName	string
+	Fields		[]CustomFieldDef
+}
+```
+
+CustomFieldManifest holds all custom field definitions for a model.
+
+### `CustomFieldMode`
+
+```go
+type CustomFieldMode string
+```
+
+CustomFieldMode controls how a custom field is stored in the database.
+
+### `Field`
+
+```go
+type Field struct {
+	Name		string
+	Type		FieldType
+	Required	bool
+	Unique		bool
+	Default		string
+	Auto		bool
+	AutoUpdate	bool
+	Min		string
+	Max		string
+	Options		[]string	// for option type: [admin, editor, viewer]
+	Reference	string		// for reference type: model name
+	Computed	bool		// virtual field, not stored in DB
+	ComputedExpr	string		// expression for computed field (e.g. "quantity * unit_price")
+}
+```
+
+Field is one column on a Model, with type and optional modifiers
+(required, unique, default, min/max, computed expression, ...).
+
+### `FieldType`
+
+```go
+type FieldType string
+```
+
+FieldType is the data type of a Field declared on a Model.
+
+### `FragmentArg`
+
+```go
+type FragmentArg struct {
+	Name		string
+	HasDefault	bool	// true if `=` was provided in the source (even with empty string)
+	DefaultValue	string	// value when HasDefault is true; ignored otherwise
+}
+```
+
+FragmentArg is one named argument accepted by a component-style
+fragment (e.g. `fragment badge(status="default")`).
+
+### `Job`
+
+```go
+type Job struct {
+	Name		string
+	Body		[]Node	// query, send email, etc.
+	MaxRetries	int	// from "retry N" declaration (default 3)
+}
+```
+
+Job is a `job` declaration: an asynchronous unit of work invoked via
+enqueue nodes.
+
+### `Layout`
+
+```go
+type Layout struct {
+	Name		string
+	HTMLContent	string	// raw HTML with {page.title}, {page.content}, {nav}
+	Queries		[]Node	// queries to execute when rendering the layout
+}
+```
+
+Layout is a named HTML shell, referenced by Page.Layout, that wraps
+page content with shared chrome.
+
+### `LogConfig`
+
+```go
+type LogConfig struct {
+	Level		string	// "debug", "info", "warn", "error"
+	SlowQueryMs	int	// log queries slower than this (ms)
+	LogRequests	bool
+	LogErrors	bool
+	Stacktrace	bool	// log errors with stacktrace
+}
+```
+
+LogConfig configures runtime logging behaviour from a `log` block.
+
+### `Model`
+
+```go
+type Model struct {
+	Name	string
+	// Tenant references another model. Rows of this model are scoped to
+	// that tenant. The compiler auto-synthesizes a required reference
+	// field named after the tenant model (e.g. `tenant: org` adds an
+	// `org_id` column) and the runtime injects a WHERE filter on SELECT
+	// queries against this table.
+	Tenant			string
+	Fields			[]Field
+	CustomFieldsFile	string	// path to *_fields.kilnx manifest (may contain {placeholder})
+	CustomFieldsFallback	string	// fallback manifest path used when dynamic file not found
+	DynamicFields		bool	// opts model into DB-backed runtime field definitions
+	// UniqueConstraints lists composite UNIQUE groups declared with
+	// `unique (a, b, ...)` directives. Each group is the list of field
+	// names as written; references resolve to their `<name>_id` column
+	// at DDL generation time.
+	UniqueConstraints	[][]string
+	// Indexes lists non-unique indexes declared with `index (a, b, ...)`
+	// directives. Same field-name resolution as UniqueConstraints.
+	Indexes	[][]string
+}
+```
+
+Model is a `model` declaration: a database table with typed fields,
+optional tenant scoping, and composite indexes.
+
+### `Node`
+
+```go
+type Node struct {
+	Type		NodeType
+	Value		string
+	Name		string			// for query: result var name
+	SQL		string			// for query: the raw SQL
+	SourceModel	string			// primary model this query targets (set by analyzer)
+	Props		map[string]string	// for on: condition; for send email: body
+	Paginate	int			// for query: items per page (0 = no pagination)
+	ModelName	string			// for validate: which model to validate against
+	QuerySQL	string			// for respond ... query: pre-fill data
+	Validations	[]Validation		// for validate block
+	RespondTarget	string			// for respond: CSS selector target
+	RespondSwap	string			// for respond: htmx swap strategy
+	HTMLContent	string			// for html: raw HTML content
+	EmailTo		string			// for send email: recipient (:email or query result)
+	EmailSubject	string			// for send email: subject line
+	EmailTemplate	string			// for send email: template name
+	JobName		string			// for enqueue: which job to run
+	JobParams	map[string]string	// for enqueue: params to pass to job
+	Children	[]Node			// for on: child nodes to execute
+	StatusCode	int			// for respond: HTTP status code
+	BroadcastRoom	string			// for broadcast: room name
+	BroadcastFrag	string			// for broadcast: fragment reference
+	TemplateName	string			// for generate pdf: template name
+	DataQueryName	string			// for generate pdf: data query name
+	EmailAttach	string			// for send email: attachment file path or param
+	FetchURL	string			// for fetch: the URL to request
+	FetchMethod	string			// for fetch: GET, POST, PUT, DELETE
+	FetchHeaders	map[string]string	// for fetch: request headers
+	FetchBody	map[string]string	// for fetch: POST body params
+	LLMModel	string			// for llm: model name (e.g. claude-sonnet-4-6)
+	LLMSystem	string			// for llm: system prompt
+	LLMHistorySQL	string			// for llm: SQL to fetch message history
+}
+```
+
+Node is one statement inside a Page, Action, Schedule, or similar
+body. NodeType selects which fields are meaningful; the rest are zero.
+
+### `NodeType`
+
+```go
+type NodeType int
+```
+
+NodeType discriminates which kind of body statement a Node represents.
+The active fields of Node depend on this value.
+
+### `Page`
+
+```go
+type Page struct {
+	Path		string
+	Layout		string
+	Title		string
+	Auth		bool
+	RequiresRole	string			// "auth" = any logged in, "admin"/"editor" = specific role
+	RequiresClauses	[]RequiresClause	// full clause list; supersedes RequiresRole when non-nil
+	Method		string
+	Body		[]Node
+	FragmentArgs	[]FragmentArg	// for component fragments (e.g. fragment badge(status)); nil for path-based
+}
+```
+
+Page is a routable handler. The same struct represents pages, actions,
+fragments, and API endpoints; the field set used and the App slice it
+lives on distinguish them.
+
+### `Permission`
+
+```go
+type Permission struct {
+	Role	string		// e.g., "admin", "editor", "viewer"
+	Rules	[]string	// e.g., "all", "read post", "write post where author = current_user"
+}
+```
+
+Permission is a single role-based access rule from a `permissions` block.
+
+### `RateLimit`
+
+```go
+type RateLimit struct {
+	PathPattern	string	// e.g., "/api/*", "/login"
+	Requests	int	// max requests
+	Window		string	// "minute", "hour"
+	Per		string	// "user", "ip"
+	DelaySecs	int	// cooldown on exceeded
+	Message		string	// custom message on exceeded
+}
+```
+
+RateLimit is a top-level `limit` rule that throttles requests matching
+a path pattern.
+
+### `RequiresClause`
+
+```go
+type RequiresClause struct {
+	Kind		RequiresClauseKind
+	Value		string	// role name for Role; expression text for Expr; flag name for Flag; empty for Auth/Superuser
+	LimitCount	int	// for RateLimit: max requests
+	LimitPeriod	string	// for RateLimit: "minute", "hour", "day"
+	LimitScope	string	// for RateLimit: "ip", "user", "tenant"
+}
+```
+
+RequiresClause is one predicate in a comma-separated requires list.
+All clauses are ANDed: the user must satisfy every clause.
+
+### `RequiresClauseKind`
+
+```go
+type RequiresClauseKind int
+```
+
+RequiresClauseKind identifies the type of a single requires predicate.
+
+### `Schedule`
+
+```go
+type Schedule struct {
+	Name		string
+	IntervalSecs	int	// parsed from "every 24h", "every 1m", etc.
+	Cron		string	// raw cron expression like "every monday at 9:00"
+	Body		[]Node	// query, send email, etc.
+}
+```
+
+Schedule is a `schedule` declaration: a body of nodes executed on a
+recurring interval or cron expression.
+
+### `Socket`
+
+```go
+type Socket struct {
+	Path		string
+	Auth		bool
+	RequiresRole	string
+	RequiresClauses	[]RequiresClause
+	OnConnect	[]Node
+	OnMessage	[]Node
+	OnDisconnect	[]Node
+}
+```
+
+Socket is a `socket` declaration: a bidirectional WebSocket endpoint
+with connect, message, and disconnect handlers.
+
+### `Stream`
+
+```go
+type Stream struct {
+	Path		string
+	Auth		bool
+	RequiresRole	string
+	RequiresClauses	[]RequiresClause
+	SQL		string	// query to execute on each tick
+	IntervalSecs	int	// polling interval in seconds
+	EventName	string	// SSE event name (default: "message")
+}
+```
+
+Stream is a `stream` declaration: a polling SSE endpoint that re-runs
+a SQL query on each tick and pushes results to clients.
+
+### `Test`
+
+```go
+type Test struct {
+	Name	string
+	Steps	[]TestStep
+}
+```
+
+Test is a named scenario from a `test` block, executed as an end-to-end
+flow against the running app.
+
+### `TestStep`
+
+```go
+type TestStep struct {
+	Action	string	// "visit", "fill", "submit", "expect", "as"
+	Target	string	// field name, URL, or selector
+	Value	string	// value to fill or expected value
+}
+```
+
+TestStep is a single instruction inside a Test, such as visiting a URL,
+filling a field, or asserting a value.
+
+### `Validation`
+
+```go
+type Validation struct {
+	Field	string
+	Rules	[]string	// required, is email, min N, max N
+}
+```
+
+Validation is one field-level rule set inside a `validate` block.
+
+### `Webhook`
+
+```go
+type Webhook struct {
+	Path		string
+	SecretEnv	string		// env var name for signature verification
+	Events		[]WebhookEvent	// on event handlers
+}
+```
+
+Webhook is a `webhook` declaration: an HTTP endpoint that receives
+signed events from an external service and dispatches them by name.
+
+### `WebhookEvent`
+
+```go
+type WebhookEvent struct {
+	Name	string	// e.g., "payment_intent.succeeded"
+	Body	[]Node	// actions to execute
+}
+```
+
+WebhookEvent is one `on <event>` handler inside a Webhook.
+
+### `multiError`
+
+```go
+type multiError []error
+```
+
+multiError joins multiple errors into a single error
+
+### `parserState`
+
+```go
+type parserState struct {
+	tokens		[]lexer.Token
+	pos		int
+	lines		[]string	// original source lines for raw text extraction
+	errors		[]error		// collected parse errors for multi-error reporting
+	recovery	bool		// true when skipping tokens to synchronize
+}
+```
+## Functions
+
+### `Parse`
+
+```go
+func Parse(tokens []lexer.Token, source string) (*App, error)
+```
+
+Parse builds an App AST from a token stream and the original source.
+The source is retained for error context and for line-based extraction
+of SQL, HTML, and computed expressions. A non-nil error is returned
+when one or more parse errors are encountered.
+
+### `ParseManifest`
+
+```go
+func ParseManifest(source, modelName string) (*CustomFieldManifest, error)
+```
+
+ParseManifest parses a custom fields manifest file (`*_fields.kilnx`).
+The manifest contains top-level `field <name>` blocks with kind, label,
+required, and option properties.
+
+### `extractPaginate`
+
+```go
+func extractPaginate(sql string) (string, int)
+```
+
+extractPaginate checks for "paginate N" at the end of SQL and strips it.
+Returns the cleaned SQL and the page size (0 if no pagination).
+
+### `firstRoleValue`
+
+```go
+func firstRoleValue(clauses []RequiresClause) string
+```
+
+firstRoleValue returns the first role/auth string from clauses for backward compat.
+
+### `init`
+
+```go
+func init()
+```
+
+Field-level constraints applied inside a `model` block, e.g.:
+
+	model user
+	  email: email required unique
+	  age: int min 18 max 120
+	  role: option [admin, editor] default "editor"
+
+### `parseDuration`
+
+```go
+func parseDuration(val string) int
+```
+
+parseDuration parses "5s", "10s", "1m", "5m" into seconds
+
+### `parseOneClause`
+
+```go
+func parseOneClause(s string) RequiresClause
+```
+
+parseOneClause classifies a single requires segment.
+
+### `parseRateLimitClause`
+
+```go
+func parseRateLimitClause(s string) RequiresClause
+```
+
+parseRateLimitClause parses "10/hour per user" into a RequiresClause.
+
+### `parseTestStep`
+
+```go
+func parseTestStep(line string) TestStep
+```
+### `requiresClauseEnd`
+
+```go
+func requiresClauseEnd(s string) string
+```
+
+requiresClauseEnd walks s (text after "requires") and returns the portion
+that belongs to the requires clauses, stopping before a modifier keyword
+(method, layout, title) at bracket/quote depth 0.
+
+### `resolveEnvValue`
+
+```go
+func resolveEnvValue(raw string) string
+```
+
+resolveEnvValue handles "env VAR_NAME default VALUE" syntax.
+Returns the resolved value.
+
+### `splitClauseText`
+
+```go
+func splitClauseText(text string) []string
+```
+
+splitClauseText splits a requires text on commas at bracket/quote depth 0.
+
+### `(multiError) Error`
+
+```go
+func (me multiError) Error() string
+```
+### `(parserState) addError`
+
+```go
+func (p *parserState) addError(err error)
+```
+
+addError records a parse error and enters recovery mode
+
+### `(parserState) advance`
+
+```go
+func (p *parserState) advance() lexer.Token
+```
+### `(parserState) current`
+
+```go
+func (p *parserState) current() lexer.Token
+```
+### `(parserState) extractComputedExprFromLine`
+
+```go
+func (p *parserState) extractComputedExprFromLine(lineNum int) string
+```
+
+extractComputedExprFromLine extracts the computed expression from a source line.
+For "  total: computed quantity * unit_price", it returns "quantity * unit_price".
+
+### `(parserState) extractContinuationSQL`
+
+```go
+func (p *parserState) extractContinuationSQL() string
+```
+
+extractContinuationSQL collects indented continuation lines for multi-line SQL
+
+### `(parserState) extractRequiresText`
+
+```go
+func (p *parserState) extractRequiresText(lineNum int) string
+```
+
+extractRequiresText returns the raw text that follows the `requires` keyword
+on source line lineNum, stopping before any modifier keyword (method, layout,
+title) at bracket depth 0, and before any inline comment.
+
+### `(parserState) extractSQLFromLine`
+
+```go
+func (p *parserState) extractSQLFromLine(lineNum int) string
+```
+
+extractSQLFromLine extracts the SQL portion from a source line.
+For "  query stats: SELECT count(*) as total FROM user",
+it returns "SELECT count(*) as total FROM user"
+
+### `(parserState) extractTitleFromSourceLine`
+
+```go
+func (p *parserState) extractTitleFromSourceLine(lineNum, titleCol int) string
+```
+
+extractTitleFromSourceLine extracts a dynamic title expression from the source line.
+For "page /docs/:slug title {doc.title} layout main", it returns "{doc.title}".
+
+### `(parserState) isEOF`
+
+```go
+func (p *parserState) isEOF() bool
+```
+### `(parserState) parseAPI`
+
+```go
+func (p *parserState) parseAPI() (Page, error)
+```
+
+parseAPI parses:
+
+	api /api/v1/users requires auth
+	  query users: SELECT id, name, email FROM user ORDER BY id
+	  paginate 20
+
+### `(parserState) parseAction`
+
+```go
+func (p *parserState) parseAction() (Page, error)
+```
+
+parseAction parses:
+
+	action /users/create method POST
+	  validate user
+	  query: INSERT INTO user (name, email) VALUES (:name, :email)
+	  redirect /users
+
+### `(parserState) parseAuth`
+
+```go
+func (p *parserState) parseAuth() (AuthConfig, error)
+```
+
+parseAuth parses:
+
+	auth
+	  table: user
+	  identity: email
+	  password: password
+	  login: /login
+	  after login: /dashboard
+
+### `(parserState) parseBody`
+
+```go
+func (p *parserState) parseBody() []Node
+```
+### `(parserState) parseBroadcastNode`
+
+```go
+func (p *parserState) parseBroadcastNode() Node
+```
+
+parseBroadcastNode parses:
+
+	broadcast to :room
+	broadcast to :room fragment chat-message
+
+### `(parserState) parseConfig`
+
+```go
+func (p *parserState) parseConfig() AppConfig
+```
+
+parseConfig parses:
+
+	config
+	  database: env DATABASE_URL default "sqlite://app.db"
+	  port: env PORT default 8080
+	  secret: env SECRET_KEY required
+
+### `(parserState) parseCustomFieldsDirective`
+
+```go
+func (p *parserState) parseCustomFieldsDirective() (string, string, error)
+```
+
+parseCustomFieldsDirective parses `custom fields from "<path>" [or "<fallback>"]`
+and returns (path, fallback, error). Caller verified with peekIsCustomFieldsDirective.
+
+### `(parserState) parseDurationTokens`
+
+```go
+func (p *parserState) parseDurationTokens() int
+```
+
+parseDurationTokens reads duration from token stream.
+Handles both "5s" as single token and "5" + "s" as split tokens.
+
+### `(parserState) parseEnqueueNode`
+
+```go
+func (p *parserState) parseEnqueueNode() Node
+```
+
+parseEnqueueNode parses:
+
+	enqueue generate-report
+	  start_date: :start_date
+	  requested_by: :current_user_email
+
+### `(parserState) parseFetchNode`
+
+```go
+func (p *parserState) parseFetchNode() Node
+```
+
+parseFetchNode parses:
+
+	fetch weather: GET https://api.weather.com/v1?city=:city
+	  header Authorization: env API_KEY
+	  body amount: :amount
+
+### `(parserState) parseField`
+
+```go
+func (p *parserState) parseField(app *App) (Field, error)
+```
+### `(parserState) parseFragment`
+
+```go
+func (p *parserState) parseFragment() (Page, error)
+```
+
+parseFragment parses:
+
+	fragment /users/:id/card
+	  query user: SELECT name, email FROM user WHERE id = :id
+	  html
+	    <div class="card">{user.name}</div>
+
+### `(parserState) parseGeneratePDFNode`
+
+```go
+func (p *parserState) parseGeneratePDFNode() Node
+```
+
+parseGeneratePDFNode parses: generate pdf from template X data Y
+
+### `(parserState) parseHTMLNode`
+
+```go
+func (p *parserState) parseHTMLNode() Node
+```
+
+parseHTMLNode parses an html block with raw HTML content.
+The content is extracted from source lines to preserve all characters.
+Supports nested indentation within the html block.
+
+	html
+	  <div class="card">{user.name}</div>
+
+### `(parserState) parseIndexDirective`
+
+```go
+func (p *parserState) parseIndexDirective() ([]string, error)
+```
+
+parseIndexDirective consumes `index ( ident (, ident)* )` and returns
+the list of field names. Single-column indexes are allowed (they
+accelerate non-equality predicates and sorts in ways that a UNIQUE
+index would not).
+
+### `(parserState) parseJob`
+
+```go
+func (p *parserState) parseJob() Job
+```
+
+parseJob parses:
+
+	job generate-report
+	  query data: SELECT * FROM order WHERE created > :start_date
+	  send email to :requested_by
+	    subject: "Your report is ready"
+
+### `(parserState) parseLLMNode`
+
+```go
+func (p *parserState) parseLLMNode() Node
+```
+
+parseLLMNode parses:
+
+	llm varname: model-name
+	  history: SELECT papel, conteudo FROM mensagem WHERE conversa_id = :id ORDER BY criada ASC
+	  system: You are a helpful assistant...
+
+### `(parserState) parseLayout`
+
+```go
+func (p *parserState) parseLayout() Layout
+```
+
+parseLayout parses:
+
+	layout main
+	  html
+	    <html>
+	    <head><title>{page.title}</title></head>
+	    <body>{nav}{page.content}</body>
+	    </html>
+
+### `(parserState) parseLogConfig`
+
+```go
+func (p *parserState) parseLogConfig() LogConfig
+```
+
+parseLogConfig parses:
+
+	log
+	  level: info
+	  slow-query: 100ms
+	  requests: all
+	  errors: all
+
+### `(parserState) parseManifestField`
+
+```go
+func (p *parserState) parseManifestField() (CustomFieldDef, error)
+```
+### `(parserState) parseModel`
+
+```go
+func (p *parserState) parseModel(app *App) (Model, error)
+```
+
+parseModel parses:
+
+	model user
+	  name: text required min 2 max 100
+	  email: email unique
+	  role: option [admin, editor, viewer] default viewer
+	  active: bool default true
+	  created: timestamp auto
+	  author: user required        (reference to another model)
+
+### `(parserState) parseOnNode`
+
+```go
+func (p *parserState) parseOnNode() Node
+```
+
+parseOnNode parses:
+
+	on success
+	  redirect /users
+	on error
+	  alert error "Something went wrong"
+	on not found
+	  redirect /404
+
+### `(parserState) parsePage`
+
+```go
+func (p *parserState) parsePage() (Page, error)
+```
+### `(parserState) parsePermissions`
+
+```go
+func (p *parserState) parsePermissions() []Permission
+```
+
+parsePermissions parses:
+
+	permissions
+	  admin: all
+	  editor: read post, write post where author = current_user
+	  viewer: read post where status = published
+
+### `(parserState) parseQueryNode`
+
+```go
+func (p *parserState) parseQueryNode() (Node, error)
+```
+
+parseQueryNode parses: query name: SELECT ... (rest of line and continuation lines)
+Extracts SQL directly from source lines to preserve special chars like (), *, etc.
+
+### `(parserState) parseRateLimit`
+
+```go
+func (p *parserState) parseRateLimit() RateLimit
+```
+
+parseRateLimit parses:
+
+	limit /api/*
+	  requests: 100 per minute per user
+
+### `(parserState) parseRedirectNode`
+
+```go
+func (p *parserState) parseRedirectNode() Node
+```
+
+parseRedirectNode parses: redirect /users
+
+### `(parserState) parseRequiresClauses`
+
+```go
+func (p *parserState) parseRequiresClauses(lineNum int) []RequiresClause
+```
+
+parseRequiresClauses reads the raw source line at lineNum to extract the full
+requires text (preserving dots and single quotes the lexer would drop), then
+parses it into a []RequiresClause.
+
+### `(parserState) parseRespondNode`
+
+```go
+func (p *parserState) parseRespondNode() Node
+```
+
+parseRespondNode parses:
+
+	respond fragment ".user-row" query: SELECT * FROM user WHERE id = :id
+	respond fragment delete
+
+### `(parserState) parseSchedule`
+
+```go
+func (p *parserState) parseSchedule() Schedule
+```
+
+parseSchedule parses:
+
+	schedule cleanup every 24h
+	  query: DELETE FROM session WHERE expires_at < now()
+
+	schedule report every monday at 9:00
+	  query stats: SELECT count(*) as new_users FROM user
+	  send email to admin@test.com
+	    subject: "Weekly report"
+
+### `(parserState) parseSendEmailNode`
+
+```go
+func (p *parserState) parseSendEmailNode() Node
+```
+
+parseSendEmailNode parses:
+
+	send email to :email
+	  subject: "Welcome"
+	  template: welcome
+
+or inline: send email to admin@test.com subject "Report ready"
+
+### `(parserState) parseSocket`
+
+```go
+func (p *parserState) parseSocket() Socket
+```
+
+parseSocket parses:
+
+	socket /chat/:room requires auth
+	  on connect
+	    query: SELECT ...
+	  on message
+	    query: INSERT ...
+
+### `(parserState) parseStream`
+
+```go
+func (p *parserState) parseStream() (Stream, error)
+```
+
+parseStream parses:
+
+	stream /notifications requires auth
+	  query: SELECT message, created_at FROM notifications WHERE seen = false
+	  every 5s
+
+### `(parserState) parseTenantDirective`
+
+```go
+func (p *parserState) parseTenantDirective() (string, error)
+```
+
+parseTenantDirective parses `tenant: <model>` and returns the referenced
+model name. Caller has already verified with peekIsTenantDirective.
+
+### `(parserState) parseTest`
+
+```go
+func (p *parserState) parseTest() Test
+```
+
+parseTest parses:
+
+	test "user can create post"
+	  as editor
+	  visit /posts/new
+	  fill title "Test Post"
+	  submit
+	  expect page /posts contains "Test Post"
+
+### `(parserState) parseTranslations`
+
+```go
+func (p *parserState) parseTranslations() map[string]map[string]string
+```
+
+parseTranslations parses:
+
+	translations
+	  en
+	    welcome: "Welcome back"
+	    users: "Users"
+	  pt
+	    welcome: "Bem vindo de volta"
+	    users: "Usuários"
+
+### `(parserState) parseUniqueDirective`
+
+```go
+func (p *parserState) parseUniqueDirective() ([]string, error)
+```
+
+parseUniqueDirective consumes `unique ( ident (, ident)+ )` and returns
+the list of field names. Caller has already verified with
+peekIsUniqueDirective. Groups with fewer than two fields are rejected
+because single-field uniqueness is expressed with the field-level
+constraint `field: <type> unique`.
+
+### `(parserState) parseValidateNode`
+
+```go
+func (p *parserState) parseValidateNode() Node
+```
+
+parseValidateNode parses:
+
+	validate user
+	  (uses model constraints automatically)
+
+or:
+
+	validate
+	  name: required
+	  email: required, is email
+
+### `(parserState) parseWebhook`
+
+```go
+func (p *parserState) parseWebhook() Webhook
+```
+
+parseWebhook parses:
+
+	webhook /stripe/payment secret env STRIPE_SECRET
+	  on event payment_intent.succeeded
+	    query: UPDATE order SET status = 'paid' WHERE stripe_id = :event_id
+
+### `(parserState) peek`
+
+```go
+func (p *parserState) peek() lexer.Token
+```
+
+peek returns the next token without advancing
+
+### `(parserState) peekIsCustomFieldsDirective`
+
+```go
+func (p *parserState) peekIsCustomFieldsDirective() bool
+```
+
+peekIsCustomFieldsDirective returns true when the next tokens form
+`custom fields from "<path>"` rather than a regular field declaration.
+
+### `(parserState) peekIsDynamicFieldsDirective`
+
+```go
+func (p *parserState) peekIsDynamicFieldsDirective() bool
+```
+
+peekIsDynamicFieldsDirective returns true when the next token is `fields`,
+distinguishing `dynamic fields` from a regular field named `dynamic`.
+
+### `(parserState) peekIsIndexDirective`
+
+```go
+func (p *parserState) peekIsIndexDirective() bool
+```
+
+peekIsIndexDirective reports whether the tokens at the current position
+match `index (` (a non-unique index directive).
+
+### `(parserState) peekIsTenantDirective`
+
+```go
+func (p *parserState) peekIsTenantDirective() bool
+```
+
+peekIsTenantDirective returns true if the tokens at the current position
+match the pattern `tenant : <identifier>` (the meta directive), so we can
+distinguish it from a regular field named "tenant".
+
+### `(parserState) peekIsUniqueDirective`
+
+```go
+func (p *parserState) peekIsUniqueDirective() bool
+```
+
+peekIsUniqueDirective reports whether the tokens at the current position
+match `unique (` — a composite UNIQUE directive — rather than the field
+constraint `unique` appearing as part of `<name>: <type> unique`.
+
+### `(parserState) skipNewlines`
+
+```go
+func (p *parserState) skipNewlines()
+```
+### `(parserState) skipRequiresClauses`
+
+```go
+func (p *parserState) skipRequiresClauses()
+```
+
+skipRequiresClauses advances the token stream past clause tokens, stopping
+before a modifier keyword (method, layout, title) or end of line.
+
+### `(parserState) skipToEndOfLine`
+
+```go
+func (p *parserState) skipToEndOfLine()
+```
+
+skipToEndOfLine advances past all tokens on the current line
+
+### `(parserState) skipToEndOfModifier`
+
+```go
+func (p *parserState) skipToEndOfModifier()
+```
+
+skipToEndOfModifier advances past tokens until hitting a page modifier keyword or newline
+
+### `(parserState) synchronize`
+
+```go
+func (p *parserState) synchronize()
+```
+
+synchronize advances to the next top-level keyword (indent level 0).
+This allows the parser to recover from errors and continue parsing.
+
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# Package `internal/parser`
+
+Source: [parser.go](../../../internal/parser/parser.go), [doc.go](../../../internal/parser/doc.go).
+
+## Purpose
+
+Build the Kilnx AST from the token stream produced by [`internal/lexer`](../../../internal/lexer). Each top level keyword (`page`, `action`, `model`, ...) has a parse function in this package and a co-located `*_spec.go` file that registers a language spec entry with [`internal/spec`](../../../internal/spec) for documentation generation.
+
+## Pipeline position
+
+```
+[]lexer.Token -> parser.Parse -> *parser.App -> analyzer -> optimizer -> runtime
+```
+
+The parser is the first stage that sees structure. It also performs one cross referencing pass: after every block has been built, it resolves named query references in page, action, fragment, api, schedule, job, webhook, and socket bodies by substituting the SQL of `app.NamedQueries[name]` when a `query` body node carries only a name.
+
+## Public API
+
+```go
+func Parse(tokens []lexer.Token, source string) (*App, error)
+func ParseManifest(source, modelName string) (*CustomFieldManifest, error)
+```
+
+`Parse` returns the populated `App` even when errors are present. The error value is a `multiError`: parse errors are collected and recovery resumes at the next top level keyword via `parserState.synchronize`. Callers can still inspect the partial AST.
+
+`ParseManifest` parses a `*_fields.kilnx` custom field manifest file and produces a `CustomFieldManifest` independent from the main app.
+
+`App` is the root AST node. Key fields: `Models`, `Pages`, `Actions`, `Fragments`, `APIs`, `Streams`, `Schedules`, `Jobs`, `Webhooks`, `Sockets`, `RateLimits`, `Config`, `Auth`, `Permissions`, `Layouts`, `Tests`, `LogConfig`, `Translations`, `NamedQueries`, `CustomManifests`. Each is documented inline in [parser.go](../../../internal/parser/parser.go).
+
+Per entity parse functions live on `parserState` and are dispatched from the keyword switch in `Parse`: `parseModel`, `parsePage`, `parseAction`, `parseFragment`, `parseAPI`, `parseStream`, `parseSchedule`, `parseJob`, `parseWebhook`, `parseSocket`, `parseRateLimit`, `parseConfig`, `parseAuth`, `parsePermissions`, `parseLayout`, `parseTest`, `parseLogConfig`, `parseTranslations`, `parseQueryNode`.
+
+## The `*_spec.go` registration pattern
+
+Every keyword and shared attribute has a sibling `*_spec.go` file with an `init()` that calls `spec.Register`. The parser package therefore self describes: importing it populates the registry. [`cmd/kilnx-gendocs`](../../../cmd/kilnx-gendocs/main.go) imports the parser to walk this registry and emit the markdown reference under `docs/devs/reference`.
+
+```
+//go:generate go run ../../cmd/kilnx-gendocs -o ../../docs/devs/reference
+```
+
+Run `go generate ./...` after editing any spec file.
+
+## File map
+
+- [`parser.go`](../../../internal/parser/parser.go): all AST type definitions, the `Parse` entry point, `parserState`, every per-entity parser, named query resolution, error recovery, `ParseManifest`.
+- [`doc.go`](../../../internal/parser/doc.go): package doc and `go:generate` directive.
+- [`action_spec.go`](../../../internal/parser/action_spec.go): registers `action`, a state changing endpoint (POST/PUT/DELETE).
+- [`api_spec.go`](../../../internal/parser/api_spec.go): registers `api`, a JSON returning endpoint.
+- [`attrs_spec.go`](../../../internal/parser/attrs_spec.go): shared cross keyword attributes such as `method` and `requires`.
+- [`auth_spec.go`](../../../internal/parser/auth_spec.go): registers `auth` plus its child attributes (`table`, `identity`, `password`, `login`, ...).
+- [`body_nodes_spec.go`](../../../internal/parser/body_nodes_spec.go): body level keywords (`html`, `validate`, `redirect`, `query`, `respond`, `enqueue`, `broadcast`, `send`, `fetch`, `llm`).
+- [`config_spec.go`](../../../internal/parser/config_spec.go): registers `config` and its attributes.
+- [`field_attrs_spec.go`](../../../internal/parser/field_attrs_spec.go): per-field model attributes (`required`, `unique`, `default`, `min`, `max`, `auto`, `auto_update`).
+- [`fragment_spec.go`](../../../internal/parser/fragment_spec.go): registers `fragment` (route based and component based).
+- [`job_spec.go`](../../../internal/parser/job_spec.go): registers `job` and `retry`.
+- [`layout_spec.go`](../../../internal/parser/layout_spec.go): registers `layout`.
+- [`limit_spec.go`](../../../internal/parser/limit_spec.go): registers `limit` (rate limit rule).
+- [`log_spec.go`](../../../internal/parser/log_spec.go): registers `log` configuration.
+- [`model_spec.go`](../../../internal/parser/model_spec.go): registers `model`, a table declaration with typed fields and constraints.
+- [`page_spec.go`](../../../internal/parser/page_spec.go): registers `page`, an HTTP route and view.
+- [`permissions_spec.go`](../../../internal/parser/permissions_spec.go): registers `permissions`, role based access rules.
+- [`query_spec.go`](../../../internal/parser/query_spec.go): registers `query`, used both top level (named query) and inside bodies.
+- [`schedule_spec.go`](../../../internal/parser/schedule_spec.go): registers `schedule`, interval or cron task.
+- [`socket_spec.go`](../../../internal/parser/socket_spec.go): registers `socket`, bidirectional WebSocket endpoint.
+- [`stream_spec.go`](../../../internal/parser/stream_spec.go): registers `stream`, SSE endpoint that pushes results on an interval.
+- [`test_spec.go`](../../../internal/parser/test_spec.go): registers `test`, end to end browser style scenario.
+- [`translations_spec.go`](../../../internal/parser/translations_spec.go): registers `translations`, i18n strings keyed by language and key.
+- [`webhook_spec.go`](../../../internal/parser/webhook_spec.go): registers `webhook`, external event receiver at a path.
+
+## Key behaviors and gotchas
+
+**Error recovery.** `parserState.addError` records a `multiError` entry and flips `recovery = true`. `synchronize()` then advances tokens until the next top level keyword (column 1 indent). The keyword switch in `Parse` uses `continue` after each error so unrelated entities still parse.
+
+**Source retention.** `Parse` keeps `lines := strings.Split(source, "\n")` on `parserState`. Parsers extract raw SQL, raw HTML templates, and computed field expressions directly from the original lines rather than reconstructing from tokens. This preserves whitespace, capitalisation, and embedded punctuation.
+
+**Named query resolution lives in `Parse`, not the optimizer.** After all top level entities are parsed, `Parse` walks `Pages`, `Actions`, `Fragments`, `APIs`, `Schedules`, `Jobs`, `Webhooks`, and `Sockets` and rewrites any `NodeQuery` whose `SQL` is just a bare identifier to the registered SQL from `app.NamedQueries`. The optimizer assumes this has already happened.
+
+**`Action` and `Page` share a struct.** `App.Actions`, `App.Fragments`, and `App.APIs` are all `[]Page`. They are distinguished by which slice they live on and by `Page.Method`. This lets layout, `requires`, and body handling be reused.
+
+**Tenant fields are not present in source.** `parseModel` records `model.Tenant`. The `<tenant>_id` reference column is materialised later during DDL generation; the analyzer is aware of this and does not flag the missing field.
+
+**Component fragments versus route fragments.** `parseFragment` switches on whether the next token is a path or `name(args)`. Component fragments populate `Page.FragmentArgs`; route fragments leave it nil. The analyzer's [`checkFragmentComponents`](../../../internal/analyzer/analyzer.go) relies on this distinction.
+
+**Multi error type.** `multiError` is unexported; callers should treat the returned error as opaque or call `Error()` and split on newlines. The CLI prints each line.
+
+**Top level `query` declarations are named queries.** Inside `Parse`, an unnamed top level `query` raises an error: SQL captured at the top level must have a name to be reusable. This is also where `app.NamedQueries` is populated and merged across multiple `query` blocks.
+
+**Translations are merge keyed.** Multiple `translations` blocks are folded together: existing keys for the same language are overwritten by later blocks. Authors who want strict separation should keep one block per language file.
+
+**`Permission` is flattened.** `parsePermissions` returns a slice that is appended to `app.Permissions`. Multiple `permissions` blocks therefore concatenate; ordering follows source order.
+
+**Custom field manifests are loaded out of band.** `parseModel` records `model.CustomFieldsFile` and `model.CustomFieldsFallback` only. The actual manifest parsing happens through `ParseManifest` which is called by the CLI build pipeline once the file has been resolved on disk; the resulting `CustomFieldManifest` is then attached to `app.CustomManifests`.
+
+**Computed fields keep raw source.** `Field.ComputedExpr` is populated from `extractComputedExprFromLine`, which slices the original source rather than rebuilding from tokens, preserving operators and parentheses verbatim.
+
+**Layouts capture raw HTML.** `Layout.HTMLContent` is the indented block from the source file. Placeholders `{page.title}`, `{page.content}`, and `{nav}` are interpreted at render time, not parse time.
+
+## Testing entry points
+
+- Top level parse coverage: [`parser_test.go`](../../../internal/parser/parser_test.go).
+- Spec consistency: [`spec_test.go`](../../../internal/parser/spec_test.go).
+- Domain specific scenarios: `requires_clauses_test.go`, `requires_clause_test.go`, `dynamic_fields_test.go`, `computed_test.go`, `fragment_component_test.go`.
+- Benchmarks and fuzz: `bench_test.go`, `fuzz_test.go`.
+- Fixtures live under [`testdata/`](../../../internal/parser/testdata).
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/packages/parser.md
+++ b/docs/contributors/packages/parser.md
@@ -6,7 +6,7 @@
 |---|---|
 | **Import path** | `github.com/kilnx-org/kilnx/internal/parser` |
 | **Source last touched** | `5da8498` (2026-05-08) |
-| **Doc last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `d2d0978` (2026-05-08) |
 
 
 ## Overview

--- a/docs/contributors/packages/pathutil.md
+++ b/docs/contributors/packages/pathutil.md
@@ -1,0 +1,80 @@
+# `internal/pathutil`
+
+> Package pathutil provides helpers for matching declarative route templates (e.g. "/tasks/:id/delete") against concrete request paths (e.g. "/tasks/123/delete").
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/pathutil` |
+| **Source last touched** | `cadd7a0` (2026-05-05) |
+
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`match.go`](../../../internal/pathutil/match.go) | _no file-level doc_ |
+
+## Functions
+
+### `Match`
+
+```go
+func Match(template, path string) bool
+```
+
+Match reports whether template (a route pattern with optional :param segments)
+matches path (a concrete URL path). Both must have the same number of segments.
+Segments starting with ':' in template act as wildcards.
+
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# `internal/pathutil`
+
+Tiny helper for matching declarative route templates against concrete request paths. One file, one function.
+
+## Purpose
+
+Kilnx routes are written as templates like `/tasks/:id/delete`. At request time the runtime needs to know whether a concrete path like `/tasks/123/delete` matches a declared template, and (separately) extract the wildcard values. `pathutil.Match` answers the boolean half of that question.
+
+## File map
+
+- [`match.go`](../../../internal/pathutil/match.go): the entire package. Defines [`Match(template, path string) bool`](../../../internal/pathutil/match.go).
+
+## Public surface
+
+```go
+func Match(template, path string) bool
+```
+
+That is the whole API.
+
+## Semantics
+
+- Both inputs are split on `/`. Empty segments are kept (so leading/trailing slashes count).
+- The two splits must produce the **same number of segments**. A template with N parts never matches a path with N+1 parts, even if the extra segment is empty.
+- A template segment that begins with `:` is a wildcard. It accepts any value, including empty string.
+- Every other template segment must match the corresponding path segment by exact byte equality. No case folding, no normalization, no escape handling.
+
+## Examples
+
+| Template | Path | Result |
+|---|---|---|
+| `/tasks/:id` | `/tasks/123` | true |
+| `/tasks/:id` | `/tasks/123/edit` | false (segment count differs) |
+| `/tasks/:id` | `/tasks/` | true (`:id` matches empty) |
+| `/tasks/new` | `/tasks/New` | false (case sensitive) |
+| `/a/:b/:c` | `/a/x/y` | true |
+
+## Gotchas
+
+- **Equal-segment requirement**: the function never treats `:id` as "match the rest". There is no greedy or catch-all wildcard. If you need optional trailing segments, declare separate routes.
+- **Empty segments match wildcards**: `/tasks/:id` matches `/tasks/`. The runtime relies on this for some default-value behaviors. Validate emptiness at the handler if you need a non-empty id.
+- **No parameter extraction here**: `Match` only returns a boolean. The runtime extracts the actual `:param` values via `matchPathParams` in [`internal/runtime/server.go`](../../../internal/runtime/server.go), which uses the same splitting rule. If you change `Match`'s splitting strategy, change both.
+- **Case sensitivity**: paths are compared byte-for-byte. URL paths arriving from `net/http` are not normalized by Kilnx before this check.
+
+## When to touch this file
+
+Almost never. The function is small, well covered by [`match_test.go`](../../../internal/pathutil/match_test.go), and used from the hot path of every request. Behavior changes here ripple through the entire runtime router.
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/packages/pdf.md
+++ b/docs/contributors/packages/pdf.md
@@ -1,0 +1,501 @@
+# `internal/pdf`
+
+> Package pdf is a minimal, dependency-free PDF writer used by the runtime to render reports and printable views from .kilnx pages.
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/pdf` |
+| **Source last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `5da8498` (2026-05-08) |
+
+
+## Overview
+
+The package emits a small subset of the PDF 1.4 specification (text,
+tables, basic fonts, page layout). It is intentionally not a general
+PDF library: it covers what Kilnx applications need to produce
+invoices, statements, and tabular reports without pulling in a heavy
+dependency.
+
+Build a document by creating a [Document], adding pages, and writing
+to an io.Writer.
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`document.go`](../../../internal/pdf/document.go) | _no file-level doc_ |
+| [`fonts.go`](../../../internal/pdf/fonts.go) | _no file-level doc_ |
+| [`page.go`](../../../internal/pdf/page.go) | _no file-level doc_ |
+| [`table.go`](../../../internal/pdf/table.go) | _no file-level doc_ |
+| [`writer.go`](../../../internal/pdf/writer.go) | _no file-level doc_ |
+
+## Types
+
+### `Document`
+
+```go
+type Document struct {
+	title		string
+	footer		string
+	pages		[]*Page
+	pageSize	PageSize
+}
+```
+
+Document is a minimal PDF builder (no external deps). Build a document by
+adding pages via [Document.AddPage] and serialize it with [Document.Render].
+
+### `FontMetrics`
+
+```go
+type FontMetrics struct {
+	Name	string
+	Widths	[256]int	// glyph width per WinAnsiEncoding code point
+}
+```
+
+FontMetrics holds glyph widths for a built-in font
+
+### `Margins`
+
+```go
+type Margins struct {
+	Top	float64
+	Right	float64
+	Bottom	float64
+	Left	float64
+}
+```
+
+Margins defines page margins in points
+
+### `Page`
+
+```go
+type Page struct {
+	size		PageSize
+	margins		Margins
+	ops		[]pageOp
+	document	*Document
+}
+```
+
+Page represents a single PDF page with content operations
+
+### `PageSize`
+
+```go
+type PageSize struct {
+	Width	float64
+	Height	float64
+}
+```
+
+PageSize defines the dimensions of a page
+
+### `opKind`
+
+```go
+type opKind int
+```
+### `pageOp`
+
+```go
+type pageOp struct {
+	kind	opKind
+	text	string
+	space	float64
+	table	*tableData
+}
+```
+### `pdfWriter`
+
+```go
+type pdfWriter struct {
+	buf	[]byte
+	offsets	[]int	// byte offset of each object (1-indexed, offsets[0] unused)
+	nextObj	int
+}
+```
+
+pdfWriter serializes a Document into valid PDF 1.4 binary format
+
+### `streamBuilder`
+
+```go
+type streamBuilder struct {
+	data []byte
+}
+```
+
+streamBuilder wraps a byte buffer for PDF content stream writing
+
+### `tableData`
+
+```go
+type tableData struct {
+	Headers	[]string
+	Rows	[][]string
+}
+```
+### `tableRenderer`
+
+```go
+type tableRenderer struct {
+	headers		[]string
+	rows		[][]string
+	colWidths	[]float64
+	tableWidth	float64
+	rowHeight	float64
+	headerBg	[3]float64	// RGB 0-1
+	evenRowBg	[3]float64	// RGB 0-1
+	borderGray	float64
+}
+```
+
+tableRenderer handles rendering a table into PDF content stream operations
+
+## Functions
+
+### `NewDocument`
+
+```go
+func NewDocument() *Document
+```
+
+NewDocument creates a new PDF document with A4 page size
+
+### `encodeWinAnsi`
+
+```go
+func encodeWinAnsi(s string) []byte
+```
+
+encodeWinAnsi converts a UTF-8 string to WinAnsiEncoding bytes.
+Covers ASCII and Latin-1 supplement (Portuguese accents, etc.).
+
+### `escapePDFString`
+
+```go
+func escapePDFString(data []byte) string
+```
+
+escapePDFString escapes a WinAnsi byte slice for use in a PDF string literal
+
+### `estimatePageCount`
+
+```go
+func estimatePageCount(pg *Page, doc *Document, margins Margins, usableHeight float64) int
+```
+
+estimatePageCount gives a rough page count for footer rendering
+
+### `newPDFWriter`
+
+```go
+func newPDFWriter() *pdfWriter
+```
+### `newTableRenderer`
+
+```go
+func newTableRenderer(headers []string, rows [][]string, availableWidth float64) *tableRenderer
+```
+### `renderPageContent`
+
+```go
+func renderPageContent(pg *Page, doc *Document) [][]byte
+```
+
+renderPageContent renders a page's operations into one or more content stream byte slices
+(multiple if content overflows and creates extra pages)
+
+### `replaceAll`
+
+```go
+func replaceAll(s, old, new string) string
+```
+### `splitWords`
+
+```go
+func splitWords(s string) []string
+```
+### `wrapText`
+
+```go
+func wrapText(text string, maxWidth float64, fm *FontMetrics, fontSize float64) []string
+```
+
+wrapText wraps a string into lines that fit within maxWidth at the given font size
+
+### `(Document) AddPage`
+
+```go
+func (d *Document) AddPage() *Page
+```
+
+AddPage adds a new page and returns it for adding content
+
+### `(Document) Render`
+
+```go
+func (d *Document) Render() []byte
+```
+
+Render produces the final PDF bytes
+
+### `(Document) SetFooter`
+
+```go
+func (d *Document) SetFooter(footer string)
+```
+
+SetFooter sets the footer text. Use {page} and {pages} as placeholders.
+
+### `(Document) SetPageSize`
+
+```go
+func (d *Document) SetPageSize(size PageSize)
+```
+
+SetPageSize sets the page size for new pages
+
+### `(Document) SetTitle`
+
+```go
+func (d *Document) SetTitle(title string)
+```
+
+SetTitle sets the document title (appears in PDF metadata)
+
+### `(FontMetrics) TextWidth`
+
+```go
+func (fm *FontMetrics) TextWidth(text string, fontSize float64) float64
+```
+
+TextWidth calculates the width of a string in points at the given font size
+
+### `(Page) AddHeading`
+
+```go
+func (p *Page) AddHeading(text string)
+```
+
+AddHeading adds large bold heading text
+
+### `(Page) AddSpace`
+
+```go
+func (p *Page) AddSpace(points float64)
+```
+
+AddSpace adds vertical space in points
+
+### `(Page) AddTable`
+
+```go
+func (p *Page) AddTable(headers []string, rows [][]string)
+```
+
+AddTable adds a table with headers and rows
+
+### `(Page) AddText`
+
+```go
+func (p *Page) AddText(text string)
+```
+
+AddText adds a regular paragraph
+
+### `(Page) SetMargins`
+
+```go
+func (p *Page) SetMargins(top, right, bottom, left float64)
+```
+
+SetMargins sets page margins
+
+### `(pdfWriter) allocObj`
+
+```go
+func (w *pdfWriter) allocObj() int
+```
+### `(pdfWriter) endObj`
+
+```go
+func (w *pdfWriter) endObj()
+```
+### `(pdfWriter) render`
+
+```go
+func (w *pdfWriter) render(doc *Document) []byte
+```
+### `(pdfWriter) startObj`
+
+```go
+func (w *pdfWriter) startObj(id int)
+```
+### `(pdfWriter) write`
+
+```go
+func (w *pdfWriter) write(s string)
+```
+### `(pdfWriter) writeF`
+
+```go
+func (w *pdfWriter) writeF(format string, args ...interface{})
+```
+### `(streamBuilder) writeF`
+
+```go
+func (sb *streamBuilder) writeF(format string, args ...interface{})
+```
+### `(streamBuilder) writeS`
+
+```go
+func (sb *streamBuilder) writeS(s string)
+```
+### `(tableRenderer) calculateColumnWidths`
+
+```go
+func (tr *tableRenderer) calculateColumnWidths(availableWidth float64)
+```
+### `(tableRenderer) render`
+
+```go
+func (tr *tableRenderer) render(buf *streamBuilder, x, y float64, maxHeight float64) (float64, int)
+```
+
+render writes the table into a content stream buffer at the given position.
+Returns the height consumed.
+
+### `(tableRenderer) totalHeight`
+
+```go
+func (tr *tableRenderer) totalHeight() float64
+```
+
+totalHeight returns the total height needed for the table
+
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# `internal/pdf`
+
+Minimal, dependency-free PDF 1.4 writer used by the runtime to render reports and printable views.
+
+## Purpose
+
+Some Kilnx apps need to emit invoices, statements, and tabular reports. Rather than depend on a heavyweight PDF library, the runtime ships a small writer that handles exactly what those use cases need: text, headings, vertical spacing, and paginated tables.
+
+This package is intentionally **not** a general PDF library. It does not handle images, vector graphics, custom fonts, encryption, forms, annotations, hyperlinks, or anything else outside the narrow report use case. Adding any of those is a non-goal: if you need them, switch to a real PDF library.
+
+## File map
+
+- [`doc.go`](../../../internal/pdf/doc.go): package doc.
+- [`document.go`](../../../internal/pdf/document.go): high-level `Document` and `Page` collection. Public API entry point.
+- [`page.go`](../../../internal/pdf/page.go): `Page`, `PageSize` (A4, Letter), `Margins`, content-op queue.
+- [`fonts.go`](../../../internal/pdf/fonts.go): glyph metrics for Helvetica and Helvetica-Bold under WinAnsiEncoding, plus the WinAnsi encoder and PDF string escaper.
+- [`table.go`](../../../internal/pdf/table.go): table layout and rendering into a content stream buffer (`tableRenderer`, `streamBuilder`).
+- [`writer.go`](../../../internal/pdf/writer.go): low-level `pdfWriter` that emits the actual PDF 1.4 byte stream (header, objects, xref, trailer).
+
+## Public surface
+
+```go
+func NewDocument() *Document
+(d *Document) SetTitle(title string)
+(d *Document) SetFooter(footer string)              // {page} and {pages} placeholders
+(d *Document) SetPageSize(size PageSize)            // A4 (default) or Letter
+(d *Document) AddPage() *Page
+(d *Document) Render() []byte
+
+(p *Page) AddHeading(text string)
+(p *Page) AddText(text string)
+(p *Page) AddSpace(points float64)
+(p *Page) AddTable(headers []string, rows [][]string)
+(p *Page) SetMargins(top, right, bottom, left float64)
+
+A4, Letter PageSize
+```
+
+Build a document, fill pages with operations, call `Render()`, write the bytes.
+
+## Document model
+
+A `Document` holds a list of `*Page` and document-level metadata (title, footer, page size). Each `Page` is a queue of `pageOp` values (heading, text, space, table). Nothing is laid out at append time. `Document.Render` walks the queue and produces PDF bytes in a two-pass process inside `writer.go`.
+
+Operations:
+
+- `opHeading`: 18pt Helvetica-Bold, advances 24 points.
+- `opText`: 11pt Helvetica, word-wrapped to content width via `wrapText`, 15 points per line.
+- `opSpace`: pure vertical advance, no glyphs.
+- `opTable`: routed through `tableRenderer` (see below).
+
+Pagination is handled in `renderPageContent`: when an op would dip below `bottomY` (which reserves 30 points for the footer above the bottom margin), the current content stream is finished and a new page is started. Tables that overflow are split row-by-row across page boundaries; the header row is repeated on each continuation by recreating a `tableRenderer` for the remaining rows.
+
+## Tables
+
+`tableRenderer` (in `table.go`) does column sizing in one pass:
+
+1. Compute "natural" width per column from the widest header (bold font) or cell (regular font), plus 10 points of padding.
+2. Sum the natural widths. Whether the total is larger or smaller than the available content width, scale every column by `availableWidth/totalNatural`. So columns are always proportionally distributed across the full content area.
+3. Truncate cell text by chopping bytes off the end until it fits within `colWidth - 8` at 9pt. **Byte-level truncation, not rune-level**, so multibyte UTF-8 strings can be cut mid-codepoint. In practice the WinAnsi encoder downstream catches the result, but the truncation is technically lossy on non-Latin text.
+
+Visual style is fixed:
+
+- Header row: dark blue (`{0.2, 0.4, 0.6}` RGB), white bold text.
+- Even data rows: light gray zebra stripe (`{0.94, 0.94, 0.94}`).
+- Borders: gray (`0.75`) horizontal lines under the header and between rows.
+- Row height: 20 points. Font: 9pt.
+
+These are constants. There is no theming API.
+
+## Fonts and encoding
+
+Two built-in fonts: Helvetica and Helvetica-Bold. They use the standard PDF core-font widths under WinAnsiEncoding, giving Latin-1 coverage including Portuguese accents.
+
+`encodeWinAnsi` (in `fonts.go`) maps UTF-8 input to WinAnsi bytes:
+
+- ASCII (`< 128`): pass through.
+- Latin-1 supplement (`0xA0..0xFF`): pass through directly.
+- A handful of common Unicode punctuation (en/em dash, smart quotes, bullet, euro): mapped to their WinAnsi positions.
+- Anything else: emitted as `?`.
+
+`escapePDFString` wraps a byte slice in PDF string-literal parentheses and escapes `(`, `)`, `\`. No hex-string fallback; only literal strings are emitted.
+
+`FontMetrics.TextWidth` returns string width in points at a given font size. Glyphs not in the 256-entry WinAnsi width table fall back to a default of 500 units.
+
+## PDF object structure
+
+`pdfWriter.render` emits the standard PDF 1.4 layout:
+
+1. `%PDF-1.4` header plus a four-byte binary comment so file-type sniffers recognise it.
+2. Object 1: Catalog, pointing to the Pages object.
+3. Object 2: Pages tree containing all per-page object IDs as `Kids` and a `Count`.
+4. Objects 3 and 4: Helvetica and Helvetica-Bold Type1 font objects, both with WinAnsiEncoding.
+5. Two objects per logical page: the Page dictionary (MediaBox, Contents reference, Font resources `F1`/`F2`) and the content stream object.
+6. `xref` table with offsets recorded as the writer goes.
+7. `trailer` with `/Size`, `/Root`, optional `/Info << /Title ... >>`, then `startxref` and `%%EOF`.
+
+The render function does a small two-pass dance: it walks pages once to count them, throws away the buffer, resets allocators, then walks again with the now-known IDs. This is safer than threading IDs through the layout code.
+
+## Gotchas
+
+- **Subset only**. No images, no vector graphics, no custom fonts. Anything outside text/heading/space/table is out of scope. PRs adding general PDF features will be rejected unless they keep the dependency-free, narrow-purpose contract intact.
+- **WinAnsi only**. Characters outside Latin-1 plus the small Unicode allowlist render as `?`. Non-Latin scripts (CJK, Arabic, etc.) cannot be rendered. The package exists for Brazilian/European business reports, not internationalized typesetting.
+- **Byte truncation in tables**. `tableRenderer.render` truncates cell text via `text[:len(text)-1]` until it fits. Multibyte runes can be sliced; output is then unpredictable through `encodeWinAnsi`.
+- **Naive `replaceAll`**. `writer.go` defines a private `replaceAll` rather than using `strings.ReplaceAll`. It is correct but quadratic. Footers are short, so it does not matter, just do not lift it.
+- **Byte-level offsets in `xref`**. Anything that reorders writes inside `pdfWriter` must continue to call `startObj` exactly once before each object. Forgetting that produces a `xref` with stale offsets and a corrupt file.
+- **Footer page count is an estimate**. `estimatePageCount` adds up op heights divided by usable height plus one. It is only used for the footer placeholder `{pages}`, so off-by-one errors are visible to the user.
+- **A `Document` is single-use**. `Render` mutates internal state inside `pdfWriter` and is not idempotent across calls. If you need two outputs, build two documents.
+
+## When to touch this package
+
+- New op kind (e.g. images): add to `opKind` enum, extend `Page` API, render in `renderPageContent`.
+- New page size: add a `PageSize` var to `page.go`.
+- Locale-specific punctuation: extend the `encodeWinAnsi` switch.
+
+For anything else, the right answer is usually "use a real PDF library outside the kilnx tree".
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/packages/runtime.md
+++ b/docs/contributors/packages/runtime.md
@@ -1,0 +1,2719 @@
+# `internal/runtime`
+
+> Package runtime is the HTTP server and AST interpreter that backs `kilnx run` and the binaries produced by `kilnx build`.
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/runtime` |
+| **Source last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `5da8498` (2026-05-08) |
+
+
+## Overview
+
+Responsibilities:
+
+  - HTTP routing, request parsing, and response rendering for
+    pages, actions, fragments, APIs, websockets, and streams.
+  - Built-in authentication (email/password, sessions, CSRF).
+  - Form handling and validation.
+  - Background jobs, scheduled tasks, and webhook delivery.
+  - Email sending, file uploads, and SSR template rendering.
+  - Live reload during development.
+
+The runtime executes the parser AST directly: there is no
+intermediate code generation step at run time. The optimizer
+rewrites the AST before the runtime sees it. For ahead-of-time
+builds, package internal/build embeds the runtime alongside the
+AST so the resulting binary has no compile-time dependency on the
+kilnx CLI.
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`api.go`](../../../internal/runtime/api.go) | _no file-level doc_ |
+| [`auth.go`](../../../internal/runtime/auth.go) | _no file-level doc_ |
+| [`computed.go`](../../../internal/runtime/computed.go) | _no file-level doc_ |
+| [`dynamic_fields.go`](../../../internal/runtime/dynamic_fields.go) | _no file-level doc_ |
+| [`email.go`](../../../internal/runtime/email.go) | _no file-level doc_ |
+| [`expr.go`](../../../internal/runtime/expr.go) | _no file-level doc_ |
+| [`fetch.go`](../../../internal/runtime/fetch.go) | _no file-level doc_ |
+| [`forms.go`](../../../internal/runtime/forms.go) | _no file-level doc_ |
+| [`i18n.go`](../../../internal/runtime/i18n.go) | _no file-level doc_ |
+| [`interfaces.go`](../../../internal/runtime/interfaces.go) | _no file-level doc_ |
+| [`layout.go`](../../../internal/runtime/layout.go) | _no file-level doc_ |
+| [`llm.go`](../../../internal/runtime/llm.go) | _no file-level doc_ |
+| [`logger.go`](../../../internal/runtime/logger.go) | _no file-level doc_ |
+| [`permissions.go`](../../../internal/runtime/permissions.go) | _no file-level doc_ |
+| [`query_conditional.go`](../../../internal/runtime/query_conditional.go) | _no file-level doc_ |
+| [`ratelimit.go`](../../../internal/runtime/ratelimit.go) | _no file-level doc_ |
+| [`render.go`](../../../internal/runtime/render.go) | _no file-level doc_ |
+| [`scheduler.go`](../../../internal/runtime/scheduler.go) | _no file-level doc_ |
+| [`server.go`](../../../internal/runtime/server.go) | _no file-level doc_ |
+| [`stream.go`](../../../internal/runtime/stream.go) | _no file-level doc_ |
+| [`tenant.go`](../../../internal/runtime/tenant.go) | _no file-level doc_ |
+| [`testing.go`](../../../internal/runtime/testing.go) | _no file-level doc_ |
+| [`unfurl.go`](../../../internal/runtime/unfurl.go) | _no file-level doc_ |
+| [`watcher.go`](../../../internal/runtime/watcher.go) | _no file-level doc_ |
+| [`webhook.go`](../../../internal/runtime/webhook.go) | _no file-level doc_ |
+| [`websocket.go`](../../../internal/runtime/websocket.go) | _no file-level doc_ |
+
+## Types
+
+### `AppRuntime`
+
+```go
+type AppRuntime interface {
+	RenderPage(path string, r *http.Request) (string, error)
+	HandleAction(w http.ResponseWriter, r *http.Request, action parser.Page, app *parser.App) error
+	HandleAPI(w http.ResponseWriter, r *http.Request, api parser.Page)
+}
+```
+
+AppRuntime is the interface implemented by *Server.
+It exists to allow tests and downstream packages to depend on an abstraction
+rather than the concrete Server type.
+
+### `EmailConfig`
+
+```go
+type EmailConfig struct {
+	Host		string	// KILNX_SMTP_HOST (default: localhost)
+	Port		string	// KILNX_SMTP_PORT (default: 25)
+	User		string	// KILNX_SMTP_USER
+	Password	string	// KILNX_SMTP_PASS
+	From		string	// KILNX_SMTP_FROM (default: noreply@localhost)
+}
+```
+
+EmailConfig holds SMTP settings from environment variables
+
+### `I18n`
+
+```go
+type I18n struct {
+	translations	map[string]map[string]string	// lang -> key -> value
+	defaultLanguage	string
+	detectLanguages	bool	// whether to detect language from request headers/params
+}
+```
+
+I18n manages translations
+
+### `JobQueue`
+
+```go
+type JobQueue struct {
+	server	*Server
+	jobs	map[string]parser.Job
+	mu	sync.RWMutex
+}
+```
+
+JobQueue manages async background jobs with SQLite persistence and retry support
+
+### `Logger`
+
+```go
+type Logger struct {
+	config *parser.LogConfig
+}
+```
+
+Logger wraps request handling with logging
+
+### `PaginateInfo`
+
+```go
+type PaginateInfo struct {
+	Page	int
+	PerPage	int
+	Total	int
+	HasPrev	bool
+	HasNext	bool
+}
+```
+
+PaginateInfo holds pagination state for a query
+
+### `PermissionMap`
+
+```go
+type PermissionMap map[string]map[string][]PermissionRule
+```
+
+PermissionMap indexes role -> model -> rules for fast runtime lookup.
+Model names are lower-cased.  The special key "*" holds wildcard rules
+produced by the "all" action.
+
+### `PermissionRule`
+
+```go
+type PermissionRule struct {
+	Action		string	// "all", "read", "write"
+	Resource	string	// lower-cased model name
+	Condition	string	// raw condition after "where", or empty
+}
+```
+
+PermissionRule represents a single parsed rule from the permissions block.
+
+### `RateLimiter`
+
+```go
+type RateLimiter struct {
+	mu	sync.Mutex
+	entries	map[string]*rateLimitEntry
+	rules	[]parser.RateLimit
+}
+```
+
+RateLimiter applies path-scoped fixed-window rate limits keyed by IP or
+user. Entries expire on a background sweep; auth endpoints get sane
+defaults when the developer hasn't configured them.
+
+### `Room`
+
+```go
+type Room struct {
+	mu	sync.RWMutex
+	clients	map[net.Conn]bool
+}
+```
+
+Room manages connected WebSocket clients for a path
+
+### `Server`
+
+```go
+type Server struct {
+	app			*parser.App
+	db			database.Executor
+	sessions		*SessionStore
+	jobQueue		*JobQueue
+	rateLimiter		*RateLimiter
+	logger			*Logger
+	i18n			*I18n
+	tenants			TenantMap		// models with a `tenant: <model>` directive
+	manifestCache		sync.Map		// resolved path -> *parser.CustomFieldManifest (dynamic manifests)
+	superuserIdentity	string			// identity of the platform operator; bypasses all role checks
+	fragmentComponents	map[string]*parser.Page	// component name -> fragment (for inline rendering)
+	mu			sync.RWMutex
+	tenantWarnOnce		sync.Once
+	port			int
+	scheduleStop		chan struct{}
+}
+```
+
+Server is the runtime HTTP server hosting a parsed Kilnx App. It owns the
+database executor, session store, job queue, rate limiter, logger and
+i18n table, and routes requests to page, action, fragment and API
+handlers.
+
+### `Session`
+
+```go
+type Session struct {
+	UserID		string
+	Identity	string
+	Role		string
+	ExpiresAt	time.Time
+	Data		database.Row	// full user row
+}
+```
+
+Session stores authenticated user data
+
+### `SessionStore`
+
+```go
+type SessionStore struct {
+	mu		sync.RWMutex
+	sessions	map[string]*Session
+	db		database.Executor
+	secret		string	// used for HMAC signing of session cookie values
+}
+```
+
+SessionStore manages sessions with in-memory fast path and SQLite persistence
+
+### `TenantMap`
+
+```go
+type TenantMap map[string]string
+```
+
+TenantMap indexes model name (lowercased) to the name of its tenant
+reference. e.g. {"quote": "org", "customer": "org"} means rows of
+"quote" and "customer" are scoped by org_id.
+
+### `anthropicMessage`
+
+```go
+type anthropicMessage struct {
+	Role	string	`json:"role"`
+	Content	string	`json:"content"`
+}
+```
+### `anthropicRequest`
+
+```go
+type anthropicRequest struct {
+	Model		string			`json:"model"`
+	MaxTokens	int			`json:"max_tokens"`
+	System		string			`json:"system,omitempty"`
+	Messages	[]anthropicMessage	`json:"messages"`
+}
+```
+### `anthropicResponse`
+
+```go
+type anthropicResponse struct {
+	Content	[]struct {
+		Text string `json:"text"`
+	}	`json:"content"`
+	Error	*struct {
+		Message string `json:"message"`
+	}	`json:"error"`
+}
+```
+### `csrfEntry`
+
+```go
+type csrfEntry struct {
+	createdAt time.Time
+}
+```
+
+CSRF token store with expiry (#6 fix: bounded store with TTL cleanup)
+
+### `exprParser`
+
+```go
+type exprParser struct {
+	src	string
+	pos	int
+	row	database.Row
+}
+```
+### `kxExprParser`
+
+```go
+type kxExprParser struct {
+	src	string
+	pos	int
+	params	map[string]string
+}
+```
+### `loggingResponseWriter`
+
+```go
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	statusCode	int
+}
+```
+### `ogData`
+
+```go
+type ogData struct {
+	Title		string
+	Description	string
+	Image		string
+	SiteName	string
+	URL		string
+	FetchedAt	time.Time
+}
+```
+### `parsedFilter`
+
+```go
+type parsedFilter struct {
+	Name	string
+	Args	[]string
+}
+```
+
+parsedFilter represents a single filter in a chain
+
+### `rateLimitEntry`
+
+```go
+type rateLimitEntry struct {
+	count		int
+	expiresAt	time.Time
+}
+```
+### `renderContext`
+
+```go
+type renderContext struct {
+	queries			map[string][]database.Row
+	paginate		map[string]PaginateInfo
+	currentUser		*Session
+	queryParams		map[string]string			// URL query parameters (?key=value)
+	querySourceModels	map[string]string			// query name -> primary model name (set by analyzer)
+	customManifests		map[string]*parser.CustomFieldManifest	// model name -> manifest (for list-page rebinding)
+	eachStack		[]database.Row				// stack of active {{each}} rows for parent-scope resolution
+	eachModels		[]string				// parallel stack of source model names for each entry in eachStack ("" if unknown)
+	models			[]parser.Model				// all models, for resolving computed fields
+	currentRow		database.Row				// active row when inside {{each}} block
+	fragmentArgs		map[string]string			// active component argument bindings
+	fragmentDepth		int					// recursion guard for component fragments
+	fragmentComponents	map[string]*parser.Page			// component name -> fragment (for inline rendering)
+	actions			[]parser.Page				// declared actions for action= attribute expansion
+	i18n			*I18n					// translation engine
+	request			*http.Request				// current HTTP request (for language detection)
+}
+```
+
+renderContext holds query results available during template rendering
+
+### `rowQuerier`
+
+```go
+type rowQuerier interface {
+	QueryRowsWithParams(sqlStr string, params map[string]string) ([]database.Row, error)
+}
+```
+### `stdlibFn`
+
+```go
+type stdlibFn func(args []string) (string, error)
+```
+
+stdlibFn implements a Kilnx stdlib function. All values are stringly typed
+(Kilnx is string-first end-to-end); functions parse / format on demand.
+
+## Functions
+
+### `BuildPermissionMap`
+
+```go
+func BuildPermissionMap(app *parser.App) PermissionMap
+```
+
+BuildPermissionMap parses the raw permission strings from the AST into a
+structured map for fast runtime lookups.
+
+### `BuildTenantMap`
+
+```go
+func BuildTenantMap(app *parser.App) TenantMap
+```
+
+BuildTenantMap returns a lookup of tenant-scoped models from an app.
+Model names are lowercased for case-insensitive matching. The tenant
+reference value is preserved as written so FK column generation stays
+consistent with `fieldToColumnName`.
+
+### `CheckPassword`
+
+```go
+func CheckPassword(password, hash string) bool
+```
+
+CheckPassword compares a plaintext password with a bcrypt hash
+
+### `HashPassword`
+
+```go
+func HashPassword(password string) (string, error)
+```
+
+HashPassword hashes a plaintext password with bcrypt
+
+### `LoadEmailTemplate`
+
+```go
+func LoadEmailTemplate(templateName string, params map[string]string) string
+```
+
+LoadEmailTemplate loads a template file and interpolates {key} placeholders
+
+### `NewI18n`
+
+```go
+func NewI18n(translations map[string]map[string]string, defaultLang string, detect bool) *I18n
+```
+
+NewI18n returns an I18n with the given lang->key->value map. If detect is
+true the user's language is resolved from request headers and params,
+otherwise defaultLang is always used. Empty defaultLang falls back to "en".
+
+### `NewJobQueue`
+
+```go
+func NewJobQueue(server *Server) *JobQueue
+```
+
+NewJobQueue returns a JobQueue that knows about the job definitions in
+server's app. Call Start to begin processing.
+
+### `NewLogger`
+
+```go
+func NewLogger(config *parser.LogConfig) *Logger
+```
+
+NewLogger returns a Logger using config, falling back to sensible defaults
+(info level, 100ms slow-query threshold, errors logged) when config is nil.
+
+### `NewRateLimiter`
+
+```go
+func NewRateLimiter(rules []parser.RateLimit) *RateLimiter
+```
+
+NewRateLimiter returns a RateLimiter applying rules plus implicit defaults
+for auth endpoints (login, register, forgot-password) and starts a
+background goroutine that prunes expired entries.
+
+### `NewServer`
+
+```go
+func NewServer(app *parser.App, db database.Executor, port int) *Server
+```
+
+NewServer wires app and db into a Server listening on port. It builds the
+session store, job queue, rate limiter, logger, tenant map, fragment
+component index and i18n table from app's config.
+
+### `NewSessionStore`
+
+```go
+func NewSessionStore(secret string) *SessionStore
+```
+
+NewSessionStore returns a SessionStore that signs cookies with secret and
+runs a background goroutine to expire stale sessions. If secret is empty a
+random fallback is generated and a warning is logged to stderr.
+
+### `RewritePermissionSQL`
+
+```go
+func RewritePermissionSQL(sql string, pm PermissionMap, role string, params map[string]string) (string, error)
+```
+
+RewritePermissionSQL rewrites a SELECT query to include the permission
+condition in the WHERE clause.  It follows the same structural conventions
+as RewriteTenantSQL but operates on permission rules rather than tenants.
+
+If the user's role has no conditional restriction for the queried table,
+the SQL is returned unchanged.
+
+### `RewriteTenantSQL`
+
+```go
+func RewriteTenantSQL(sql string, tenants TenantMap, params map[string]string) (string, error)
+```
+
+RewriteTenantSQL rewrites a SELECT query against a tenant-scoped table
+to include `WHERE <qualifier>.<tenant>_id = :current_user.<tenant>_id`.
+Behaviour summary:
+
+  - Empty tenant map: no-op, returns sql unchanged.
+  - Non-tenant table: returns sql unchanged.
+  - Mutations (INSERT/UPDATE/DELETE) on a tenant table: validated via
+    CheckTenantMutation, never rewritten.
+  - Tenant-scoped SELECT we can safely rewrite: returns rewritten SQL.
+  - Tenant-scoped SELECT we cannot parse safely: returns ErrUnsafeTenantShape.
+  - No `current_user.<tenant>_id` in params: returns ErrMissingTenantParam.
+
+Callers MUST NOT execute the original SQL on error. This is the
+defense-in-depth contract: when in doubt, fail the query.
+
+This is not a substitute for application-level authorization. It closes
+one specific class of bug (forgetting the tenant predicate on a SELECT)
+and refuses unsupported shapes so they are addressed by the developer.
+
+### `RunTests`
+
+```go
+func RunTests(app *parser.App, db *database.DB, baseURL string) (passed, failed int)
+```
+
+RunTests executes all test blocks and returns pass/fail counts
+
+### `SendEmail`
+
+```go
+func SendEmail(to, subject, body string) error
+```
+
+SendEmail sends an email using SMTP
+
+### `SendEmailWithAttachment`
+
+```go
+func SendEmailWithAttachment(to, subject, body, attachPath string) error
+```
+
+SendEmailWithAttachment sends an email with a file attachment using MIME multipart
+
+### `SendEmailWithTemplate`
+
+```go
+func SendEmailWithTemplate(to, subject, body, templateName string, params map[string]string) error
+```
+
+SendEmailWithTemplate sends an email, optionally using a template
+
+### `WatchAndServe`
+
+```go
+func WatchAndServe(filename string, db *database.DB, port int) error
+```
+
+WatchAndServe loads the Kilnx app at filename, starts the scheduler and
+job queue, watches the source file (and its imports) for changes to
+trigger hot reload, and serves HTTP on port. Blocks until the server exits.
+
+### `annotateFetchRows`
+
+```go
+func annotateFetchRows(rows []database.Row, status int) []database.Row
+```
+
+annotateFetchRows attaches status_code/ok to the first row so the result is
+usable through renderContext.queries (page render path).
+
+### `applyFilters`
+
+```go
+func applyFilters(value string, chain string) (string, bool)
+```
+
+applyFilters runs a filter chain on a value, returns (result, isRaw)
+
+### `applyOp`
+
+```go
+func applyOp(left string, op byte, right string) (string, error)
+```
+
+applyOp performs string-aware arithmetic. If both sides parse as numbers
+the result is numeric (int when result is whole, else float). Otherwise
+`+` falls back to string concatenation (handy for building keys/ids);
+other ops require numbers.
+
+### `arg`
+
+```go
+func arg(a []string, i int) string
+```
+### `bindFetchResult`
+
+```go
+func bindFetchResult(params map[string]string, name string, rows []database.Row, status int)
+```
+
+bindFetchResult populates params with `<name>.<key>` entries from the first
+row of the response, plus `<name>.status_code` and `<name>.ok` so users can
+branch with `on <name>.ok` / `on <name>.status_code`.
+
+### `bodyShouldBeJSON`
+
+```go
+func bodyShouldBeJSON(headers map[string]string) bool
+```
+
+bodyShouldBeJSON returns true if any user-supplied header has Content-Type
+set to a JSON media type (case-insensitive).
+
+### `boolStr`
+
+```go
+func boolStr(b bool) string
+```
+### `buildCustomIterRows`
+
+```go
+func buildCustomIterRows(row database.Row, manifest *parser.CustomFieldManifest) []database.Row
+```
+
+buildCustomIterRows creates synthetic rows for {{each q.custom}} iteration.
+Each row has name, value, label, and kind fields. Designed for detail pages
+where the query returns a single row; on list pages use {q.custom.field} dot-access.
+
+### `buildFragmentArgs`
+
+```go
+func buildFragmentArgs(argStr string, frag *parser.Page, ctx *renderContext) map[string]string
+```
+
+buildFragmentArgs parses an argument string and applies defaults for a fragment.
+
+### `buildRequestBody`
+
+```go
+func buildRequestBody(node parser.Node, params map[string]string, wantJSON bool) (io.Reader, string, error)
+```
+
+buildRequestBody resolves :param references in body values and encodes the
+result either as application/json (when wantJSON) or
+application/x-www-form-urlencoded. Returns an empty body for GET requests.
+
+### `checkTenantMutation`
+
+```go
+func checkTenantMutation(sql, scrubbed string, tenants TenantMap, params map[string]string) error
+```
+
+checkTenantMutation verifies that an INSERT / UPDATE / DELETE on a
+tenant-scoped table binds the tenant column explicitly. This is not a
+rewrite: intent must remain visible in the .kilnx source. The
+`scrubbed` argument has had comments and string literals stripped so
+we do not accept a bind needle hidden inside a comment.
+
+### `clientIP`
+
+```go
+func clientIP(r *http.Request) string
+```
+### `compareNumeric`
+
+```go
+func compareNumeric(a, b string) int
+```
+
+compareNumeric compares two string values as numbers. Returns -1, 0, or 1.
+
+### `computeAcceptKey`
+
+```go
+func computeAcceptKey(key string) string
+```
+### `csrfCleanupLoop`
+
+```go
+func csrfCleanupLoop()
+```
+### `evalAuthExpr`
+
+```go
+func evalAuthExpr(expr string, session *Session) bool
+```
+
+evalAuthExpr evaluates a boolean expression against session data.
+Supports: "field == value", "field != value", "field in ['a','b']",
+numeric comparisons, and "and"/"or" conjunctions.
+
+### `evalExpression`
+
+```go
+func evalExpression(src string, params map[string]string) (string, error)
+```
+### `evalSingleAuthCondition`
+
+```go
+func evalSingleAuthCondition(expr string, session *Session) bool
+```
+
+evalSingleAuthCondition evaluates one predicate: field op value or field in [...].
+
+### `evaluateComputedExpr`
+
+```go
+func evaluateComputedExpr(expr string, row database.Row) string
+```
+
+evaluateComputedExpr evaluates a computed field expression against a row.
+Supports: identifiers (resolved against the row), int/float literals,
++ - * / operators, parentheses. Returns the formatted value, or "" if
+any identifier is missing or non-numeric.
+
+### `evaluateCondition`
+
+```go
+func evaluateCondition(condition string, ctx *renderContext, currentRow database.Row) bool
+```
+
+evaluateCondition evaluates a condition expression.
+Supported forms:
+
+	field                                -> truthy check (non-empty, non-zero, non-false)
+	field == "value"                     -> equality
+	field != "value"                     -> inequality
+	queryName.count > 0                  -> numeric comparison
+	queryName.count == 0                 -> numeric/string equality
+	expr1 and expr2                      -> logical AND
+	expr1 or expr2                       -> logical OR
+
+### `evaluateExpect`
+
+```go
+func evaluateExpect(step parser.TestStep, lastBody string, lastStatus int, lastLocation string, db *database.DB) bool
+```
+
+evaluateExpect handles all expect assertion variants
+
+### `evaluateQueryCondition`
+
+```go
+func evaluateQueryCondition(condition string, params map[string]string) bool
+```
+
+evaluateQueryCondition evaluates a simple condition against query parameters.
+Supported forms:
+
+	params.key                -> truthy check (non-empty)
+	params.key == "value"     -> equality
+	params.key != "value"     -> inequality
+
+### `evaluateSingleCondition`
+
+```go
+func evaluateSingleCondition(condition string, ctx *renderContext, currentRow database.Row) bool
+```
+
+evaluateSingleCondition evaluates a single comparison or truthy check.
+
+### `executeFetch`
+
+```go
+func executeFetch(node parser.Node, params map[string]string) ([]database.Row, int, error)
+```
+
+executeFetch performs an HTTP request and returns the response rows plus
+the HTTP status code. A non-nil error indicates a transport-level failure
+(DNS, connection, timeout, body read) and should propagate to the caller
+so the surrounding action can roll back. HTTP 4xx/5xx are NOT treated as
+errors: the response body is parsed and the status code is returned so
+the caller may bind `<name>.status_code` / `<name>.ok` and let the user
+branch with `on`.
+
+### `executeLLM`
+
+```go
+func executeLLM(node parser.Node, db rowQuerier, params map[string]string) (string, error)
+```
+### `expandActionAttributes`
+
+```go
+func expandActionAttributes(content string, ctx *renderContext) string
+```
+
+expandActionAttributes replaces action="/path" on supported elements with
+hx-post/hx-delete/etc. It uses the matching action block's Method (always
+set by parser, defaults to POST for `action ...`) to pick the verb. For
+non-GET verbs a CSRF placeholder ({csrf}) is emitted via hx-vals; the
+surrounding pipeline replaces {csrf} with a real token. <form> elements
+are intentionally not rewritten.
+
+### `expandColumnModeFields`
+
+```go
+func expandColumnModeFields(rows []database.Row, manifest *parser.CustomFieldManifest) []database.Row
+```
+
+expandColumnModeFields adds "custom.<field>" aliases for column-mode manifest fields
+so that {q.custom.field} template access works the same as JSON-mode fields.
+
+### `expandCustomFields`
+
+```go
+func expandCustomFields(rows []database.Row) []database.Row
+```
+
+expandCustomFields parses the "custom" JSON column in each row and adds
+flattened "custom.<field>" keys so templates can access {q.custom.revenue}.
+
+### `expandEachBlocks`
+
+```go
+func expandEachBlocks(content string, ctx *renderContext, nonce string) string
+```
+
+expandEachBlocks processes all {{each queryName}}...{{else}}...{{end}} blocks.
+Uses a stack-based parser to handle nested blocks correctly.
+
+### `expandFragmentCalls`
+
+```go
+func expandFragmentCalls(content string, ctx *renderContext) string
+```
+
+expandFragmentCalls processes {{componentName arg=expr}} blocks inside HTML content.
+It looks up the component fragment, binds arguments, and renders the body inline.
+
+### `expandFragmentCallsOutsideEach`
+
+```go
+func expandFragmentCallsOutsideEach(content string, ctx *renderContext) string
+```
+
+expandFragmentCallsOutsideEach expands fragment component calls that are
+NOT inside a {{each}}...{{end}} block. Calls inside each-blocks are handled
+per-row inside expandEachBlocks (so they can reference the current row).
+
+### `expandIfBlocks`
+
+```go
+func expandIfBlocks(content string, ctx *renderContext, currentRow database.Row) string
+```
+
+expandIfBlocks processes all {{if expr}}...{{else}}...{{end}} blocks.
+currentRow is non-nil when inside an {{each}} block.
+
+### `expandPluralization`
+
+```go
+func expandPluralization(content string, ctx *renderContext, params map[string]string) string
+```
+
+expandPluralization processes {expr|plural:'singular','plural'} within a string.
+
+### `expandQueryConditionals`
+
+```go
+func expandQueryConditionals(sql string, params map[string]string) string
+```
+
+expandQueryConditionals processes {{if expr}}...{{end}} blocks inside a SQL
+string, using the provided parameters for condition evaluation. It returns the
+SQL with conditional fragments included or removed based on the evaluation.
+
+### `expandSingleFragmentCall`
+
+```go
+func expandSingleFragmentCall(match string, ctx *renderContext) string
+```
+
+expandSingleFragmentCall expands one {{name args}} occurrence using ctx.
+Returns the original match if the name is not a known component or if the
+recursion guard has fired.
+
+### `expandTranslations`
+
+```go
+func expandTranslations(content string, ctx *renderContext) string
+```
+
+expandTranslations processes {t.key} and {t.key param=expr} placeholders.
+It looks up the translation in the detected language, resolves any parameters,
+and applies pluralization filters within the translated value.
+
+### `extractCSRFFromHTML`
+
+```go
+func extractCSRFFromHTML(html string) string
+```
+### `extractEventType`
+
+```go
+func extractEventType(payload map[string]interface{}) string
+```
+### `extractFormAction`
+
+```go
+func extractFormAction(htmlContent string) string
+```
+### `extractFormData`
+
+```go
+func extractFormData(r *http.Request, config *parser.AppConfig) map[string]string
+```
+
+extractFormData reads form values from a POST request, including file uploads.
+config may be nil; defaults are used in that case.
+
+### `fetchOGData`
+
+```go
+func fetchOGData(url string) *ogData
+```
+
+fetchOGData fetches Open Graph metadata from a URL
+
+### `findComputedField`
+
+```go
+func findComputedField(models []parser.Model, modelName, fieldName string) *parser.Field
+```
+
+findComputedField returns the parser.Field for a model's computed field by name,
+or nil if no such computed field exists.
+
+### `findMatchingEnd`
+
+```go
+func findMatchingEnd(content string) (body, elseBody string, endPos int)
+```
+
+findMatchingEnd finds the body, else body, and position after {{end}} for a block,
+accounting for nested {{each}}/{{if}} blocks.
+
+### `findModel`
+
+```go
+func findModel(models []parser.Model, name string) *parser.Model
+```
+
+findModel returns a pointer to the model with the given name, or nil if not found.
+
+### `firstLine`
+
+```go
+func firstLine(sql string) string
+```
+### `flattenJSON`
+
+```go
+func flattenJSON(obj map[string]interface{}, prefix string) database.Row
+```
+
+flattenJSON converts a nested JSON object into a flat map[string]string.
+Nested keys are joined with dots: {"user": {"name": "Alice"}} -> {"user.name": "Alice"}
+
+### `flattenMap`
+
+```go
+func flattenMap(m map[string]interface{}, prefix string, result map[string]string)
+```
+### `flattenPayload`
+
+```go
+func flattenPayload(payload map[string]interface{}, prefix string) map[string]string
+```
+
+flattenPayload converts nested JSON to flat key-value pairs
+e.g., {"data": {"id": "123"}} -> {"event_data_id": "123"}
+
+### `fnAbs`
+
+```go
+func fnAbs(a []string) (string, error)
+```
+### `fnBcrypt`
+
+```go
+func fnBcrypt(a []string) (string, error)
+```
+### `fnCeil`
+
+```go
+func fnCeil(a []string) (string, error)
+```
+### `fnClamp`
+
+```go
+func fnClamp(a []string) (string, error)
+```
+### `fnCoalesce`
+
+```go
+func fnCoalesce(a []string) (string, error)
+```
+### `fnContains`
+
+```go
+func fnContains(a []string) (string, error)
+```
+### `fnEnds`
+
+```go
+func fnEnds(a []string) (string, error)
+```
+### `fnFloor`
+
+```go
+func fnFloor(a []string) (string, error)
+```
+### `fnFormat`
+
+```go
+func fnFormat(a []string) (string, error)
+```
+### `fnInt`
+
+```go
+func fnInt(a []string) (string, error)
+```
+### `fnJSONGet`
+
+```go
+func fnJSONGet(a []string) (string, error)
+```
+### `fnMatches`
+
+```go
+func fnMatches(a []string) (string, error)
+```
+### `fnMax`
+
+```go
+func fnMax(a []string) (string, error)
+```
+### `fnMin`
+
+```go
+func fnMin(a []string) (string, error)
+```
+### `fnNow`
+
+```go
+func fnNow(a []string) (string, error)
+```
+### `fnRegexExtract`
+
+```go
+func fnRegexExtract(a []string) (string, error)
+```
+### `fnReplace`
+
+```go
+func fnReplace(a []string) (string, error)
+```
+### `fnRound`
+
+```go
+func fnRound(a []string) (string, error)
+```
+### `fnStarts`
+
+```go
+func fnStarts(a []string) (string, error)
+```
+### `fnUUID`
+
+```go
+func fnUUID(a []string) (string, error)
+```
+### `fnUnary`
+
+```go
+func fnUnary(f func(string) string) stdlibFn
+```
+### `fnUnbase64`
+
+```go
+func fnUnbase64(a []string) (string, error)
+```
+### `formatComputedNumber`
+
+```go
+func formatComputedNumber(v float64) string
+```
+
+formatComputedNumber renders a float as a string, dropping the trailing ".0" for
+integral values so that "2 * 3" renders as "6" rather than "6.000000".
+
+### `formatFloat`
+
+```go
+func formatFloat(f float64) string
+```
+### `formatNumber`
+
+```go
+func formatNumber(f float64, decimals int) string
+```
+
+formatNumber formats a float with thousand separators and given decimal places
+
+### `generateCSRFToken`
+
+```go
+func generateCSRFToken() string
+```
+### `generateNonce`
+
+```go
+func generateNonce() string
+```
+
+generateNonce returns a short random hex string for placeholder uniqueness
+
+### `generateSessionID`
+
+```go
+func generateSessionID() string
+```
+### `getEnv`
+
+```go
+func getEnv(key, fallback string) string
+```
+### `getPaginateField`
+
+```go
+func getPaginateField(info PaginateInfo, field string) string
+```
+
+getPaginateField returns a pagination metadata field value
+
+### `getRoom`
+
+```go
+func getRoom(name string) *Room
+```
+### `goDateFormat`
+
+```go
+func goDateFormat(format string) string
+```
+
+goDateFormat converts strftime-like format to Go layout
+
+### `hasUserPage`
+
+```go
+func hasUserPage(app *parser.App, path string) bool
+```
+
+hasUserPage reports whether the app declares a `page` at exactly the
+given path. Uses exact string equality (not matchPath) because the
+auth dispatcher only needs to cover fixed paths like /login and
+/register; parameterised matching would let a page like /login-extra
+accidentally shadow the built-in /login.
+
+### `inferHTTPVerb`
+
+```go
+func inferHTTPVerb(action *parser.Page) string
+```
+
+inferHTTPVerb returns the HTTP verb declared on an action block.
+Method is always set by the parser (default "POST" for `action ...`,
+see parser.parseAction), so this is a thin uppercase wrapper kept for
+clarity at call sites.
+
+### `init`
+
+```go
+func init()
+```
+### `interpolate`
+
+```go
+func interpolate(text string, ctx *renderContext) string
+```
+
+interpolate replaces {name.field} patterns with query result values
+Supports:
+  - {queryName.field} -> first row of named query, specific column
+  - {queryName.count} -> number of rows in named query (built-in)
+
+### `interpolateEscaped`
+
+```go
+func interpolateEscaped(text string, ctx *renderContext) string
+```
+
+interpolateEscaped replaces {query.field} patterns with escaped values.
+Used for content outside {{each}} blocks.
+
+### `interpolateRow`
+
+```go
+func interpolateRow(text string, row database.Row, ctx *renderContext) string
+```
+
+interpolateRow replaces {field} patterns with the current row's values (escaped),
+and {query.field} with cross-query values (also escaped).
+
+### `isAllowedURLScheme`
+
+```go
+func isAllowedURLScheme(rawURL string) bool
+```
+
+isAllowedURLScheme returns true if the URL uses an allowed scheme.
+
+### `isAllowedUploadExt`
+
+```go
+func isAllowedUploadExt(filename string) bool
+```
+### `isIdentPart`
+
+```go
+func isIdentPart(c byte) bool
+```
+### `isIdentStart`
+
+```go
+func isIdentStart(c byte) bool
+```
+### `isInsideEachBlock`
+
+```go
+func isInsideEachBlock(text string) func(int) bool
+```
+
+isInsideEachBlock returns a closure that checks if a position in the text
+falls inside a {{each}}...{{end}} block. Used to defer filter processing
+to the per-row iteration in expandEachBlocks.
+
+### `isLocalPath`
+
+```go
+func isLocalPath(path string) bool
+```
+
+isLocalPath validates that a redirect path is local (not an open redirect) (#1 fix)
+
+### `isMutationStart`
+
+```go
+func isMutationStart(lower string) bool
+```
+### `isPathWithinAllowedDirs`
+
+```go
+func isPathWithinAllowedDirs(path string) bool
+```
+
+isPathWithinAllowedDirs checks whether the given path is inside one of the
+allowed directories (current working dir, uploads/, templates/).
+
+### `isSQLKeyword`
+
+```go
+func isSQLKeyword(s string) bool
+```
+### `isSensitiveField`
+
+```go
+func isSensitiveField(name, passwordField string) bool
+```
+### `jsonCoerce`
+
+```go
+func jsonCoerce(v string) any
+```
+
+jsonCoerce tries to emit numbers/bools/null as native JSON types when the
+value is unambiguous. Anything else stays a string. This lets users pass
+`body amount: :total` to APIs (Stripe etc.) that require typed numbers.
+
+### `linkify`
+
+```go
+func linkify(text string) string
+```
+### `loadApp`
+
+```go
+func loadApp(filename string) (*parser.App, error)
+```
+### `loadEmailConfig`
+
+```go
+func loadEmailConfig() EmailConfig
+```
+### `looksLikeExpression`
+
+```go
+func looksLikeExpression(s string) bool
+```
+### `matchPath`
+
+```go
+func matchPath(pattern, urlPath string) bool
+```
+
+matchPath checks if a route pattern matches a URL path.
+Supports :param segments: /users/:id matches /users/5
+
+### `matchPathParams`
+
+```go
+func matchPathParams(pattern, urlPath string) map[string]string
+```
+
+matchPathParams extracts :param values from a URL given a pattern
+
+### `matchRateLimitPath`
+
+```go
+func matchRateLimitPath(pattern, path string) bool
+```
+### `mergeConsecutiveRoles`
+
+```go
+func mergeConsecutiveRoles(msgs []anthropicMessage) []anthropicMessage
+```
+
+mergeConsecutiveRoles collapses consecutive messages with the same role
+to satisfy Anthropic's alternating user/assistant requirement.
+
+### `nextCronOccurrence`
+
+```go
+func nextCronOccurrence(expr string) time.Time
+```
+
+nextCronOccurrence parses "every monday at 9:00" and returns the next occurrence
+
+### `parseFilterChain`
+
+```go
+func parseFilterChain(chain string) []parsedFilter
+```
+
+parseFilterChain splits "upcase | truncate: 30 | default: N/A" into filters
+
+### `parseInList`
+
+```go
+func parseInList(s string) []string
+```
+
+parseInList parses items from a comma-separated list, stripping quotes.
+
+### `parseJSONResponse`
+
+```go
+func parseJSONResponse(body []byte) ([]database.Row, error)
+```
+
+parseJSONResponse converts JSON into database.Row slices for template use.
+Supports: object (single row), array of objects (multiple rows), or wraps primitives.
+
+### `parsePermissionRule`
+
+```go
+func parsePermissionRule(raw string) *PermissionRule
+```
+### `printRoutes`
+
+```go
+func printRoutes(app *parser.App)
+```
+### `processRawInRow`
+
+```go
+func processRawInRow(content string, row database.Row, ctx *renderContext, nonce string) string
+```
+
+processRawInRow handles {field | filters} inside {{each}} blocks where field comes from the current row.
+Skips expressions that are inside nested {{each}} blocks so the inner loop processes them.
+
+### `readWSFrame`
+
+```go
+func readWSFrame(reader *bufio.Reader) ([]byte, byte, error)
+```
+
+readWSFrame reads a WebSocket frame and returns the payload, opcode, and any error.
+
+### `redactURL`
+
+```go
+func redactURL(raw string) string
+```
+
+redactURL strips the query string so secrets passed via :param substitution
+do not end up in stdout/log lines.
+
+### `redirectWithError`
+
+```go
+func redirectWithError(w http.ResponseWriter, r *http.Request, path, msg string)
+```
+
+redirectWithError issues a 303 See Other to `path?error=...` so the
+user-declared page can re-render with the error visible via a query
+parameter (`{error|default:""}`). Keeps POST handlers in Go while
+letting the UI live entirely in .kilnx land.
+
+### `render404`
+
+```go
+func render404(path string, pages []parser.Page) string
+```
+### `renderDefaultLayout`
+
+```go
+func renderDefaultLayout(title, nav, content string) string
+```
+### `renderForbidden`
+
+```go
+func renderForbidden(pages []parser.Page, session *Session) string
+```
+### `renderHTML`
+
+```go
+func renderHTML(content string, ctx *renderContext) string
+```
+
+renderHTML is the main template processing function for NodeHTML content.
+It processes all template directives and returns the final HTML string.
+
+### `renderMarkdown`
+
+```go
+func renderMarkdown(text string) string
+```
+
+renderMarkdown converts a subset of markdown to HTML.
+Supports: **bold**, *italic*, `inline code`, ```code blocks```,
+[links](url), ~strikethrough~, and newlines to <br>.
+
+### `renderNav`
+
+```go
+func renderNav(pages []parser.Page, currentPath string, session *Session, appName string, logoutPath string) string
+```
+### `renderSSERows`
+
+```go
+func renderSSERows(rows []database.Row) string
+```
+
+renderSSERows renders query results as HTML for SSE consumption
+
+### `renderUnfurl`
+
+```go
+func renderUnfurl(og *ogData) string
+```
+
+renderUnfurl generates an HTML card for unfurled link preview
+
+### `renderWithLayout`
+
+```go
+func renderWithLayout(layout parser.Layout, title, nav, content string, layoutCtx *renderContext) string
+```
+### `resolveComputedFromQuery`
+
+```go
+func resolveComputedFromQuery(ctx *renderContext, queryName, field string) (string, bool)
+```
+
+resolveComputedFromQuery attempts to evaluate a computed field {queryName.field}
+using the first row of the named query and the model that produced it. Returns
+(value, true) on success; otherwise ("", false) so the caller can fall through.
+
+### `resolveComputedFromRow`
+
+```go
+func resolveComputedFromRow(ctx *renderContext, row database.Row, modelName, field string) (string, bool)
+```
+
+resolveComputedFromRow attempts to evaluate a computed field on a row, using
+the model name carried alongside the row. Returns (value, true) on success.
+
+### `resolveEmailRecipient`
+
+```go
+func resolveEmailRecipient(to string, params map[string]string) string
+```
+
+resolveEmailRecipient resolves the "to" field.
+Can be a literal email, a :param from context, or a query result.
+
+### `resolveImports`
+
+```go
+func resolveImports(absPath, projectRoot string, seen map[string]bool, depth int) (string, error)
+```
+### `resolveKxValue`
+
+```go
+func resolveKxValue(value string, params map[string]string) string
+```
+
+resolveKxValue is the single entry point used by fetch / future-callers to
+turn a user-supplied string value into its final form. It tries the
+expression evaluator first; on failure it falls back to legacy `:param`
+substitution so existing apps keep working.
+
+### `resolvePermissionPlaceholders`
+
+```go
+func resolvePermissionPlaceholders(filter string, params map[string]string) string
+```
+
+resolvePermissionPlaceholders validates that any :current_user.id reference
+has a bound parameter available.
+
+### `resolveQueryParam`
+
+```go
+func resolveQueryParam(expr string, params map[string]string) string
+```
+
+resolveQueryParam resolves a parameter reference like "params.status" or "status"
+from the provided params map.
+
+### `resolveSessionField`
+
+```go
+func resolveSessionField(field string, session *Session) string
+```
+
+resolveSessionField returns the value of a session field referenced as
+"current_user.fieldName" or plain "fieldName".
+
+### `resolveTenantPlaceholder`
+
+```go
+func resolveTenantPlaceholder(template string, session *Session, pathParams map[string]string, r *http.Request) string
+```
+
+resolveTenantPlaceholder replaces {user.field}, {:param}, {header.H} in a manifest
+path template using session, path params, and request headers.
+
+### `resolveValue`
+
+```go
+func resolveValue(expr string, ctx *renderContext, currentRow database.Row) string
+```
+
+resolveValue resolves a template expression to its value.
+Handles: "paginate.query.field", "params.key", "queryName.field", "queryName.count",
+bare "field", and parent-scope "^field", "^^field", etc.
+Returns the original "{expr}" string if not found.
+
+### `runSingleTest`
+
+```go
+func runSingleTest(test parser.Test, app *parser.App, db *database.DB, baseURL string) bool
+```
+### `sanitizeEmailAddress`
+
+```go
+func sanitizeEmailAddress(addr string) string
+```
+
+sanitizeEmailAddress removes control characters that could be used for
+header injection (CRLF) or null-byte attacks.
+
+### `sanitizeHostHeader`
+
+```go
+func sanitizeHostHeader(host string) string
+```
+
+sanitizeHostHeader removes control characters and spaces from a Host header
+to prevent Host Header Injection attacks.
+
+### `sanitizeIdentifier`
+
+```go
+func sanitizeIdentifier(name string) string
+```
+### `serializeCustomBrackets`
+
+```go
+func serializeCustomBrackets(data map[string]string)
+```
+
+serializeCustomBrackets collects custom[field]=value entries from form data,
+JSON-encodes them as data["custom"], and also promotes each field as a top-level
+key so column-mode SQL (e.g. INSERT ... (:revenue)) can bind directly.
+
+### `sha256Hex`
+
+```go
+func sha256Hex(s string) string
+```
+### `slugify`
+
+```go
+func slugify(s string) string
+```
+### `sortStringsByLenDesc`
+
+```go
+func sortStringsByLenDesc(s []string)
+```
+### `splitArgPairs`
+
+```go
+func splitArgPairs(s string) []string
+```
+
+splitArgPairs tokenizes a translation argument string into space-separated
+pairs while respecting quoted values. A naive strings.Split on " " would
+corrupt arguments such as name="John Doe".
+
+### `splitArgStr`
+
+```go
+func splitArgStr(s string) []string
+```
+
+splitArgStr tokenizes a fragment call argument string into space-separated
+tokens, respecting single and double quoted substrings. Whitespace inside
+quotes is preserved within the token (e.g. title="Hello World").
+
+### `splitCondition`
+
+```go
+func splitCondition(condition string) (string, string, string)
+```
+
+splitCondition splits "left op right" while respecting quoted strings.
+Returns left, operator, right. If no operator found, returns condition, "", "".
+
+### `splitLogical`
+
+```go
+func splitLogical(condition, keyword string) []string
+```
+
+splitLogical splits a condition string on a logical keyword (" and " or " or "),
+respecting quoted strings. Returns the original string in a single-element slice
+if the keyword is not found outside quotes.
+
+### `splitPluralSpec`
+
+```go
+func splitPluralSpec(spec string) []string
+```
+
+splitPluralSpec splits a plural spec by comma, but not inside quotes.
+
+### `stringLen`
+
+```go
+func stringLen(s string) int
+```
+### `stripQuotes`
+
+```go
+func stripQuotes(s string) string
+```
+
+stripQuotes removes surrounding double or single quotes from a string.
+
+### `stripSQLNoise`
+
+```go
+func stripSQLNoise(sql string) string
+```
+
+stripSQLNoise removes comments and string literals. The returned
+string preserves overall length by replacing stripped ranges with
+spaces, so byte positions remain valid for downstream regexps.
+
+### `substituteParams`
+
+```go
+func substituteParams(value string, params map[string]string) string
+```
+
+substituteParams replaces every `:key` reference in value with its mapped
+param. Keys are tried longest-first so `:user.id` takes precedence over
+`:user`.
+
+### `timeAgo`
+
+```go
+func timeAgo(t time.Time) string
+```
+
+timeAgo returns a human-readable relative time string
+
+### `touchesTenantTable`
+
+```go
+func touchesTenantTable(sql string, tenants TenantMap) bool
+```
+
+touchesTenantTable returns true if the SQL (whitespace-tokenised) mentions
+any tenant-scoped model name as a standalone identifier. Conservative: we
+would rather reject an innocuous query than miss a tenant leak.
+
+### `translatePermissionCondition`
+
+```go
+func translatePermissionCondition(condition, qualifier string) (string, error)
+```
+
+translatePermissionCondition converts a simple permission condition like
+"author = current_user" into a SQL predicate.
+Supported shapes (case-insensitive):
+
+	field = current_user
+	field = 'literal'
+	field = 123
+
+### `truncateSQL`
+
+```go
+func truncateSQL(sql string) string
+```
+### `unfurlURLs`
+
+```go
+func unfurlURLs(text string) string
+```
+
+unfurlURLs finds URLs in text and appends link preview cards
+
+### `validateCSRFToken`
+
+```go
+func validateCSRFToken(token string) bool
+```
+### `validateFormData`
+
+```go
+func validateFormData(modelName string, app *parser.App, formData map[string]string) []string
+```
+
+validateFormData validates form data against model constraints
+
+### `validateInlineRules`
+
+```go
+func validateInlineRules(validations []parser.Validation, formData map[string]string) []string
+```
+
+validateInlineRules validates form data against explicit validation rules
+(not model-based). Supports: "required", "is email", "is date", "min N", "max N"
+
+### `verifySignature`
+
+```go
+func verifySignature(payload []byte, signature, secret string) bool
+```
+### `verifyStripeSignature`
+
+```go
+func verifyStripeSignature(payload []byte, header, secret string) bool
+```
+### `watchFile`
+
+```go
+func watchFile(filename string, srv *Server)
+```
+### `windowDuration`
+
+```go
+func windowDuration(window string) time.Duration
+```
+### `writeJSON`
+
+```go
+func writeJSON(w http.ResponseWriter, status int, data interface{})
+```
+### `writeWSFrame`
+
+```go
+func writeWSFrame(conn net.Conn, data []byte) error
+```
+### `writeWSPing`
+
+```go
+func writeWSPing(conn net.Conn) error
+```
+
+writeWSPing sends a WebSocket ping frame (opcode 0x9) with no payload.
+
+### `(I18n) Translate`
+
+```go
+func (i *I18n) Translate(key string, r *http.Request) string
+```
+
+Translate returns the translation for a key in the detected language
+
+### `(I18n) TranslateAll`
+
+```go
+func (i *I18n) TranslateAll(text string, r *http.Request) string
+```
+
+TranslateAll replaces {t.key} patterns in text with translations
+
+### `(I18n) detectLanguage`
+
+```go
+func (i *I18n) detectLanguage(r *http.Request) string
+```
+
+detectLanguage reads Accept-Language header and returns best match
+
+### `(JobQueue) Enqueue`
+
+```go
+func (jq *JobQueue) Enqueue(name string, params map[string]string) error
+```
+
+Enqueue persists a job to the _kilnx_jobs table
+
+### `(JobQueue) Start`
+
+```go
+func (jq *JobQueue) Start()
+```
+
+Start recovers any jobs left in the executing state from a previous run
+and launches the background poller goroutine.
+
+### `(JobQueue) pollQueue`
+
+```go
+func (jq *JobQueue) pollQueue()
+```
+
+pollQueue continuously polls _kilnx_jobs for available work
+
+### `(JobQueue) processNextJob`
+
+```go
+func (jq *JobQueue) processNextJob()
+```
+### `(JobQueue) recoverOrphanedJobs`
+
+```go
+func (jq *JobQueue) recoverOrphanedJobs()
+```
+
+recoverOrphanedJobs resets jobs stuck in 'executing' state back to 'available'.
+This handles the case where the server was restarted while jobs were running.
+
+### `(JobQueue) safeExecuteNodes`
+
+```go
+func (jq *JobQueue) safeExecuteNodes(nodes []parser.Node, params map[string]string) (err error)
+```
+
+safeExecuteNodes runs nodes with panic recovery, returning any error
+
+### `(Logger) LogError`
+
+```go
+func (l *Logger) LogError(msg string, err error)
+```
+
+LogError logs an error, optionally with a goroutine stack trace.
+Nil-tolerant: tests and early-boot paths may hold a nil Logger.
+
+### `(Logger) LogRequest`
+
+```go
+func (l *Logger) LogRequest(r *http.Request, status int, duration time.Duration)
+```
+
+LogRequest logs an HTTP request if request logging is enabled
+
+### `(Logger) LogSecurity`
+
+```go
+func (l *Logger) LogSecurity(msg string, err error)
+```
+
+LogSecurity always emits a security-relevant event regardless of the
+user's `log.errors` config. Routed to stderr so operators never lose
+the signal that a tenant guard, CSRF check, or similar invariant
+fired. Nil-tolerant for tests.
+
+### `(Logger) LogSlowQuery`
+
+```go
+func (l *Logger) LogSlowQuery(sql string, duration time.Duration)
+```
+
+LogSlowQuery logs a query if it exceeds the slow query threshold
+
+### `(Logger) LoggingMiddleware`
+
+```go
+func (l *Logger) LoggingMiddleware(next http.Handler) http.Handler
+```
+
+LoggingMiddleware wraps an http.Handler with request logging
+
+### `(PermissionMap) CanAccess`
+
+```go
+func (pm PermissionMap) CanAccess(role, resource string) bool
+```
+
+CanAccess reports whether role has any permission (read or write) for
+resource.  It respects the hard-coded role hierarchy as a fallback.
+
+### `(PermissionMap) CanRead`
+
+```go
+func (pm PermissionMap) CanRead(role, resource string) bool
+```
+
+CanRead reports whether role may read the resource.
+
+### `(PermissionMap) CanWrite`
+
+```go
+func (pm PermissionMap) CanWrite(role, resource string) bool
+```
+
+CanWrite reports whether role may write the resource.
+
+### `(PermissionMap) ConditionForRead`
+
+```go
+func (pm PermissionMap) ConditionForRead(role, resource string) string
+```
+
+ConditionForRead returns the first read-condition for role+resource, or "".
+
+### `(PermissionMap) ConditionForWrite`
+
+```go
+func (pm PermissionMap) ConditionForWrite(role, resource string) string
+```
+
+ConditionForWrite returns the first write-condition for role+resource, or "".
+
+### `(PermissionMap) hasRule`
+
+```go
+func (pm PermissionMap) hasRule(role, resource, action string) bool
+```
+### `(RateLimiter) Check`
+
+```go
+func (rl *RateLimiter) Check(r *http.Request, session *Session) bool
+```
+
+Check returns true if the request is allowed, false if rate limited
+
+### `(RateLimiter) CheckClause`
+
+```go
+func (rl *RateLimiter) CheckClause(count int, period string, key string) bool
+```
+
+CheckClause enforces a per-key counter for `requires limit N/period per scope`
+clauses. Returns true if the request is within the limit. Uses the same
+in-memory map as path-level rules, scoped under a "clause:" prefix.
+
+### `(RateLimiter) CheckWithRule`
+
+```go
+func (rl *RateLimiter) CheckWithRule(r *http.Request, session *Session) (bool, *parser.RateLimit)
+```
+
+CheckWithRule returns (exceeded bool, matched rule) for the request.
+exceeded is true when the request should be blocked.
+
+### `(RateLimiter) cleanup`
+
+```go
+func (rl *RateLimiter) cleanup()
+```
+### `(RateLimiter) minWindow`
+
+```go
+func (rl *RateLimiter) minWindow() time.Duration
+```
+
+minWindow returns the shortest window duration across all rules
+
+### `(Room) add`
+
+```go
+func (room *Room) add(conn net.Conn)
+```
+### `(Room) broadcast`
+
+```go
+func (room *Room) broadcast(message []byte)
+```
+### `(Room) remove`
+
+```go
+func (room *Room) remove(conn net.Conn)
+```
+### `(Server) RefreshJobQueue`
+
+```go
+func (s *Server) RefreshJobQueue()
+```
+
+RefreshJobQueue updates the job definitions from the current app (for hot-reload)
+
+### `(Server) Reload`
+
+```go
+func (s *Server) Reload(app *parser.App)
+```
+
+Reload swaps in a newly parsed app for hot-reload, refreshing superuser
+identity and the fragment component index under the server's write lock.
+
+### `(Server) Start`
+
+```go
+func (s *Server) Start() error
+```
+
+Start binds the HTTP listener and serves the request mux wrapped with the
+logging middleware. It blocks until the listener returns.
+
+### `(Server) StartJobQueue`
+
+```go
+func (s *Server) StartJobQueue()
+```
+
+StartJobQueue starts the background job queue poller.
+
+### `(Server) StartScheduler`
+
+```go
+func (s *Server) StartScheduler()
+```
+
+StartScheduler launches goroutines for each schedule defined in the app.
+It stops any previously running schedule goroutines before starting new ones.
+
+### `(Server) StopScheduler`
+
+```go
+func (s *Server) StopScheduler()
+```
+
+StopScheduler signals all running schedule goroutines to exit.
+
+### `(Server) buildHandler`
+
+```go
+func (s *Server) buildHandler() http.Handler
+```
+### `(Server) checkRateLimit`
+
+```go
+func (s *Server) checkRateLimit(count int, period string, scope string, r *http.Request, session *Session) bool
+```
+
+checkRateLimit returns true if the request is within the rate limit.
+Uses the in-memory RateLimiter (mutex-protected, race-safe) so the check
+works identically on SQLite and PostgreSQL deployments. Single-instance only:
+in a multi-process deployment each instance enforces its own counter.
+
+### `(Server) evalRequiresClauses`
+
+```go
+func (s *Server) evalRequiresClauses(clauses []parser.RequiresClause, session *Session, r *http.Request) bool
+```
+
+evalRequiresClauses returns true when the session satisfies ALL clauses (AND semantics).
+
+Privilege checks (auth, role, expr, superuser) are bypassed for the configured
+superuser identity. Availability and traffic controls (flag, rate-limit) are
+always evaluated, since a disabled flag or exhausted endpoint is a signal that
+no caller, including the operator, should reach the handler.
+
+### `(Server) executeNodes`
+
+```go
+func (s *Server) executeNodes(nodes []parser.Node, params map[string]string) error
+```
+
+executeNodes runs a list of nodes (for schedules and jobs).
+Returns the first error encountered during query execution.
+
+### `(Server) getApp`
+
+```go
+func (s *Server) getApp() *parser.App
+```
+### `(Server) getSession`
+
+```go
+func (s *Server) getSession(r *http.Request) *Session
+```
+
+getSession extracts the session from the request cookie, verifying HMAC signature
+
+### `(Server) handleAPI`
+
+```go
+func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request, endpoint parser.Page)
+```
+
+handleAPI processes an API endpoint and returns JSON.
+For mutation methods (POST/PUT/DELETE), supports validate, transactions, and redirect.
+
+### `(Server) handleAction`
+
+```go
+func (s *Server) handleAction(w http.ResponseWriter, r *http.Request, action parser.Page, app *parser.App)
+```
+
+handleAction processes a POST/PUT/DELETE request.
+All mutation queries within an action are wrapped in an implicit transaction.
+
+### `(Server) handleActionNodes`
+
+```go
+func (s *Server) handleActionNodes(w http.ResponseWriter, r *http.Request, nodes []parser.Node, formData map[string]string, app *parser.App)
+```
+
+handleActionNodes processes action nodes inside `on` branches.
+Supports redirect, respond, send email, query execution, and job enqueue.
+
+### `(Server) handleForgotPassword`
+
+```go
+func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request)
+```
+
+handleForgotPassword processes reset requests. Only POST is served;
+GET is rendered by the user-declared `page /forgot-password` (enforced
+at compile time by the analyzer).
+
+### `(Server) handleLogin`
+
+```go
+func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request)
+```
+
+handleLogin processes the login form POST
+
+### `(Server) handleLogout`
+
+```go
+func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request)
+```
+
+handleLogout clears the session (POST only, CSRF validated)
+
+### `(Server) handleRegister`
+
+```go
+func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request)
+```
+
+handleRegister handles user registration
+
+### `(Server) handleResetPassword`
+
+```go
+func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request)
+```
+
+handleResetPassword processes the password reset form
+
+### `(Server) handleSocket`
+
+```go
+func (s *Server) handleSocket(w http.ResponseWriter, r *http.Request, sock parser.Socket)
+```
+
+handleSocket handles WebSocket upgrade and bidirectional communication
+
+### `(Server) handleStream`
+
+```go
+func (s *Server) handleStream(w http.ResponseWriter, r *http.Request, stream parser.Stream)
+```
+
+handleStream serves a Server-Sent Events endpoint.
+It executes the stream's SQL query at the configured interval
+and sends results as SSE events.
+
+### `(Server) handleWebhook`
+
+```go
+func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request, wh parser.Webhook)
+```
+
+handleWebhook processes an incoming webhook POST
+
+### `(Server) hasPermission`
+
+```go
+func (s *Server) hasPermission(userRole, requiredRole string, perms []parser.Permission) bool
+```
+
+hasPermission checks if userRole has the required access level
+
+### `(Server) invalidateDynamicManifestCache`
+
+```go
+func (s *Server) invalidateDynamicManifestCache(sql string)
+```
+
+invalidateDynamicManifestCache clears the manifest cache entry when a
+mutation targets a _<model>_field_defs table.
+
+### `(Server) mergeDBFieldDefs`
+
+```go
+func (s *Server) mergeDBFieldDefs(modelName string, base *parser.CustomFieldManifest) *parser.CustomFieldManifest
+```
+
+mergeDBFieldDefs queries _<model>_field_defs and merges rows into base.
+Static fields always win on name collision.
+
+### `(Server) modelHasCustomFields`
+
+```go
+func (s *Server) modelHasCustomFields(app *parser.App, modelName string) bool
+```
+
+modelHasCustomFields reports whether a model has any custom field support
+(static manifest or dynamic fields).
+
+### `(Server) populateCurrentUserParams`
+
+```go
+func (s *Server) populateCurrentUserParams(params map[string]string, sess *Session)
+```
+
+populateCurrentUserParams copies the logged-in user's row into `params`
+under the `current_user.<column>` prefix, redacting known-sensitive
+columns (password, tokens, secrets) plus the `auth.password` column
+declared in the .kilnx config. Callers SHOULD use this helper instead
+of iterating session.Data directly.
+
+### `(Server) rateLimitKey`
+
+```go
+func (s *Server) rateLimitKey(scope string, r *http.Request, session *Session) string
+```
+
+rateLimitKey returns the key for rate limiting based on scope.
+Returns empty string when the scope cannot be resolved (e.g. `per tenant`
+on a single-tenant app); the caller treats empty as "no limit applied".
+
+### `(Server) renderFragment`
+
+```go
+func (s *Server) renderFragment(frag parser.Page, r *http.Request) string
+```
+
+renderFragment renders a fragment (partial HTML, no page wrapper)
+
+### `(Server) renderFragmentWithParams`
+
+```go
+func (s *Server) renderFragmentWithParams(frag parser.Page, params map[string]string) string
+```
+
+renderFragmentWithParams renders a fragment using provided params (for WebSocket broadcast)
+
+### `(Server) renderPage`
+
+```go
+func (s *Server) renderPage(p parser.Page, allPages []parser.Page, r *http.Request) string
+```
+### `(Server) requireAPIAuth`
+
+```go
+func (s *Server) requireAPIAuth(w http.ResponseWriter, r *http.Request, page parser.Page) bool
+```
+
+requireAPIAuth checks auth for API endpoints, returning JSON 401/403 instead of HTML redirect.
+
+### `(Server) requireAuth`
+
+```go
+func (s *Server) requireAuth(w http.ResponseWriter, r *http.Request, page parser.Page) bool
+```
+
+requireAuth checks if the page requires auth and/or satisfies all requires clauses.
+Returns true if the request should proceed, false if redirected or forbidden.
+
+### `(Server) resolveFlag`
+
+```go
+func (s *Server) resolveFlag(name string) bool
+```
+
+resolveFlag checks if a feature flag is enabled.
+Priority: 1) env var FLAG_<NAME>, 2) DB table _kilnx_flags, 3) false
+
+### `(Server) resolveManifest`
+
+```go
+func (s *Server) resolveManifest(model *parser.Model, app *parser.App, session *Session, pathParams map[string]string, r *http.Request) *parser.CustomFieldManifest
+```
+
+resolveManifest returns the custom field manifest for a model, resolving dynamic
+paths at request time. Results are cached per resolved path.
+
+### `(Server) runCronSchedule`
+
+```go
+func (s *Server) runCronSchedule(sched parser.Schedule, stop <-chan struct{})
+```
+
+runCronSchedule handles "every monday at 9:00" style expressions
+
+### `(Server) runSchedule`
+
+```go
+func (s *Server) runSchedule(sched parser.Schedule, stop <-chan struct{})
+```
+### `(Server) sendSSEEvent`
+
+```go
+func (s *Server) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher, stream parser.Stream, params map[string]string)
+```
+### `(Server) warnTenantScopeOnce`
+
+```go
+func (s *Server) warnTenantScopeOnce()
+```
+
+warnTenantScopeOnce logs once that `per tenant` resolved to an empty key.
+Surfaces a misconfiguration that would otherwise silently disable the limit.
+
+### `(SessionStore) Create`
+
+```go
+func (ss *SessionStore) Create(user database.Row, identityField string) string
+```
+
+Create issues a new 24h session for user, persists it to SQLite if a DB is
+attached, and returns the session ID.
+
+### `(SessionStore) Delete`
+
+```go
+func (ss *SessionStore) Delete(id string)
+```
+
+Delete removes the session from memory and from the persistence DB.
+
+### `(SessionStore) Get`
+
+```go
+func (ss *SessionStore) Get(id string) *Session
+```
+
+Get returns the session for id, or nil if missing or expired.
+
+### `(SessionStore) SetDB`
+
+```go
+func (ss *SessionStore) SetDB(db database.Executor)
+```
+
+SetDB attaches a database for session persistence and loads existing sessions
+
+### `(SessionStore) cleanupLoop`
+
+```go
+func (ss *SessionStore) cleanupLoop()
+```
+
+cleanupLoop periodically removes expired sessions
+
+### `(SessionStore) loadFromDB`
+
+```go
+func (ss *SessionStore) loadFromDB()
+```
+
+loadFromDB restores non-expired sessions from SQLite on startup
+
+### `(SessionStore) signSessionID`
+
+```go
+func (ss *SessionStore) signSessionID(id string) string
+```
+
+signSessionID creates an HMAC-signed cookie value: "id.signature"
+
+### `(SessionStore) verifySessionID`
+
+```go
+func (ss *SessionStore) verifySessionID(signed string) (string, bool)
+```
+
+verifySessionID verifies and extracts the session ID from a signed cookie value
+
+### `(exprParser) parseExpr`
+
+```go
+func (p *exprParser) parseExpr() (float64, bool)
+```
+
+parseExpr handles + and -
+
+### `(exprParser) parseFactor`
+
+```go
+func (p *exprParser) parseFactor() (float64, bool)
+```
+
+parseFactor handles unary minus, parens, identifiers, numbers
+
+### `(exprParser) parseIdent`
+
+```go
+func (p *exprParser) parseIdent() (float64, bool)
+```
+### `(exprParser) parseNumber`
+
+```go
+func (p *exprParser) parseNumber() (float64, bool)
+```
+### `(exprParser) parseTerm`
+
+```go
+func (p *exprParser) parseTerm() (float64, bool)
+```
+
+parseTerm handles * and /
+
+### `(exprParser) skipSpaces`
+
+```go
+func (p *exprParser) skipSpaces()
+```
+### `(kxExprParser) parseAdditive`
+
+```go
+func (p *kxExprParser) parseAdditive() (string, error)
+```
+### `(kxExprParser) parseCallArgs`
+
+```go
+func (p *kxExprParser) parseCallArgs() ([]string, error)
+```
+### `(kxExprParser) parseMultiplicative`
+
+```go
+func (p *kxExprParser) parseMultiplicative() (string, error)
+```
+### `(kxExprParser) parseNumber`
+
+```go
+func (p *kxExprParser) parseNumber() string
+```
+### `(kxExprParser) parsePrimary`
+
+```go
+func (p *kxExprParser) parsePrimary() (string, error)
+```
+### `(kxExprParser) parseStringLiteral`
+
+```go
+func (p *kxExprParser) parseStringLiteral(quote byte) (string, error)
+```
+### `(kxExprParser) parseUnary`
+
+```go
+func (p *kxExprParser) parseUnary() (string, error)
+```
+### `(kxExprParser) readIdentifier`
+
+```go
+func (p *kxExprParser) readIdentifier() string
+```
+### `(kxExprParser) readIdentifierWithDots`
+
+```go
+func (p *kxExprParser) readIdentifierWithDots() string
+```
+### `(kxExprParser) skipSpace`
+
+```go
+func (p *kxExprParser) skipSpace()
+```
+### `(loggingResponseWriter) Flush`
+
+```go
+func (lw *loggingResponseWriter) Flush()
+```
+
+Flush proxies to the underlying ResponseWriter for SSE support.
+
+### `(loggingResponseWriter) Hijack`
+
+```go
+func (lw *loggingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error)
+```
+
+Hijack proxies to the underlying ResponseWriter for WebSocket support.
+
+### `(loggingResponseWriter) WriteHeader`
+
+```go
+func (lw *loggingResponseWriter) WriteHeader(code int)
+```
+
+WriteHeader records the status code so LoggingMiddleware can report it,
+then forwards to the underlying ResponseWriter.
+
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# `internal/runtime`
+
+The HTTP server and AST interpreter that backs `kilnx run` and the binaries produced by `kilnx build`. Largest package in the codebase: 27 source files, around 10k lines.
+
+## What this package owns
+
+- HTTP routing, request parsing, response rendering for pages, actions, fragments, APIs, websockets, SSE streams.
+- Built-in authentication (email/password, sessions, CSRF) and authorization (permissions, requires clauses, tenant scoping).
+- Form handling, validation, file uploads.
+- Background jobs, scheduled tasks, webhook receipt and verification.
+- SSR template rendering with htmx integration, i18n, layouts.
+- Outbound HTTP fetches and Anthropic-LLM calls invocable from `.kilnx` actions.
+- Email sending, computed-field evaluation, dynamic field manifests.
+- Live reload during development.
+
+The runtime executes the parser AST directly. There is no intermediate code generation step at run time; the optimizer rewrites the AST before the runtime sees it.
+
+## Request lifecycle
+
+Every HTTP request passes through this rough sequence inside `server.go`'s catch-all handler:
+
+1. **Logging middleware** wraps the response writer ([`logger.go`](../../../internal/runtime/logger.go)).
+2. **Rate limiter** decides whether to short-circuit with 429 ([`ratelimit.go`](../../../internal/runtime/ratelimit.go)).
+3. **Webhook routes** match first, no CSRF ([`webhook.go`](../../../internal/runtime/webhook.go)).
+4. **WebSocket routes** match next, upgrade and hand off ([`websocket.go`](../../../internal/runtime/websocket.go)).
+5. **Auth POSTs** (login, register, logout, forgot, reset) are handled by the runtime ([`auth.go`](../../../internal/runtime/auth.go)) when an `auth` block exists.
+6. **POST/PUT/DELETE** match against declared `action` blocks ([`forms.go`](../../../internal/runtime/forms.go) for body parsing, `server.go` for execution).
+7. **SSE streams** match by path ([`stream.go`](../../../internal/runtime/stream.go)).
+8. **API endpoints** match and serve JSON ([`api.go`](../../../internal/runtime/api.go)).
+9. **Pages and fragments** are the fall-through, rendered by [`render.go`](../../../internal/runtime/render.go).
+
+Cross-cutting concerns intercept at multiple steps: permissions and requires clauses ([`permissions.go`](../../../internal/runtime/permissions.go)), tenant SQL rewriting ([`tenant.go`](../../../internal/runtime/tenant.go)), i18n ([`i18n.go`](../../../internal/runtime/i18n.go)), expression evaluation ([`expr.go`](../../../internal/runtime/expr.go)).
+
+## Sub-area map
+
+### `server.go`
+
+Owner of the HTTP server, the main `*Server` type, and the request dispatch loop. `NewServer` wires together the session store, job queue, rate limiter, logger, tenant map, fragment-component index, and i18n table from the parsed `*parser.App`. `Start` builds the mux (embedded htmx and SSE assets at `/_kilnx/...`, uploads at `/_uploads/`, optional user `static/` at `/_static/`, `GET /healthz`, then the catch-all) and listens. `Reload` swaps in a hot-reloaded app under the server's write lock. The `AppRuntime` interface in [`interfaces.go`](../../../internal/runtime/interfaces.go) describes what tests and downstream packages depend on.
+
+### `auth.go`
+
+Email/password authentication. `SessionStore` keeps an in-memory hot path plus persistence in `_kilnx_sessions`, signs cookie values with HMAC-SHA256 over the configured `config.secret` (random fallback with a stderr warning when missing). Provides `handleLogin`/`handleLogout`/`handleRegister`/`handleForgotPassword`/`handleResetPassword`, bcrypt password hashing, password-reset token generation and email delivery, host-header sanitization. `getSession`/`requireAuth`/`requireAPIAuth` are called from every authenticated route.
+
+### `render.go`
+
+The SSR template engine. Walks `{{each}}`, `{{if}}`, and `{field}` directives over a `renderContext` of executed queries. Handles filter chains (`{name | upcase | truncate: 30 | default: N/A}`), `{csrf}` token expansion, `{paginate.<query>.field}` metadata, `{params.key}` URL-param access. Runs a final i18n pass for `{t.key}` placeholders. Largest single file; consult before adding template syntax.
+
+### `permissions.go`
+
+Parses the `permissions` block into a `PermissionMap` keyed by role and lower-cased model. Recognises `all`/`read`/`write` actions, optional `where` conditions, and a hard-coded admin/editor/viewer hierarchy as a fallback. `CanAccess` and `CheckPermission` are called from page guards, action guards, and tenant rewriting. Requires clauses (per-route fine-grained checks) live alongside in `requires_clauses_*.go` test files but their evaluator lives here and in `expr.go`.
+
+### `forms.go`
+
+Form data extraction and validation. `extractFormData` parses URL-encoded and multipart bodies, including file uploads with extension whitelisting (`allowedUploadExts`). Maintains a CSRF token store with a 30-minute TTL and a background sweeper. Resolves dynamic-field bracket syntax (`custom[fieldname]`) and provides validation helpers used by actions and APIs.
+
+### `scheduler.go`
+
+Background scheduler. `StartScheduler` launches one goroutine per `schedule` block: interval-based (`every 30 seconds`) or cron-style (`every monday at 9:00`, parsed by `nextCronOccurrence`). Also hosts the job queue (`JobQueue`), which polls `_kilnx_jobs` for available rows, runs them with retry/backoff, and exposes `enqueue` to action bodies. `RefreshJobQueue` re-reads job definitions on hot reload.
+
+### `websocket.go`
+
+WebSocket upgrade and broadcast. Implements RFC 6455 framing by hand (no third-party lib): `writeWSFrame`, masking, ping/pong, close handling. `Room` tracks connected clients per path; `broadcast` writes to every conn with a 5-second deadline and prunes dead connections. `handleSocket` runs the user-declared `socket` body in response to inbound messages.
+
+### `stream.go`
+
+Server-Sent Events. Re-runs the stream's SQL query on a ticker and writes each result set as an SSE event with `event: <name>` and `data:` framing per line. Honours `auth`, `requires_role`, and requires clauses before opening the stream. Uses `RewriteTenantSQL` to scope the query before execution. Single SSE event per tick, no diffing.
+
+### `webhook.go`
+
+Inbound webhook handler. POST-only. Body is capped at 1 MiB. When `secret_env` is configured, verifies HMAC-SHA256 signatures in either GitHub format (`X-Hub-Signature-256: sha256=hex`), generic (`X-Signature-256`), or Stripe format (`Stripe-Signature: t=...,v1=...` with a 5-minute replay window). Flattens nested JSON payloads into a flat `event_<key>` param map and routes to the matching `event` handler in the user's `webhook` block.
+
+### `fetch.go`
+
+Outbound HTTP from action bodies (`fetch ...`). 10-second timeout, max 5 redirects. Bodies encode as JSON when a Content-Type header opts in, otherwise form-encoded. Honours `env:VAR` header values, `:param` substitution in URL and headers, and the expression evaluator from `expr.go` for header values. Caps response read at 2 MiB. Returns rows for the template plus `<name>.status_code` and `<name>.ok` so user code can branch with `on <name>.ok`. Redacts query strings in stdout logs to avoid leaking secrets.
+
+### `llm.go`
+
+Anthropic Claude integration. Reads `ANTHROPIC_API_KEY`, defaults to `claude-haiku-4-5-20251001`, supports `system` prompt and `history` SQL (rows with `papel`/`conteudo` columns; `assistente` maps to `assistant`, `sistema` collapses to `user`). Merges consecutive same-role messages so the API's alternating requirement is satisfied. 60-second client timeout, 1 MiB response cap.
+
+### `i18n.go`
+
+Translation lookup. `I18n` holds `lang -> key -> value`. `Translate(key, r)` resolves the request's language from `?lang=` query, then `Accept-Language` (with base-language fallback for `pt-BR -> pt`), falling back to the configured default and finally to the key itself. `TranslateAll` substitutes every `{t.key}` placeholder during a render-pass tail.
+
+### `layout.go`
+
+Layout rendering. `renderDefaultLayout` emits the built-in HTML wrapper (htmx and SSE script tags). `renderWithLayout` substitutes `{page.title}`, `{page.content}`, `{nav}`, `{kilnx.js}` placeholders inside a user-declared `layout` block, then runs the template engine over it for any layout-level queries.
+
+### `logger.go`
+
+Pluggable structured logging. `LogRequest` (request line, status, duration, opt-in via `log.requests`), `LogSlowQuery` (threshold from `log.slow_query_ms`, default 100ms), `LogError` (with optional `runtime.Stack` dump when `log.stacktrace` is set), `LogSecurity` (always to stderr, never silenced; used for tenant-guard violations and CSRF failures). `LoggingMiddleware` wraps a `http.Handler`, capturing the status via a `loggingResponseWriter` that also implements `Hijacker` and `Flusher` so WebSockets and SSE keep working.
+
+### `ratelimit.go`
+
+Fixed-window rate limiter keyed by IP or user. In-memory map capped at `maxRateLimitEntries = 100_000` with adaptive cleanup interval (half the shortest configured window, clamped to 1s..60s). Auth endpoints (`/login`, `/register`, `/forgot-password`) get implicit defaults of 10 req/min/IP unless the developer overrides them. `CheckClause` is the per-key counter used by `requires limit N/period per scope` clauses on routes; entries are namespaced under a `clause:` prefix.
+
+### `api.go`
+
+JSON API endpoint dispatcher. Handles CORS preflight (`OPTIONS`) per `config.cors_origins`. For mutations (POST/PUT/DELETE) opens a `TxHandle`, extracts form/JSON body data, merges with path and query params, and runs the action body inside the transaction. Returns paginated row sets when the query uses `paginate`, otherwise a flat row list. Status codes follow the redirect / validation outcome.
+
+### `computed.go`
+
+Computed-field evaluator. `findComputedField` looks up a `parser.Field` by model and field name; `evaluateComputedExpr` runs a tiny arithmetic parser over identifiers (resolved against the row), int/float literals, `+ - * /` operators, and parentheses. Used during render to project virtual columns that are not stored in the table.
+
+### `dynamic_fields.go`
+
+Dynamic custom-field manifests. `mergeDBFieldDefs` queries `_<model>_field_defs` and merges the rows into the static manifest. Static fields always win on name collision. `invalidateDynamicManifestCache` is called from action bodies that mutate the field-defs table, so the manifest cache (`Server.manifestCache`) is dropped on writes. `modelHasCustomFields` is the cheap lookup used by the SQL rewriter to decide whether to expand `custom.field` shorthand.
+
+### `email.go`
+
+Outbound SMTP. Reads `KILNX_SMTP_HOST`/`PORT`/`USER`/`PASS`/`FROM` from the environment. `LoadEmailTemplate` reads `templates/<name>.html`, interpolates `{key}` placeholders with HTML escaping. `SendEmailWithTemplate` ties the two together. Address sanitization strips CR/LF/NUL to prevent header injection.
+
+### `expr.go`
+
+Expression evaluator and stdlib. Pure functions callable from action bodies (`body amount: round(:total * 1.5)`, `body slug: slugify(:title)`): `lower`, `upper`, `trim`, `len`, `slugify`, `bcrypt`, `sha256`, `base64`/`unbase64`, `uuid`, `now`, `coalesce`, `regex`, `matches`, `json_get`, `round`/`floor`/`ceil`/`abs`, `min`/`max`/`clamp`, `replace`, `contains`, `starts`/`ends`, `int`, `format`. `resolveKxValue` is the single entry point: tries the expression evaluator when input "looks like" a function call, falls back to `:param` substitution otherwise. WASM-style extensibility is reserved for the `plugin` keyword (not yet implemented here).
+
+### `query_conditional.go`
+
+Inline `{{if expr}}...{{else}}...{{end}}` blocks inside SQL strings. Lets queries opt their `WHERE` clauses in or out based on params. Supports truthy checks, `==`, and `!=` against literal strings, with `params.key` and bare `key` references both honoured.
+
+### `tenant.go`
+
+Multi-tenant SQL rewriter. `BuildTenantMap` indexes tenant-scoped models from the `tenant: <ref>` directive. `RewriteTenantSQL` injects the appropriate `WHERE <tenant>_id = :current_user.<tenant>_id` predicate into SELECTs and rejects mutations that do not bind the tenant id explicitly. Fail-closed: any unsupported SQL shape (subquery in FROM, schema-qualified names, missing WHERE position) returns a sentinel error and the runtime aborts the query. Strips comments and string literals before content scans so attackers cannot hide tenant table names inside them.
+
+### `testing.go`
+
+End-to-end test runner for `test` blocks. `RunTests` iterates test scenarios; `runSingleTest` drives an `http.Client` with a cookie jar and `CheckRedirect` returning `http.ErrUseLastResponse` so redirects are observable. Implements steps: `as <role>` (creates user, logs in, extracts CSRF), `visit`, `submit`, `expect`, `expect_redirect`, etc. Used by the `kilnx test` CLI command, not at request time.
+
+### `unfurl.go`
+
+Open Graph metadata fetcher for link previews. 5-second timeout, 3-redirect cap. Caches results in-memory for one hour. Parses `<meta property="og:..."` and `<meta name="twitter:..."` tags plus `<title>` as a fallback. Used by template helpers that render link previews.
+
+### `watcher.go`
+
+Development hot reload. `WatchAndServe` is the entry point used by `kilnx run`: loads the app, prints routes, starts the server, and spawns `watchFile` to poll the source file's mtime every 500ms. Imports are resolved transitively (`resolveImports`, depth cap 64, project-root containment check, `.kilnx` extension required) so editing any imported file triggers a full reparse. On reload `Reload`/`StartScheduler`/`RefreshJobQueue` are called in sequence.
+
+### `interfaces.go`
+
+`AppRuntime` interface implemented by `*Server`. Lets tests and downstream packages depend on the abstraction rather than the concrete type. Exposes `RenderPage`, `HandleAction`, `HandleAPI`.
+
+## Cross-cutting hot spots
+
+A few pieces of behavior are scattered across files because they are touched by many sub-areas:
+
+- **`renderContext`** and the template engine span `render.go`, `layout.go`, and `i18n.go`.
+- **`executeNodes`** is the AST walker that runs action bodies; it is in `server.go` but is invoked from `webhook.go`, `scheduler.go`, `api.go`, and the action path.
+- **`evalRequiresClauses`** is in `permissions.go` but is called from `stream.go`, `api.go`, the action path, and the page-render guard.
+- **`RewriteTenantSQL`** in `tenant.go` is the single chokepoint for tenant scoping; every SQL execution path that touches user data must call it. New SQL execution sites are the most common place to introduce a bug.
+- **`resolveKxValue`** and `substituteParams` from `expr.go` are the canonical way to interpolate user-supplied values; never use `strings.ReplaceAll` directly on a `:param` token.
+
+## Gotchas
+
+- **String-first by design**. Every value flowing through the runtime is a string. Numeric coercion happens at the edges (`fnInt`, `jsonCoerce`, computed fields). Resist adding typed scaffolding inside the engine; it shows up as cascading complexity in the templating and SQL layers.
+- **Hot reload swaps the AST under a write lock**. Anything that caches parser pointers (manifests, fragment indexes, tenant maps) must be rebuilt in `Reload`. Forgetting one creates ghost behavior after edits.
+- **Permissions and requires clauses are independent layers**. The role-based map handles coarse access; clauses handle row-level conditions. Both must pass. Adding a guard means checking both.
+- **Tenant rewriter is fail-closed**. If your new SQL shape returns `ErrUnsafeTenantShape`, the right answer is usually to refactor the SQL, not to widen the rewriter. Widening it requires a security review.
+- **CSRF tokens have a 30-minute TTL with a background sweeper**. Tests that drive forms slowly can race the sweeper. Use the test client in `testing.go` rather than ad-hoc HTTP.
+- **WebSocket framing is hand-rolled**. There is no `gorilla/websocket` here. Bug-fix WebSocket code with care; tests in `websocket_test.go` are the spec.
+- **Slow-query callback is wired only for real `*database.DB`**. Tests using a fake `Executor` skip slow-query telemetry; real-world dashboards reflect production behavior only.
+- **Auth defaults are aggressive**. `defaultAuthRateLimits` applies even when the user has no `limit` block. Disabling those requires declaring an explicit `limit` for the auth path.
+- **`config.secret` falls back to a random ephemeral value**. Sessions invalidate on every restart in that case. The warning is on stderr; ops dashboards must surface it.
+
+## When to touch this package
+
+Almost any user-visible behavior change ends up here. A non-exhaustive triage:
+
+- New keyword or AST node: parser/analyzer changes first, then a new sub-area or extension to an existing one. New files belong with their conceptual neighbors (a new auth method goes in `auth.go`, a new fetch flag in `fetch.go`).
+- New template syntax: `render.go`. Update the directive table at the top of the file.
+- New stdlib function: `expr.go`, register in the `stdlib` map.
+- New permission action: `permissions.go` and the regex.
+- New dialect-aware behavior: usually belongs in [`internal/database`](./database.md), not here. Cross-check before adding.
+- Anything security-relevant (auth, CSRF, tenant scoping, webhook signatures): always pair with `LogSecurity` and an integration test.
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/packages/spec.md
+++ b/docs/contributors/packages/spec.md
@@ -1,0 +1,272 @@
+# `internal/spec`
+
+> Package spec is the canonical schema for Kilnx language entities (keywords and attributes).
+
+| | |
+|---|---|
+| **Import path** | `github.com/kilnx-org/kilnx/internal/spec` |
+| **Source last touched** | `5da8498` (2026-05-08) |
+
+
+## Files
+
+| File | Summary |
+|------|---------|
+| [`spec.go`](../../../internal/spec/spec.go) | _no file-level doc_ |
+
+## Types
+
+### `Arg`
+
+```go
+type Arg struct {
+	Name		string
+	Type		string
+	Required	bool
+	Variadic	bool
+}
+```
+### `Entity`
+
+```go
+type Entity struct {
+	Name		string
+	Kind		Kind
+	Summary		string
+	Description	string
+	Syntax		string
+	Args		[]Arg
+	ParentScope	[]string
+	Children	[]string
+	Repeatable	bool
+	Required	bool
+	Default		string
+	Since		string
+	Examples	[]Example
+	SeeAlso		[]string
+}
+```
+### `Example`
+
+```go
+type Example struct {
+	Title	string
+	Code	string
+}
+```
+### `Kind`
+
+```go
+type Kind int
+```
+## Functions
+
+### `All`
+
+```go
+func All() map[string]Entity
+```
+
+All returns a copy of the registry. Order is unspecified.
+
+### `ByKind`
+
+```go
+func ByKind(k Kind) []Entity
+```
+### `ChildrenOf`
+
+```go
+func ChildrenOf(parent string) []Entity
+```
+
+ChildrenOf returns the union of:
+  - entities listed explicitly in parent.Children
+  - entities whose ParentScope contains parent (reverse lookup)
+
+Result is deduped by Name and sorted alphabetically.
+
+### `Get`
+
+```go
+func Get(name string) (Entity, bool)
+```
+### `ParentsOf`
+
+```go
+func ParentsOf(attr string) []Entity
+```
+### `Register`
+
+```go
+func Register(e Entity)
+```
+
+Register adds an entity to the registry. Intended to be called from
+init() in the package that implements the entity (parser, lexer, etc).
+
+Re-registering an attribute with the same Name is allowed for overloaded
+DSL keywords that appear in multiple parent contexts (e.g. `requests`
+inside `log` and `limit`). The ParentScope of the existing entity is
+extended with the new entry's parents, and a context-specific note is
+appended to the Description. For keywords, duplicate registration panics.
+
+### `contains`
+
+```go
+func contains(s []string, v string) bool
+```
+### `(Kind) String`
+
+```go
+func (k Kind) String() string
+```
+
+## Notes
+
+<!-- MANUAL-NOTES START -->
+# Package `internal/spec`
+
+Source: [spec.go](../../../internal/spec/spec.go).
+
+## Purpose
+
+Define the canonical schema for Kilnx language entities (keywords and attributes) and host the registry that documentation tooling reads. Entities are not declared in this package: they live next to their implementation (for example [`internal/parser/page_spec.go`](../../../internal/parser/page_spec.go)) and register themselves via `Register` at `init()` time. [`cmd/kilnx-gendocs`](../../../cmd/kilnx-gendocs/main.go) then imports those packages and walks the populated registry.
+
+## Pipeline position
+
+```
+parser/*_spec.go init()  -> spec.Register -> in-memory registry
+                                              |
+cmd/kilnx-gendocs main()  ----- spec.All / spec.ByKind / spec.ChildrenOf -----> docs/devs/reference/*.md
+```
+
+The package has no runtime role beyond `init()` time registration. Production binaries built without the gendocs tool still import the registry transitively because each `*_spec.go` lives in `internal/parser`. This is harmless: the registry is a tiny in process map.
+
+## Public API
+
+```go
+type Kind int
+
+const (
+    KindKeyword Kind = iota
+    KindAttribute
+)
+
+func (k Kind) String() string
+
+type Entity struct {
+    Name        string
+    Kind        Kind
+    Summary     string
+    Description string
+    Syntax      string
+    Args        []Arg
+    ParentScope []string
+    Children    []string
+    Repeatable  bool
+    Required    bool
+    Default     string
+    Since       string
+    Examples    []Example
+    SeeAlso     []string
+}
+
+type Arg struct {
+    Name     string
+    Type     string
+    Required bool
+    Variadic bool
+}
+
+type Example struct {
+    Title string
+    Code  string
+}
+
+func Register(e Entity)
+func All() map[string]Entity
+func Get(name string) (Entity, bool)
+func ByKind(k Kind) []Entity
+func ChildrenOf(parent string) []Entity
+func ParentsOf(attr string) []Entity
+```
+
+## File map
+
+- [`spec.go`](../../../internal/spec/spec.go): `Kind`, `Entity`, `Arg`, `Example`, registry storage, `Register`, lookup helpers, sort behaviour.
+- [`spec_test.go`](../../../internal/spec/spec_test.go): tests for re-registration semantics and lookup helpers.
+
+## Entity fields
+
+- `Name`: identifier as written in source (`page`, `model`, `requires`, ...). Case sensitive. Must be non empty or `Register` panics.
+- `Kind`: `KindKeyword` for top level constructs, `KindAttribute` for child attributes that appear inside a parent block.
+- `Summary`: one line description used as a section header in generated docs.
+- `Description`: long form prose; markdown formatting (`backticks`, paragraph breaks) is preserved verbatim.
+- `Syntax`: a single line showing the canonical written form, e.g. `action <path> [method <verb>] [requires <clause>]`.
+- `Args`: positional arguments. Each `Arg` carries `Name`, `Type`, `Required`, and `Variadic`.
+- `ParentScope`: for attributes, the list of keyword names that may host this attribute. Empty for keywords. Extended automatically when an attribute is registered more than once.
+- `Children`: explicit list of child entity names. Used together with the `ParentScope` reverse lookup by `ChildrenOf`.
+- `Repeatable`: whether the entity may appear more than once in the same scope.
+- `Required`: whether the entity is mandatory in its scope.
+- `Default`: string form of the default value (used by the `method` attribute, for example).
+- `Since`: semver of the release that introduced the entity.
+- `Examples`: list of `(Title, Code)` snippets rendered in the docs.
+- `SeeAlso`: cross reference list of related entity names.
+
+## Registry storage and lookup
+
+The registry is a package level `var entities = map[string]Entity{}`. There is no mutex: registration happens at `init()` time, which Go serialises per package, so no concurrent writes occur. After `init()` the map is treated as read only.
+
+`All` returns a defensive copy; mutations on the result do not affect the registry. Iteration order is unspecified.
+
+`Get` is a plain map lookup with `ok` semantics.
+
+`ByKind` filters the registry and **sorts alphabetically by `Name`** before returning, so doc output is stable across runs.
+
+`ChildrenOf(parent)` returns the union of:
+
+- entities listed in `parent.Children`;
+- entities whose `ParentScope` slice contains `parent` (reverse lookup).
+
+The result is deduplicated by name and sorted alphabetically. This dual lookup means the parser can express the same parent/child relationship from either side.
+
+`ParentsOf(attr)` returns the entities named in the attribute's `ParentScope`, in registration order. It returns nil if the entity is missing or is a keyword.
+
+## `Register` semantics
+
+```go
+func Register(e Entity)
+```
+
+Calling `Register` with an empty `Name` panics. The behaviour for duplicate `Name` depends on `Kind`:
+
+**Duplicate keyword: panic.** Two `KindKeyword` registrations under the same name fail with `panic("spec.Register: duplicate keyword <name>")`. Keywords are unique identifiers in the language, so a duplicate is always a programming error.
+
+**Duplicate attribute: merge.** Attributes may be registered multiple times to express that the same attribute appears under different parents (for example `requests` inside both `log` and `limit`). The existing entry is updated:
+
+- new entries from `e.ParentScope` are appended (deduped via `contains`);
+- a context-specific note `When used in <parent>: <text>` is appended to `Description`, where `<text>` is the new `Description` (or `Summary` if `Description` is empty);
+- empty fields on the existing entry (`Summary`, `Syntax`, `Default`, `Args`) are filled from the new entry;
+- `Examples` are concatenated.
+
+Mismatched kinds (keyword versus attribute under the same name) panic with `kind mismatch`.
+
+## Consumed by `cmd/kilnx-gendocs`
+
+[`cmd/kilnx-gendocs`](../../../cmd/kilnx-gendocs/main.go) imports `internal/parser` (which transitively imports every `*_spec.go`), then calls `spec.ByKind(KindKeyword)` and `spec.ByKind(KindAttribute)` to drive its templates under `cmd/kilnx-gendocs/templates`. Output goes to `docs/devs/reference/<name>.md`. Run via the `go:generate` directive in [`internal/parser/doc.go`](../../../internal/parser/doc.go):
+
+```
+go generate ./...
+```
+
+## Key behaviors and gotchas
+
+**Registration order is import order.** Two attributes registered under the same name pick up fields from the first registration that supplies them. If two registrations both set `Summary`, the first wins. Authors should treat the first registration of an attribute as the canonical definition and let later registrations only extend `ParentScope` and `Examples`.
+
+**No removal API.** The registry is append only. Tests that need a clean registry must run in their own process or accept the cumulative state.
+
+**Sort stability.** Alphabetic sort in `ByKind` and `ChildrenOf` is the only guaranteed ordering. Do not rely on registration order for output.
+
+**Empty `ParentScope` plus `KindAttribute` is legal but useless.** Such an attribute will never be returned by `ChildrenOf` and will be filtered out of any parent based docs section. Authors should always set `ParentScope` for attributes.
+<!-- MANUAL-NOTES END -->

--- a/docs/contributors/testing.md
+++ b/docs/contributors/testing.md
@@ -1,0 +1,203 @@
+# Testing
+
+Testing conventions used across the Kilnx Go codebase. Two distinct concerns share the word "test":
+
+1. **Go tests for the Kilnx implementation.** Standard `go test` covering the lexer, parser, analyzer, optimizer, runtime, and CLI. This page is mostly about these.
+2. **The `test` keyword inside `.kilnx` apps.** A small DSL for HTTP-level smoke tests that user apps run via `kilnx test app.kilnx`. See [`docs/devs/reference/keywords/test.md`](../devs/reference/keywords/test.md) and the runner in [`internal/runtime/testing.go`](../../internal/runtime/testing.go). Mentioned here for completeness, treated separately below.
+
+## Running the suite
+
+```bash
+go test ./...                 # all packages
+go test -race ./...           # race detector, the default for local dev
+go test -run TestParse ./internal/parser
+go test -bench=. ./internal/parser
+go test -fuzz=FuzzParse ./internal/parser
+```
+
+CI runs `go test -race ./...` plus the smoke pipeline. See [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml).
+
+## Layout
+
+Tests live next to the code they cover, no separate `tests/` tree. One `_test.go` file per concern:
+
+```
+internal/parser/parser_test.go        recursive descent parser
+internal/parser/bench_test.go         parser benchmarks
+internal/parser/fuzz_test.go          parser fuzz seeds
+internal/parser/spec_test.go          spec registry invariants
+internal/analyzer/analyzer_test.go    type/schema checks
+internal/analyzer/security_test.go    security rules
+internal/runtime/server_render_test.go HTTP rendering integration
+internal/runtime/webhook_test.go      webhook handler
+internal/runtime/*_e2e_test.go        end-to-end HTTP integration
+internal/pathutil/match_test.go       URL path matching
+smoke/                                .kilnx files exercised by CI
+```
+
+## Table-driven tests
+
+The default style. Cleanest example: [`internal/pathutil/match_test.go`](../../internal/pathutil/match_test.go).
+
+```go
+func TestMatch(t *testing.T) {
+    cases := []struct {
+        template string
+        path     string
+        want     bool
+    }{
+        {"/tasks/:id/delete", "/tasks/123/delete", true},
+        {"/tasks/:id", "/tasks/abc", true},
+        {"/tasks/:id", "/tasks/abc/extra", false},
+        {"/", "/", true},
+    }
+    for _, tc := range cases {
+        got := Match(tc.template, tc.path)
+        if got != tc.want {
+            t.Errorf("Match(%q,%q) = %v, want %v",
+                tc.template, tc.path, got, tc.want)
+        }
+    }
+}
+```
+
+Use this whenever a function has clear input and expected output. Name the slice `cases` or `tests`, name the iterator `tc` or `tt`. Skip subtests (`t.Run`) for short tables; promote to `t.Run(tc.name, ...)` when failure messages stop being self-describing.
+
+## Parser tests
+
+[`internal/parser/parser_test.go`](../../internal/parser/parser_test.go) defines two helpers reused throughout the package:
+
+```go
+func parse(t *testing.T, src string) *App {
+    t.Helper()
+    tokens := lexer.Tokenize(src)
+    app, err := Parse(tokens, src)
+    if err != nil {
+        t.Fatalf("parse error: %v", err)
+    }
+    return app
+}
+
+func parseAllowErrors(t *testing.T, src string) (*App, error) {
+    t.Helper()
+    tokens := lexer.Tokenize(src)
+    return Parse(tokens, src)
+}
+```
+
+A typical parser test looks like:
+
+```go
+func TestPageRequiresAuth(t *testing.T) {
+    app := parse(t, "page /dashboard requires auth\n  \"Dashboard\"")
+    p := app.Pages[0]
+    if !p.Auth {
+        t.Error("page should have Auth=true")
+    }
+    if p.RequiresRole != "auth" {
+        t.Errorf("expected RequiresRole 'auth', got %q", p.RequiresRole)
+    }
+}
+```
+
+To add a parser test for a new keyword or attribute:
+
+1. Pick the smallest source string that exercises the path. Use `\n` and indented lines.
+2. Call `parse(t, src)` (or `parseAllowErrors` if you want to assert error behavior).
+3. Index into `app.Pages`, `app.Webhooks`, etc., and assert AST fields.
+
+For invariants over the entire spec registry (every entity has a `Summary`, all `Children` are registered, etc.), add to [`spec_test.go`](../../internal/parser/spec_test.go) rather than rolling your own walker.
+
+## Analyzer tests
+
+Analyzer tests build a `parser.App` directly via struct literals, no parser involved. See [`internal/analyzer/analyzer_test.go`](../../internal/analyzer/analyzer_test.go) and [`internal/analyzer/security_test.go`](../../internal/analyzer/security_test.go):
+
+```go
+func TestCheckWebhookSecrets(t *testing.T) {
+    app := &parser.App{
+        Webhooks: []parser.Webhook{
+            {Path: "/webhook/stripe"},
+            {Path: "/webhook/github", SecretEnv: "GITHUB_SECRET"},
+        },
+    }
+    diags := checkWebhookSecrets(app)
+    if len(diags) != 1 {
+        t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+    }
+    if !strings.Contains(diags[0].Context, "/webhook/stripe") {
+        t.Errorf("expected context about /webhook/stripe, got %q", diags[0].Context)
+    }
+}
+```
+
+To add a new analyzer test:
+
+1. Construct the `parser.App` directly. Skip the parser, you want full control of the AST shape and a stable input.
+2. Call the specific check function (`checkWebhookSecrets`, `checkPasswordExposure`, etc.) rather than the umbrella `Analyze`. Tighter assertions, faster feedback.
+3. Assert on the number of diagnostics first, then on `Severity`, `Message`, and `Context`. Avoid asserting exact messages: use `strings.Contains` for the substring you care about.
+
+## Runtime tests
+
+Runtime tests use `net/http/httptest`. Two flavors:
+
+- **Unit tests**: drive a single handler with a fabricated request. Example: [`internal/runtime/webhook_test.go`](../../internal/runtime/webhook_test.go) builds a `parser.Webhook`, computes an HMAC, and calls `s.handleWebhook(rr, req, wh)` directly.
+- **End-to-end tests**: spin up the full server and hit it over HTTP. Files end in `_e2e_test.go`, e.g. [`webhook_e2e_test.go`](../../internal/runtime/webhook_e2e_test.go), [`requires_clauses_e2e_test.go`](../../internal/runtime/requires_clauses_e2e_test.go), [`stream_e2e_test.go`](../../internal/runtime/stream_e2e_test.go).
+
+Helpers in [`mock_test.go`](../../internal/runtime/mock_test.go) and [`helpers_test.go`](../../internal/runtime/helpers_test.go) build a `*Server` against an in-memory SQLite for both flavors.
+
+## Benchmarks
+
+Standard Go bench format, one file per package: [`internal/parser/bench_test.go`](../../internal/parser/bench_test.go), [`internal/analyzer/bench_test.go`](../../internal/analyzer/bench_test.go), [`internal/runtime/bench_test.go`](../../internal/runtime/bench_test.go). Name benchmarks `BenchmarkX1k`, `BenchmarkX10k`, etc., when scaling input size. Run with:
+
+```bash
+go test -bench=. -benchmem ./internal/parser
+```
+
+## Fuzzing
+
+The parser has a fuzz harness at [`internal/parser/fuzz_test.go`](../../internal/parser/fuzz_test.go) seeded with realistic `.kilnx` snippets covering each top-level keyword. Run locally:
+
+```bash
+go test -fuzz=FuzzParse -fuzztime=30s ./internal/parser
+```
+
+Crashes are saved under `internal/parser/testdata/fuzz/`. When a fuzz crash is fixed, the corpus entry is left in place as a permanent regression test.
+
+## Smoke tests
+
+[`smoke/`](../../smoke/) holds tiny `.kilnx` programs the CI pipeline runs end to end. The current entry is [`hello.kilnx`](../../smoke/hello.kilnx):
+
+```kilnx
+page /
+  html
+    <p>Hello World</p>
+
+test "homepage loads"
+  visit /
+  expect status 200
+  expect page / contains "Hello World"
+```
+
+CI exercises three paths against this file (see [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) and [`.github/workflows/declarative-tests.yml`](../../.github/workflows/declarative-tests.yml)):
+
+```bash
+./kilnx check smoke/hello.kilnx
+./kilnx test  smoke/hello.kilnx
+./kilnx build smoke/hello.kilnx -o hello
+```
+
+Add a new smoke file when introducing a feature large enough to need an integration story but small enough to live in a self-contained `.kilnx` example. Keep them under fifty lines.
+
+## The `test` keyword inside .kilnx apps
+
+Distinct from Go testing: the `test` block is a feature of the Kilnx language itself. The runner is [`RunTests`](../../internal/runtime/testing.go) in `internal/runtime/testing.go`. Steps include `as <role>`, `visit <path>`, `fill <field> <value>`, `submit`, and `expect status N` / `expect page <path> contains "<text>"`. The full reference is generated at [`docs/devs/reference/keywords/test.md`](../devs/reference/keywords/test.md). When changing the runner, add coverage in [`testing_test.go`](../../internal/runtime/testing_test.go).
+
+## Pre-commit and CI
+
+The repo ships a hook bundle at `.githooks/` enabled via:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+`pre-commit` runs `gofmt`, `go vet`, and `go run ./cmd/kilnx-gendocs` so spec changes always commit alongside their generated docs. CI re-runs the same checks plus `go test -race ./...`, the smoke pipeline, and `kilnx-gendocs -check-stale`. Keep the local loop tight: `go test -race ./...` should pass before pushing.

--- a/docs/devs/concepts/auth-and-permissions.md
+++ b/docs/devs/concepts/auth-and-permissions.md
@@ -1,0 +1,125 @@
+# Auth and permissions
+
+Kilnx ships with email/password authentication. You declare an [`auth`](../reference/keywords/auth.md) block and the runtime wires up login, logout, registration, password reset, sessions, CSRF protection, and bcrypt hashing. Authorization, when needed, is layered on top with [`permissions`](../reference/keywords/permissions.md).
+
+## The auth block
+
+`auth` points at a model and tells the runtime which fields hold the identity and the password hash.
+
+```kilnx
+model user
+  email: email required unique
+  password: password required
+  name: text
+  role: option [admin, editor, viewer] default "viewer"
+  created_at: timestamp auto
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  logout: /logout
+  register: /register
+  after login: /dashboard
+  superuser: env SUPERUSER_EMAIL
+```
+
+The runtime serves login, logout, and registration forms at the configured paths. Submitted passwords are hashed with bcrypt before they hit the database. Sessions are HMAC-signed cookies; the signing secret comes from the `SECRET_KEY` env var or from a `secret` attribute inside [`config`](../reference/keywords/config.md).
+
+The `superuser` line designates an identity (here, an email read from `SUPERUSER_EMAIL`) that bypasses role checks. Useful for the bootstrap admin.
+
+## Protecting routes
+
+Any [`page`](../reference/keywords/page.md), [`action`](../reference/keywords/action.md), [`fragment`](../reference/keywords/fragment.md), or [`api`](../reference/keywords/api.md) can require auth with the [`requires`](../reference/attributes/requires.md) attribute:
+
+```kilnx
+page /dashboard requires auth
+  html
+    <h1>Welcome, {current_user.name}</h1>
+```
+
+`requires auth` accepts any logged-in user. If the request is not authenticated, the runtime redirects to the login path declared in the `auth` block.
+
+`current_user` is bound automatically inside protected routes. Use it in queries (`WHERE owner = :current_user.id`) and templates (`{current_user.name}`).
+
+## CSRF and form posts
+
+CSRF protection is on by default. Every action that accepts form input expects a CSRF token. The runtime injects the token into rendered forms via the standard template helpers, so for htmx and regular form posts it is automatic. You only need to think about CSRF if you build a custom form outside the template engine.
+
+Sessions are HTTP-only and signed. There is no client-side session handling.
+
+## Permissions: roles and rules
+
+`requires auth` is binary. For role-based rules, declare a [`permissions`](../reference/keywords/permissions.md) block:
+
+```kilnx
+permissions
+  admin: all
+  editor: read post, write post where author = current_user
+  viewer: read post where status = published
+```
+
+Each role gets a list of rules. The vocabulary is small:
+
+- `all`: every action on every resource.
+- `read <resource>`: SELECTs against the named model.
+- `write <resource>`: INSERT, UPDATE, DELETE.
+- `where <expression>`: an optional filter, evaluated against the row and `current_user`.
+
+Routes opt in by name:
+
+```kilnx
+page /admin requires admin
+  html
+    <h1>Admin</h1>
+
+action /posts/:id/publish requires editor
+  query: UPDATE post SET status = 'published' WHERE id = :id
+  redirect /posts
+```
+
+If the current user's role does not satisfy the rule, the runtime returns 403.
+
+The `where` clause is enforced both at the route layer and inside model-bound queries. A viewer hitting `SELECT * FROM post` only sees rows where `status = 'published'`, even if the SQL did not include that filter explicitly. The analyzer rewrites the query to add the rule's predicate.
+
+## A complete slice
+
+```kilnx
+model user
+  email: email required unique
+  password: password required
+  role: option [admin, editor, viewer] default "viewer"
+
+model post
+  title: text required
+  body: text
+  author: reference user required
+  status: option [draft, published] default "draft"
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  after login: /
+
+permissions
+  admin: all
+  editor: read post, write post where author = current_user
+  viewer: read post where status = published
+
+page / requires auth
+  query posts: SELECT id, title, status FROM post ORDER BY id DESC
+  html
+    {{each posts}}
+    <li>{title} ({status})</li>
+    {{end}}
+```
+
+A viewer sees only published posts. An editor sees their own drafts plus all published. An admin sees everything.
+
+## Read next
+
+- [Pages, actions, fragments](pages-actions-fragments.md): the routes you are protecting.
+- [Models and data](models-and-data.md): the `user` model under `auth`.

--- a/docs/devs/concepts/index.md
+++ b/docs/devs/concepts/index.md
@@ -1,0 +1,23 @@
+# Concepts
+
+These pages explain how Kilnx is meant to be used, not just what each keyword does. If you want a syntax lookup, jump to the [reference](../reference/index.md).
+
+Read them in order the first time. Each page assumes the previous ones.
+
+## The pages
+
+- [Mental model](mental-model.md): what kind of language Kilnx is, how `kilnx run` and `kilnx build` differ, and why files are indent-significant.
+- [Models and data](models-and-data.md): declaring tables with `model`, field types and constraints, automatic migrations, SQLite versus Postgres.
+- [Pages, actions, fragments](pages-actions-fragments.md): the three building blocks of the HTTP layer, and where `api` fits.
+- [Auth and permissions](auth-and-permissions.md): the `auth` block, sessions, CSRF, and role-based rules with `permissions`.
+- [Jobs and schedules](jobs-and-schedules.md): asynchronous work with `job` plus `enqueue`, recurring tasks with `schedule`, inbound events with `webhook`.
+
+## Reading path by goal
+
+If you are evaluating Kilnx, read the [mental model](mental-model.md) first. It is the shortest answer to "what is this".
+
+If you are porting an existing CRUD app, [models and data](models-and-data.md) plus [pages, actions, fragments](pages-actions-fragments.md) cover most of what you need.
+
+If you need login and roles, go straight to [auth and permissions](auth-and-permissions.md). It assumes you have a `user` model.
+
+If your app needs background work or third-party integrations, [jobs and schedules](jobs-and-schedules.md) covers `job`, `schedule`, and `webhook`.

--- a/docs/devs/concepts/jobs-and-schedules.md
+++ b/docs/devs/concepts/jobs-and-schedules.md
@@ -1,0 +1,113 @@
+# Jobs and schedules
+
+Some work should not block an HTTP response. Some work should run on a clock. Some work is triggered by an external system. Kilnx covers the three cases with [`job`](../reference/keywords/job.md), [`schedule`](../reference/keywords/schedule.md), and [`webhook`](../reference/keywords/webhook.md).
+
+## Jobs: asynchronous work
+
+A `job` is a named block that runs out-of-band. Pages and actions enqueue it; the runtime executes it on a worker.
+
+```kilnx
+job generate-report
+  retry 3
+  query: SELECT * FROM order WHERE created > :start_date
+  send email to :requested_by
+    subject: "Your report is ready"
+```
+
+`retry 3` tells the runtime to re-run the job up to three times if it fails. After exhausting retries, the job is marked failed and surfaced to the logs.
+
+To trigger the job, use [`enqueue`](../reference/attributes/enqueue.md) inside any route or another job:
+
+```kilnx
+action /reports/request method POST requires auth
+  enqueue generate-report
+    start_date: :form.start_date
+    requested_by: :current_user.email
+  redirect /reports
+```
+
+The action returns immediately after enqueuing. The job runs in the background and the user is redirected.
+
+Jobs are useful for slow operations: bulk emails, PDF generation, third-party API calls, report rollups. The pattern is "respond fast, finish later".
+
+## Schedules: recurring work
+
+A `schedule` runs on a cadence, set by [`every`](../reference/attributes/every.md). The argument is a duration or a cron expression.
+
+```kilnx
+schedule cleanup-sessions every 1h
+  query: DELETE FROM session WHERE expires_at < now()
+```
+
+The runtime invokes the body once per interval. Common cadences:
+
+- `every 30s`, `every 5m`, `every 1h`, `every 24h`: durations.
+- `every "0 0 * * *"`: cron, runs at midnight.
+- `every "*/15 * * * *"`: cron, every fifteen minutes.
+
+Schedules can do anything a job can: run queries, send emails, fetch external APIs, or enqueue jobs themselves:
+
+```kilnx
+schedule daily-digest every "0 8 * * *"
+  query users: SELECT id, email FROM user WHERE digest_opt_in = true
+  enqueue send-digest
+    user_ids: :users.id
+```
+
+This pattern (schedule fans out work to a job) keeps schedule bodies short and lets the job system handle retries per item.
+
+Schedules execute in-process. If you run multiple replicas of the binary, every replica fires its own schedule. For distributed cron without duplicates, run one replica with schedules enabled, or use an external scheduler that calls a route.
+
+## Webhooks: inbound events
+
+A `webhook` is the inverse of a schedule: someone else calls you. The runtime verifies an HMAC signature against a shared secret read from an env var, then dispatches to a handler matching the event name.
+
+```kilnx
+webhook /stripe/payment secret env STRIPE_SECRET
+  on event payment_intent.succeeded
+    query: UPDATE order SET status = 'paid' WHERE stripe_id = :event_id
+
+  on event payment_intent.failed
+    query: UPDATE order SET status = 'failed' WHERE stripe_id = :event_id
+```
+
+The path is the URL the third party calls. The secret env var holds the signing key. Each `on event` matches a specific event name in the payload. Unrecognized events are ignored (or you can add a default handler).
+
+Webhooks are the right tool for payment confirmations, VCS pushes, mail provider events, and anything else where the world tells your app something changed.
+
+## Putting them together
+
+A small order-processing flow uses all three:
+
+```kilnx
+model order
+  amount: float required
+  status: option [pending, paid, failed, fulfilled] default "pending"
+  stripe_id: text unique
+  created: timestamp auto
+
+job fulfill-order
+  retry 5
+  query: UPDATE order SET status = 'fulfilled' WHERE id = :order_id
+  send email to :customer_email
+    subject: "Your order shipped"
+
+webhook /stripe/payment secret env STRIPE_SECRET
+  on event payment_intent.succeeded
+    query: UPDATE order SET status = 'paid' WHERE stripe_id = :event_id
+    enqueue fulfill-order
+      order_id: :event.metadata.order_id
+      customer_email: :event.metadata.email
+
+schedule chase-pending every 6h
+  query stale: SELECT id FROM order WHERE status = 'pending' AND created < now() - interval '24 hours'
+  enqueue chase-customer
+    order_ids: :stale.id
+```
+
+Stripe posts to the webhook. The webhook updates the order and enqueues fulfillment. The fulfillment job retries up to five times and emails the customer. A schedule chases stale orders every six hours.
+
+## Read next
+
+- [Auth and permissions](auth-and-permissions.md): webhooks bypass session auth, but routes that trigger jobs typically require it.
+- [Reference](../reference/index.md): full attribute lists for `job`, `schedule`, and `webhook`.

--- a/docs/devs/concepts/mental-model.md
+++ b/docs/devs/concepts/mental-model.md
@@ -1,0 +1,68 @@
+# Mental model
+
+Kilnx is a declarative language for web backends. You write `.kilnx` files, the compiler reads them, and the runtime serves HTTP. The whole thing is around 27 keywords.
+
+## Declarative, not imperative
+
+A Kilnx file describes the shape of an application: which models exist, which routes serve them, which queries run on each route. There is no `main` function, no request handler signature, no router to register. You declare a [`page`](../reference/keywords/page.md), and a route exists.
+
+```kilnx
+page /about
+  html
+    <h1>About us</h1>
+```
+
+When something needs custom logic, the language gives you primitives (`query`, `validate`, `redirect`, `respond`, `enqueue`, `send`, `fetch`) instead of dropping you into Go.
+
+## Indent-significant syntax
+
+Blocks are defined by indentation, like Python or YAML. Two spaces per level is conventional. The keyword opens a block, and indented children belong to it:
+
+```kilnx
+model task
+  title: text required
+  done: bool default false
+```
+
+Children of `model` are field declarations. Children of `page` are queries, validations, and the response. The parser rejects mixed tabs and spaces.
+
+## How `kilnx run` and `kilnx build` differ
+
+There are two ways to execute a `.kilnx` file.
+
+`kilnx run app.kilnx` parses the file, builds the AST in memory, and starts an HTTP server that interprets it. Migrations apply on startup. Edits to the file are picked up on restart. This is the dev loop.
+
+`kilnx build app.kilnx -o app` produces a standalone binary that embeds the AST, the runtime, your templates, htmx, SQLite, and bcrypt. The output is around 15 MB and has no external dependencies. This is what you ship.
+
+There is no separate "code generation" step in either case. The AST drives the runtime. `build` just freezes the AST inside an executable. There is no Go file written to disk that mirrors your `.kilnx`.
+
+## Pipeline
+
+Every run, in either mode, walks the same pipeline:
+
+```
+.kilnx -> Lexer -> Parser -> Analyzer -> Optimizer -> Runtime
+```
+
+The analyzer checks types, validates that queries reference real columns, and confirms that templates only use bound variables. The optimizer rewrites `SELECT *` to the columns your templates actually use, and folds constants. The runtime then serves HTTP.
+
+If `kilnx check app.kilnx` returns clean, the file will run.
+
+## How it compares
+
+If you know Rails or Django, Kilnx is in the same neighborhood: a full-stack server framework that owns the database, the routes, and the rendered HTML. The differences are scope and surface.
+
+Rails and Django are libraries on top of a host language. You write Ruby or Python, you call into the framework, and the framework calls back into your code. Kilnx is the language. There is no host language to learn alongside it. The downside is that custom logic outside the provided primitives (LLM calls, email, fetch, validate, queries) is not available; the upside is that you can read any Kilnx app from top to bottom without leaving the file.
+
+If you know [htmx](https://htmx.org), Kilnx is the natural server pair. Pages render full HTML, [fragments](../reference/keywords/fragment.md) render partials, and the runtime understands swap targets, triggers, and SSE. htmx is bundled in the binary, but it is not required: any client that speaks HTTP works. JSON endpoints exist via [`api`](../reference/keywords/api.md).
+
+## What the file produces
+
+A single `.kilnx` file can contain everything: models, auth, pages, fragments, APIs, jobs, schedules, webhooks, tests. Files can also be split, but the runtime sees the merged AST. There is no module system in the conventional sense, because there is no procedural code to scope.
+
+The output of `kilnx run` is an HTTP server. The output of `kilnx build` is a binary. Both are driven by the same AST, validated by the same analyzer, optimized by the same passes.
+
+## Read next
+
+- [Models and data](models-and-data.md): how `model` becomes a table.
+- [Pages, actions, fragments](pages-actions-fragments.md): the HTTP layer.

--- a/docs/devs/concepts/models-and-data.md
+++ b/docs/devs/concepts/models-and-data.md
@@ -1,0 +1,114 @@
+# Models and data
+
+A [`model`](../reference/keywords/model.md) declares a table. The runtime auto-migrates the schema on startup: adding fields, indexes, or unique constraints triggers `ALTER TABLE` automatically.
+
+## Declaring a model
+
+```kilnx
+model user
+  email: email required unique
+  name: text required
+  role: option [admin, editor, viewer] default "viewer"
+  age: int min 18 max 120
+  created_at: timestamp auto
+```
+
+Each field follows the shape `name: <type> [constraint...]`. The type is required. Constraints are space-separated.
+
+## Field types
+
+Built-in types include:
+
+- `text`, `email`, `password`: strings, with format validation on `email` and bcrypt hashing on `password`.
+- `int`, `float`: numerics, support `min` and `max`.
+- `bool`: boolean, often paired with `default false` or `default true`.
+- `timestamp`, `date`: time values, support `auto` and `auto_update`.
+- `uuid`: UUID v4, usually with `auto`.
+- `image`, `file`: uploads, see [`uploads`](../reference/attributes/uploads.md) under `config`.
+- `json`: structured data stored as JSON.
+- `reference <model>`: foreign key to another model.
+- `option [a, b, c]`: enum-like, restricted to the listed values.
+- `tags`: list of string tags.
+
+## Constraints
+
+The most common constraints, all documented in the reference:
+
+- [`required`](../reference/attributes/required.md): `NOT NULL` plus runtime validation.
+- [`unique`](../reference/attributes/unique.md): single-field unique constraint.
+- [`default <value>`](../reference/attributes/default.md): database-level default.
+- [`min`](../reference/attributes/min.md) and [`max`](../reference/attributes/max.md): numeric range or string length.
+- [`auto`](../reference/attributes/auto.md): auto-fill on insert. UUIDs get a v4, timestamps get the current time, integer IDs auto-increment.
+- [`auto_update`](../reference/attributes/auto_update.md): auto-fill on insert and update. Standard for `updated_at: timestamp auto_update`.
+- [`tenant: <model>`](../reference/attributes/tenant.md): scope all rows to a tenant model. Auto-synthesizes the FK and filters queries by the current tenant.
+
+For composite indexes and uniqueness:
+
+```kilnx
+model invoice
+  tenant: account
+  amount: float required
+  status: option [draft, sent, paid] default "draft"
+  index (tenant, status)
+```
+
+See the [model reference](../reference/keywords/model.md) for the full list.
+
+## Migrations
+
+Migrations are not separate files. The runtime diffs the declared schema against the live database on startup and applies the changes. Adding a field, an index, or a unique constraint is automatic. Renames and destructive changes are not inferred; for those, write the SQL yourself or add the new field and migrate data with a `query` directive.
+
+There is no `db migrate` command. `kilnx run` and the built binary both migrate on start.
+
+## Database backends
+
+The database is selected by `DATABASE_URL`. The default is `sqlite://app.db`, a file in the working directory.
+
+```bash
+DATABASE_URL=sqlite:///var/data/app.db kilnx run app.kilnx
+```
+
+For Postgres:
+
+```bash
+DATABASE_URL=postgres://user:pass@host:5432/dbname kilnx run app.kilnx
+```
+
+You can also pin the URL declaratively inside a [`config`](../reference/keywords/config.md) block, which keeps the deployment uniform across environments.
+
+## Querying models
+
+Queries are inline SQL. The analyzer validates column references against the model definitions, so a typo in a `SELECT` is a compile error, not a runtime error.
+
+```kilnx
+page /tasks
+  query tasks: SELECT id, title, done FROM task ORDER BY created DESC paginate 20
+  html
+    {{each tasks}}
+    <li>{title}</li>
+    {{end}}
+```
+
+`paginate <n>` adds offset/limit handling and exposes pagination metadata to the template. The optimizer rewrites `SELECT *` to only the columns your template actually reads, so wide tables stay fast without manual column lists.
+
+For one-shot named queries reused across pages, declare a top-level [`query`](../reference/keywords/query.md) block.
+
+## Inserts and updates
+
+Writes go inside an [`action`](../reference/keywords/action.md) (form posts, deletes, updates):
+
+```kilnx
+action /tasks/new method POST
+  validate task
+  query: INSERT INTO task (title) VALUES (:title)
+  redirect /tasks
+```
+
+`validate task` runs the model's constraints (required, min, max, unique) against the form input before the insert.
+
+Bind parameters with `:name`. The runtime does parameter binding, never string interpolation, so SQL injection is not a concern.
+
+## Read next
+
+- [Pages, actions, fragments](pages-actions-fragments.md): how the HTTP layer uses these models.
+- [Auth and permissions](auth-and-permissions.md): the `auth` block sits on top of a `user` model.

--- a/docs/devs/concepts/pages-actions-fragments.md
+++ b/docs/devs/concepts/pages-actions-fragments.md
@@ -1,0 +1,146 @@
+# Pages, actions, fragments
+
+Three keywords cover almost the entire HTTP layer. [`page`](../reference/keywords/page.md) renders a full HTML document. [`action`](../reference/keywords/action.md) handles state-changing requests and redirects. [`fragment`](../reference/keywords/fragment.md) returns a slice of HTML, either as an htmx target or as a reusable include. JSON endpoints use [`api`](../reference/keywords/api.md), covered briefly at the end.
+
+## Page
+
+A `page` is a GET endpoint that returns a full HTML document. The body holds queries and the response template.
+
+```kilnx
+page /
+  html
+    <h1>Hello World</h1>
+```
+
+With data:
+
+```kilnx
+page /tasks
+  query tasks: SELECT id, title FROM task ORDER BY created DESC
+  html
+    <h1>Tasks</h1>
+    <ul>
+      {{each tasks}}
+      <li>{title}</li>
+      {{end}}
+    </ul>
+```
+
+Pages can carry attributes inline:
+
+```kilnx
+page /dashboard layout app title "Dashboard" requires auth
+  query @user_count: SELECT count(*) FROM users
+  html
+    <h1>{{ .user_count }} users</h1>
+```
+
+`layout`, `title`, and `requires` are common. See the [page reference](../reference/keywords/page.md) for the rest.
+
+## Action
+
+An `action` is a non-GET endpoint that mutates state. By default it does not return a full document; it ends with a [`redirect`](../reference/attributes/redirect.md) (typical browser flow) or with [`respond`](../reference/attributes/respond.md) (return a fragment to htmx).
+
+```kilnx
+action /users/create method POST requires auth
+  validate user
+  query: INSERT INTO user (email, name) VALUES (:email, :name)
+  redirect /users
+```
+
+`validate user` runs the model's constraints against the form payload. If validation fails, the request returns to the originating page with errors bound for the template.
+
+For htmx flows, swap the redirect for a fragment response:
+
+```kilnx
+action /tasks/:id/delete requires auth
+  query: DELETE FROM task WHERE id = :id AND owner = :current_user.id
+  respond fragment delete
+```
+
+This returns the rendered `delete` fragment, which htmx swaps into the DOM.
+
+## Fragment
+
+A `fragment` returns partial HTML without a document wrapper. There are two flavors.
+
+Route-based fragments respond to AJAX requests:
+
+```kilnx
+fragment /users/:id/card
+  query user: SELECT name, email FROM user WHERE id = :id
+  html
+    <div class="card">{user.name}</div>
+```
+
+Use them as `hx-get` or `hx-post` targets.
+
+Component-based fragments are reusable templates invoked by name from inside other pages or fragments:
+
+```kilnx
+fragment badge(status, color="blue")
+  html
+    <span class="{color}">{status}</span>
+```
+
+You include them in another template with the fragment name and arguments.
+
+## Putting it together
+
+A small CRUD slice usually pairs all three:
+
+```kilnx
+model task
+  title: text required
+  done: bool default false
+  created: timestamp auto
+
+page /tasks
+  query tasks: SELECT id, title, done FROM task ORDER BY created DESC
+  html
+    <h1>Tasks</h1>
+    <ul id="tasks">
+      {{each tasks}}
+      <li>{title}
+        <button hx-post="/tasks/{id}/delete"
+                hx-target="closest li" hx-swap="outerHTML">x</button>
+      </li>
+      {{end}}
+    </ul>
+    <form hx-post="/tasks/new" hx-target="#tasks" hx-swap="beforeend">
+      <input name="title" required>
+      <button>Add</button>
+    </form>
+
+action /tasks/new method POST
+  validate task
+  query new: INSERT INTO task (title) VALUES (:title) RETURNING id, title
+  respond fragment task-row
+
+action /tasks/:id/delete method POST
+  query: DELETE FROM task WHERE id = :id
+  respond status 200
+
+fragment task-row(task)
+  html
+    <li>{task.title}</li>
+```
+
+The page renders the initial list. The form submits to an action that inserts and returns a row fragment, which htmx appends. The delete button posts to an action that returns 200, and htmx removes the `<li>` based on `hx-swap`.
+
+## JSON: `api`
+
+When you need JSON, declare an [`api`](../reference/keywords/api.md). It looks like a `page` but returns serialized data instead of HTML.
+
+```kilnx
+api /api/tasks
+  query tasks: SELECT id, title, done FROM task
+  respond tasks
+```
+
+Use `api` for SPAs, mobile clients, or third-party integrations. The default response shape is JSON.
+
+## Read next
+
+- [Auth and permissions](auth-and-permissions.md): protect pages, actions, and fragments with `requires`.
+- [Models and data](models-and-data.md): the queries inside these blocks bind to your models.

--- a/docs/devs/index.md
+++ b/docs/devs/index.md
@@ -1,0 +1,53 @@
+# Kilnx for Developers
+
+Kilnx is a declarative backend language that compiles to a single Go binary. You describe your app in a `.kilnx` file: models, pages, actions, queries, auth. The compiler handles HTTP routing, SQL migrations, template rendering, sessions, CSRF, and htmx integration.
+
+The whole language is around 27 keywords. The runtime ships with two dependencies: SQLite and bcrypt. There is no JavaScript build step, no ORM to configure, no framework to pick.
+
+A complete app can fit in three lines:
+
+```kilnx
+page /
+  html
+    <h1>Hello World</h1>
+```
+
+`kilnx run app.kilnx` and you have an HTTP server on port 8080.
+
+## What to read next
+
+If you have never run Kilnx before, start with the quickstart. It walks from install to a running binary in five minutes.
+
+If you want to understand the model behind the language before writing code, jump into the concepts. They explain the runtime, data layer, request lifecycle, auth, and background work.
+
+If you already know the basics and want to look up a keyword, the reference is generated from the parser spec and is the source of truth.
+
+## Navigation
+
+- [Quickstart](quickstart.md): install, write `app.kilnx`, run it, build a binary.
+- [Concepts](concepts/index.md): the mental model and the main building blocks.
+  - [Mental model](concepts/mental-model.md)
+  - [Models and data](concepts/models-and-data.md)
+  - [Pages, actions, fragments](concepts/pages-actions-fragments.md)
+  - [Auth and permissions](concepts/auth-and-permissions.md)
+  - [Jobs and schedules](concepts/jobs-and-schedules.md)
+- [Reference](reference/index.md): every keyword and attribute, with syntax and examples.
+
+## Where Kilnx fits
+
+Kilnx is a full-stack server framework, closer in scope to Rails or Django than to Express or FastAPI. It expects to own the database schema, the HTTP layer, and the rendered HTML. The natural front end is [htmx](https://htmx.org), already embedded in the runtime, but any client that speaks HTTP works.
+
+Two design choices set the tone for everything else:
+
+1. SQL is part of the language. Queries are inline, parsed and validated against your models at compile time. There is no ORM in the path.
+2. The output is a binary. `kilnx build app.kilnx -o app` produces one executable that embeds the runtime, your templates, htmx, SQLite, and bcrypt. Copy it to a server and run it.
+
+Read [PRINCIPLES.md](https://github.com/kilnx-org/kilnx/blob/main/PRINCIPLES.md) for the constitutional rules that drive these decisions.
+
+## Editor support
+
+A [VS Code extension](https://marketplace.visualstudio.com/items?itemName=atoolz.kilnx-vscode-toolkit) provides syntax highlighting, diagnostics, completions, hover docs, and go-to-definition through the built-in LSP server.
+
+## Try it without installing
+
+The [online playground](https://kilnx.org/playground.html) runs Kilnx in the browser. Useful for quick experiments before installing the CLI.

--- a/docs/devs/quickstart.md
+++ b/docs/devs/quickstart.md
@@ -1,0 +1,120 @@
+# Quickstart
+
+Five minutes from zero to a running Kilnx app and a standalone binary.
+
+## 1. Install the CLI
+
+On macOS or Linux, install through Homebrew:
+
+```bash
+brew install kilnx-org/tap/kilnx
+```
+
+Or use the install script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kilnx-org/kilnx/main/install.sh | sh
+```
+
+The script downloads the latest release for your OS and architecture and drops the `kilnx` binary into `/usr/local/bin`. Verify the install:
+
+```bash
+kilnx version
+```
+
+If you prefer to build from source, clone the repo and run `go build -o kilnx ./cmd/kilnx/`.
+
+## 2. Hello World
+
+Create a file called `app.kilnx`:
+
+```kilnx
+page /
+  html
+    <h1>Hello World</h1>
+```
+
+Run it:
+
+```bash
+kilnx run app.kilnx
+```
+
+Open [http://localhost:8080](http://localhost:8080). You should see "Hello World".
+
+The default port is `8080`. To change it, set `PORT=3000` in your environment, or declare `port: 3000` inside a [`config`](reference/keywords/config.md) block.
+
+## 3. Add a model and a list
+
+Stop the server with `Ctrl+C` and edit `app.kilnx`:
+
+```kilnx
+model task
+  title: text required
+  done: bool default false
+  created: timestamp auto
+
+page /
+  query tasks: SELECT id, title, done FROM task ORDER BY created DESC
+  html
+    <h1>Tasks</h1>
+    <ul>
+      {{each tasks}}
+      <li>{title} {{if done}}(done){{end}}</li>
+      {{end}}
+    </ul>
+```
+
+Run `kilnx run app.kilnx` again. The first start auto-migrates the schema, creating a `task` table in a SQLite database file. The default database URL is `sqlite://app.db`. Override it by setting `DATABASE_URL` in the environment.
+
+The page is empty because there are no rows. Add one with the SQLite CLI or with a quick form:
+
+```kilnx
+action /tasks/new method POST
+  query: INSERT INTO task (title) VALUES (:title)
+  redirect /
+
+page /new
+  html
+    <form method="post" action="/tasks/new">
+      <input name="title" required>
+      <button>Add</button>
+    </form>
+```
+
+Visit [http://localhost:8080/new](http://localhost:8080/new), submit the form, and the redirect lands you back on the list.
+
+## 4. Static analysis
+
+Kilnx has a compile step that runs even before the server starts. To check your file without running it:
+
+```bash
+kilnx check app.kilnx
+```
+
+The analyzer validates field types, query column references, and route shapes. Errors point at line and column.
+
+## 5. Build a standalone binary
+
+When you are ready to ship:
+
+```bash
+kilnx build app.kilnx -o myapp
+```
+
+The output is a single executable, around 15 MB, that embeds the runtime, your templates, htmx, SQLite, and bcrypt. Copy it to any Linux or macOS host and run it:
+
+```bash
+scp myapp server:~/
+ssh server './myapp'
+```
+
+No runtime install on the server, no container required.
+
+## Where to go next
+
+- [Mental model](concepts/mental-model.md): how the runtime executes your file.
+- [Models and data](concepts/models-and-data.md): types, constraints, migrations.
+- [Pages, actions, fragments](concepts/pages-actions-fragments.md): the HTTP layer.
+- [Auth and permissions](concepts/auth-and-permissions.md): login, sessions, roles.
+- [Reference](reference/index.md): every keyword and attribute.

--- a/docs/devs/reference/attributes/after_login.md
+++ b/docs/devs/reference/attributes/after_login.md
@@ -31,5 +31,5 @@ Written `after login: <path>` (with a space) in source.
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
 

--- a/docs/devs/reference/attributes/as.md
+++ b/docs/devs/reference/attributes/as.md
@@ -21,7 +21,7 @@ as <role>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/testing.go` |
 

--- a/docs/devs/reference/attributes/auto.md
+++ b/docs/devs/reference/attributes/auto.md
@@ -25,7 +25,7 @@ Behavior depends on field type: `uuid` generates a v4 UUID, `timestamp` sets the
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/auto_update.md
+++ b/docs/devs/reference/attributes/auto_update.md
@@ -25,7 +25,7 @@ Typically used for `updated_at: timestamp auto_update` to track last-modified ti
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/broadcast.md
+++ b/docs/devs/reference/attributes/broadcast.md
@@ -47,7 +47,7 @@ socket /chat/:room
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/cors.md
+++ b/docs/devs/reference/attributes/cors.md
@@ -21,7 +21,7 @@ cors: <origin>, ...
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/custom.md
+++ b/docs/devs/reference/attributes/custom.md
@@ -31,7 +31,7 @@ Resolves at parse time from a path that may contain `{placeholder}` segments.
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/database.md
+++ b/docs/devs/reference/attributes/database.md
@@ -21,7 +21,7 @@ database: env <VAR> default <url>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/default.md
+++ b/docs/devs/reference/attributes/default.md
@@ -31,7 +31,7 @@ Applied at the database level (`DEFAULT` clause). The literal must match the fie
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/default_language.md
+++ b/docs/devs/reference/attributes/default_language.md
@@ -21,7 +21,7 @@ default language: <code>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/delay.md
+++ b/docs/devs/reference/attributes/delay.md
@@ -31,7 +31,7 @@ If set, requests over the limit are held for `delay` seconds before responding. 
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/detect_language.md
+++ b/docs/devs/reference/attributes/detect_language.md
@@ -21,7 +21,7 @@ detect language: <strategy>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/dynamic_fields.md
+++ b/docs/devs/reference/attributes/dynamic_fields.md
@@ -25,5 +25,5 @@ Written `dynamic fields` (with a space) in source. Used for low-code apps where 
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
 

--- a/docs/devs/reference/attributes/enqueue.md
+++ b/docs/devs/reference/attributes/enqueue.md
@@ -46,7 +46,7 @@ action /reports method POST
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/errors.md
+++ b/docs/devs/reference/attributes/errors.md
@@ -21,7 +21,7 @@ errors: <strategy> [stacktrace]
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/event.md
+++ b/docs/devs/reference/attributes/event.md
@@ -27,7 +27,7 @@ event: <name>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/every.md
+++ b/docs/devs/reference/attributes/every.md
@@ -32,7 +32,7 @@ Accepts a duration like `5s`, `1m`, `1h`, `24h` or a cron expression (in `schedu
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/expect.md
+++ b/docs/devs/reference/attributes/expect.md
@@ -21,7 +21,7 @@ expect <assertion>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/testing.go` |
 

--- a/docs/devs/reference/attributes/fetch.md
+++ b/docs/devs/reference/attributes/fetch.md
@@ -47,7 +47,7 @@ page /weather
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/fill.md
+++ b/docs/devs/reference/attributes/fill.md
@@ -21,7 +21,7 @@ fill <name> "<value>"
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/testing.go` |
 

--- a/docs/devs/reference/attributes/forgot.md
+++ b/docs/devs/reference/attributes/forgot.md
@@ -31,5 +31,5 @@ Also accepted as `forgot_password` or `forgot-password`.
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
 

--- a/docs/devs/reference/attributes/generate.md
+++ b/docs/devs/reference/attributes/generate.md
@@ -41,7 +41,7 @@ action /invoices/:id/pdf
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/html.md
+++ b/docs/devs/reference/attributes/html.md
@@ -47,7 +47,7 @@ page /
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/identity.md
+++ b/docs/devs/reference/attributes/identity.md
@@ -32,7 +32,7 @@ Usually `email` or `username`. Must exist on the auth table and be unique.
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/index.md
+++ b/docs/devs/reference/attributes/index.md
@@ -36,7 +36,7 @@ model order
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/level.md
+++ b/docs/devs/reference/attributes/level.md
@@ -22,7 +22,7 @@ level: <severity>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/llm.md
+++ b/docs/devs/reference/attributes/llm.md
@@ -42,7 +42,7 @@ action /chat method POST
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/login.md
+++ b/docs/devs/reference/attributes/login.md
@@ -28,7 +28,7 @@ login: <path>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/logout.md
+++ b/docs/devs/reference/attributes/logout.md
@@ -27,7 +27,7 @@ logout: <path>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/max.md
+++ b/docs/devs/reference/attributes/max.md
@@ -31,7 +31,7 @@ Mirror of `min`. For string fields, this also influences column size where appli
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `74103b0` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/forms.go` |
 

--- a/docs/devs/reference/attributes/message.md
+++ b/docs/devs/reference/attributes/message.md
@@ -27,7 +27,7 @@ message: "<text>"
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/method.md
+++ b/docs/devs/reference/attributes/method.md
@@ -48,7 +48,7 @@ page /contact method POST
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/min.md
+++ b/docs/devs/reference/attributes/min.md
@@ -31,7 +31,7 @@ Numeric fields enforce `value >= n`; string-like fields enforce length >= n. Val
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `74103b0` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/forms.go` |
 

--- a/docs/devs/reference/attributes/name.md
+++ b/docs/devs/reference/attributes/name.md
@@ -21,7 +21,7 @@ name: "<text>"
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/on.md
+++ b/docs/devs/reference/attributes/on.md
@@ -52,7 +52,7 @@ action /users/create method POST
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/password.md
+++ b/docs/devs/reference/attributes/password.md
@@ -32,7 +32,7 @@ Field name on the auth table holding hashed passwords. Type must be `password` i
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/port.md
+++ b/docs/devs/reference/attributes/port.md
@@ -22,7 +22,7 @@ port: env <VAR> default <n>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/redirect.md
+++ b/docs/devs/reference/attributes/redirect.md
@@ -45,7 +45,7 @@ action /logout method POST
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/register.md
+++ b/docs/devs/reference/attributes/register.md
@@ -27,7 +27,7 @@ register: <path>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/requests.md
+++ b/docs/devs/reference/attributes/requests.md
@@ -35,7 +35,7 @@ When used in `log`: Inside a `log` block: which requests to log. One of `all`, `
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/required.md
+++ b/docs/devs/reference/attributes/required.md
@@ -34,7 +34,7 @@ model user
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `74103b0` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/forms.go` |
 

--- a/docs/devs/reference/attributes/requires.md
+++ b/docs/devs/reference/attributes/requires.md
@@ -55,7 +55,7 @@ page /admin requires admin
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/reset.md
+++ b/docs/devs/reference/attributes/reset.md
@@ -31,5 +31,5 @@ Also accepted as `reset_password` or `reset-password`.
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
 

--- a/docs/devs/reference/attributes/respond.md
+++ b/docs/devs/reference/attributes/respond.md
@@ -41,7 +41,7 @@ action /users/:id/toggle method POST
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/retry.md
+++ b/docs/devs/reference/attributes/retry.md
@@ -28,7 +28,7 @@ retry <n>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/secret.md
+++ b/docs/devs/reference/attributes/secret.md
@@ -21,7 +21,7 @@ secret: env <VAR> required
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/send.md
+++ b/docs/devs/reference/attributes/send.md
@@ -42,7 +42,7 @@ action /signup method POST
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/slow_query.md
+++ b/docs/devs/reference/attributes/slow_query.md
@@ -21,5 +21,5 @@ slow-query: <duration>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
 

--- a/docs/devs/reference/attributes/static.md
+++ b/docs/devs/reference/attributes/static.md
@@ -21,7 +21,7 @@ static: <path>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/submit.md
+++ b/docs/devs/reference/attributes/submit.md
@@ -21,7 +21,7 @@ submit
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/testing.go` |
 

--- a/docs/devs/reference/attributes/superuser.md
+++ b/docs/devs/reference/attributes/superuser.md
@@ -31,7 +31,7 @@ Typically pulled from an env var. The matching user is treated as having every r
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/table.md
+++ b/docs/devs/reference/attributes/table.md
@@ -38,7 +38,7 @@ auth
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/tenant.md
+++ b/docs/devs/reference/attributes/tenant.md
@@ -31,7 +31,7 @@ Auto-synthesizes a required reference field to the tenant model and transparentl
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/auth.go` |
 

--- a/docs/devs/reference/attributes/title.md
+++ b/docs/devs/reference/attributes/title.md
@@ -45,7 +45,7 @@ page / title "Home"
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/unique.md
+++ b/docs/devs/reference/attributes/unique.md
@@ -25,7 +25,7 @@ Single-field unique constraint. For composite uniqueness, use a model-level `uni
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/uploads.md
+++ b/docs/devs/reference/attributes/uploads.md
@@ -21,7 +21,7 @@ uploads: <path> max <mb>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/validate.md
+++ b/docs/devs/reference/attributes/validate.md
@@ -50,7 +50,7 @@ action /signup method POST
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/attributes/visit.md
+++ b/docs/devs/reference/attributes/visit.md
@@ -21,7 +21,7 @@ visit <path>
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/testing.go` |
 

--- a/docs/devs/reference/keywords/action.md
+++ b/docs/devs/reference/keywords/action.md
@@ -53,7 +53,7 @@ action /users/create method POST requires auth
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/api.md
+++ b/docs/devs/reference/keywords/api.md
@@ -49,7 +49,7 @@ api /api/v1/users requires auth
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/auth.md
+++ b/docs/devs/reference/keywords/auth.md
@@ -56,7 +56,7 @@ auth
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/config.md
+++ b/docs/devs/reference/keywords/config.md
@@ -51,7 +51,7 @@ config
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/fragment.md
+++ b/docs/devs/reference/keywords/fragment.md
@@ -60,7 +60,7 @@ fragment badge(status, color="blue")
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/job.md
+++ b/docs/devs/reference/keywords/job.md
@@ -50,7 +50,7 @@ job generate-report
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/layout.md
+++ b/docs/devs/reference/keywords/layout.md
@@ -51,7 +51,7 @@ page /dashboard layout main title "Dashboard"
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/limit.md
+++ b/docs/devs/reference/keywords/limit.md
@@ -49,7 +49,7 @@ limit /api/*
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/log.md
+++ b/docs/devs/reference/keywords/log.md
@@ -40,7 +40,7 @@ log
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/model.md
+++ b/docs/devs/reference/keywords/model.md
@@ -70,7 +70,7 @@ model invoice
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/page.md
+++ b/docs/devs/reference/keywords/page.md
@@ -63,7 +63,7 @@ page /dashboard layout app title "Dashboard" requires auth
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/render.go` |
 

--- a/docs/devs/reference/keywords/permissions.md
+++ b/docs/devs/reference/keywords/permissions.md
@@ -38,7 +38,7 @@ permissions
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/query.md
+++ b/docs/devs/reference/keywords/query.md
@@ -56,7 +56,7 @@ page /users
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/schedule.md
+++ b/docs/devs/reference/keywords/schedule.md
@@ -48,7 +48,7 @@ schedule cleanup-sessions every 1h
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/socket.md
+++ b/docs/devs/reference/keywords/socket.md
@@ -52,7 +52,7 @@ socket /chat/:room requires auth
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/stream.md
+++ b/docs/devs/reference/keywords/stream.md
@@ -51,7 +51,7 @@ stream /notifications requires auth
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/test.md
+++ b/docs/devs/reference/keywords/test.md
@@ -48,7 +48,7 @@ test "Create user"
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/translations.md
+++ b/docs/devs/reference/keywords/translations.md
@@ -40,7 +40,7 @@ translations
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/reference/keywords/webhook.md
+++ b/docs/devs/reference/keywords/webhook.md
@@ -47,7 +47,7 @@ webhook /stripe/payment secret env STRIPE_SECRET
 
 | | |
 |---|---|
-| **Spec last touched** | `e1d0f3f` (2026-05-08) |
-| **Source last touched** | `b2cecfb` (2026-05-08) |
+| **Spec last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `5da8498` (2026-05-08) |
 | **Source files** | `internal/parser/parser.go` |
 

--- a/docs/devs/tutorials/01-todo-app.md
+++ b/docs/devs/tutorials/01-todo-app.md
@@ -1,0 +1,270 @@
+# Tutorial 1: Build a Todo app
+
+In this tutorial you will build a small Todo CRUD app from scratch. By the end you will have:
+
+- a `Todo` model with two fields,
+- three pages: list, new, and edit,
+- three actions: create, toggle, and delete,
+- an inline toggle that updates a single row over htmx without a full page reload.
+
+The whole app fits in one `.kilnx` file. Useful references: [`model`](../reference/keywords/model.md), [`page`](../reference/keywords/page.md), [`action`](../reference/keywords/action.md), [`fragment`](../reference/keywords/fragment.md), [`query`](../reference/keywords/query.md).
+
+## 1. Set up
+
+Create an empty file:
+
+```bash
+mkdir todo-app && cd todo-app
+touch app.kilnx
+```
+
+You will edit `app.kilnx` step by step and re-run `kilnx run app.kilnx` after each step. The runtime auto-migrates the SQLite database, so the `todo` table appears the first time you start the server.
+
+## 2. Declare the `Todo` model
+
+Open `app.kilnx` and add:
+
+```kilnx
+model todo
+  id: uuid auto
+  title: text required min 1 max 200
+  done: bool default false
+  created_at: timestamp auto
+```
+
+What is happening:
+
+- `id: uuid auto` gives every row a generated UUID primary key. See [`auto`](../reference/attributes/auto.md).
+- `title: text required min 1 max 200` enforces a non-empty title at most 200 chars. See [`required`](../reference/attributes/required.md), [`min`](../reference/attributes/min.md), [`max`](../reference/attributes/max.md).
+- `done: bool default false` defaults new todos to unfinished. See [`default`](../reference/attributes/default.md).
+- `created_at: timestamp auto` stamps the row at insert time.
+
+Run the server once to apply the migration:
+
+```bash
+kilnx run app.kilnx
+```
+
+You should see a log line about the `todo` table being created. Stop the server with Ctrl+C.
+
+## 3. List page
+
+Add the index page that shows all todos:
+
+```kilnx
+page /todos title "Todos"
+  query todos: SELECT id, title, done FROM todo ORDER BY created_at DESC
+  html
+    <h1>Todos</h1>
+    <p><a href="/todos/new">New todo</a></p>
+    <ul id="todo-list">
+      {#each todos}
+        {> todo_row(todo=this)}
+      {/each}
+    </ul>
+```
+
+The page runs an inline [`query`](../reference/keywords/query.md) named `todos` and binds the rows to a template variable. Inside the `{#each}` loop, each row is rendered through a reusable component named `todo_row`. We define that component next.
+
+## 4. The `todo_row` component fragment
+
+Component fragments are declared with parentheses. They render a slice of HTML and are invoked with `{> name(arg=value)}`:
+
+```kilnx
+fragment todo_row(todo)
+  html
+    <li id="todo-{todo.id}" class="todo">
+      <input type="checkbox"
+             hx-post="/todos/{todo.id}/toggle"
+             hx-target="#todo-{todo.id}"
+             hx-swap="outerHTML"
+             {#if todo.done}checked{/if}>
+      <span class="{#if todo.done}done{/if}">{todo.title}</span>
+      <a href="/todos/{todo.id}/edit">edit</a>
+      <form method="post" action="/todos/{todo.id}/delete" style="display:inline">
+        <button type="submit">delete</button>
+      </form>
+    </li>
+```
+
+The checkbox uses three htmx attributes:
+
+- `hx-post` posts to the toggle endpoint when clicked,
+- `hx-target` says which DOM node receives the response,
+- `hx-swap="outerHTML"` replaces the whole `<li>` with what the server returns.
+
+We will write that toggle response in step 7.
+
+## 5. New todo: page plus action
+
+A page renders the form, an action processes the submission. Add both:
+
+```kilnx
+page /todos/new title "New todo"
+  html
+    <h1>New todo</h1>
+    <form method="post" action="/todos/create">
+      <label>Title <input name="title" required></label>
+      <button type="submit">Create</button>
+      <a href="/todos">Cancel</a>
+    </form>
+
+action /todos/create method POST
+  validate todo
+  query: INSERT INTO todo (title) VALUES (:title)
+  redirect /todos
+```
+
+`validate todo` runs the model-level rules from step 2: it rejects empty titles and titles longer than 200 chars. See [`validate`](../reference/attributes/validate.md). On success the action inserts the row and sends the user back to the list.
+
+Restart the server, visit `http://localhost:8080/todos/new`, submit a title, and you should land on `/todos` with one row visible.
+
+## 6. Edit a todo
+
+The edit flow mirrors the new flow, except the form is preloaded and the SQL is an `UPDATE`:
+
+```kilnx
+page /todos/:id/edit title "Edit todo"
+  query todo: SELECT id, title, done FROM todo WHERE id = :id
+  html
+    <h1>Edit todo</h1>
+    <form method="post" action="/todos/{todo.id}/update">
+      <label>Title <input name="title" value="{todo.title}" required></label>
+      <label><input type="checkbox" name="done" {#if todo.done}checked{/if}> Done</label>
+      <button type="submit">Save</button>
+      <a href="/todos">Cancel</a>
+    </form>
+
+action /todos/:id/update method POST
+  validate todo
+  query: UPDATE todo SET title = :title, done = :done WHERE id = :id
+  redirect /todos
+```
+
+The `:id` placeholder in the path becomes a parameter that the SQL can reference as `:id`. Same for `:title` and `:done`, which come from the form body.
+
+## 7. Inline toggle: action plus fragment
+
+This is the part that makes the list feel snappy. The checkbox in `todo_row` posts to `/todos/:id/toggle`. The action flips the `done` flag and asks the server to render only the updated row, which htmx then swaps in place.
+
+```kilnx
+action /todos/:id/toggle method POST
+  query: UPDATE todo SET done = NOT done WHERE id = :id
+  query todo: SELECT id, title, done FROM todo WHERE id = :id
+  respond
+    html
+      {> todo_row(todo=todo)}
+```
+
+What you should see when you click a checkbox at `http://localhost:8080/todos`:
+
+1. The browser issues a `POST /todos/<id>/toggle`.
+2. The action updates the row, reloads it, and renders the `todo_row` component.
+3. htmx replaces the matching `<li id="todo-<id>">` with the new HTML. No full page reload.
+
+If you prefer the explicit form, [`respond`](../reference/attributes/respond.md) also accepts a CSS selector via `respond fragment ".selector"`. The version above keeps the fragment lookup local to the action body, which is easier to reason about when you are starting out.
+
+## 8. Delete
+
+Same idea as toggle, except we redirect back to the list rather than swap a fragment:
+
+```kilnx
+action /todos/:id/delete method POST
+  query: DELETE FROM todo WHERE id = :id
+  redirect /todos
+```
+
+## 9. Try it end to end
+
+1. `kilnx run app.kilnx`.
+2. Open `http://localhost:8080/todos`. Empty list.
+3. Click "New todo", create three todos.
+4. Click a checkbox. Only that row repaints. The text gains a `done` class.
+5. Click "edit" on any row, change the title, save. Back to the list with the new title.
+6. Click "delete". Row disappears.
+
+If something goes wrong, run `kilnx check app.kilnx` to surface parse and type errors before the server even starts.
+
+## 10. Full source
+
+Save this as `app.kilnx`:
+
+```kilnx
+model todo
+  id: uuid auto
+  title: text required min 1 max 200
+  done: bool default false
+  created_at: timestamp auto
+
+page /todos title "Todos"
+  query todos: SELECT id, title, done FROM todo ORDER BY created_at DESC
+  html
+    <h1>Todos</h1>
+    <p><a href="/todos/new">New todo</a></p>
+    <ul id="todo-list">
+      {#each todos}
+        {> todo_row(todo=this)}
+      {/each}
+    </ul>
+
+fragment todo_row(todo)
+  html
+    <li id="todo-{todo.id}" class="todo">
+      <input type="checkbox"
+             hx-post="/todos/{todo.id}/toggle"
+             hx-target="#todo-{todo.id}"
+             hx-swap="outerHTML"
+             {#if todo.done}checked{/if}>
+      <span class="{#if todo.done}done{/if}">{todo.title}</span>
+      <a href="/todos/{todo.id}/edit">edit</a>
+      <form method="post" action="/todos/{todo.id}/delete" style="display:inline">
+        <button type="submit">delete</button>
+      </form>
+    </li>
+
+page /todos/new title "New todo"
+  html
+    <h1>New todo</h1>
+    <form method="post" action="/todos/create">
+      <label>Title <input name="title" required></label>
+      <button type="submit">Create</button>
+      <a href="/todos">Cancel</a>
+    </form>
+
+action /todos/create method POST
+  validate todo
+  query: INSERT INTO todo (title) VALUES (:title)
+  redirect /todos
+
+page /todos/:id/edit title "Edit todo"
+  query todo: SELECT id, title, done FROM todo WHERE id = :id
+  html
+    <h1>Edit todo</h1>
+    <form method="post" action="/todos/{todo.id}/update">
+      <label>Title <input name="title" value="{todo.title}" required></label>
+      <label><input type="checkbox" name="done" {#if todo.done}checked{/if}> Done</label>
+      <button type="submit">Save</button>
+      <a href="/todos">Cancel</a>
+    </form>
+
+action /todos/:id/update method POST
+  validate todo
+  query: UPDATE todo SET title = :title, done = :done WHERE id = :id
+  redirect /todos
+
+action /todos/:id/toggle method POST
+  query: UPDATE todo SET done = NOT done WHERE id = :id
+  query todo: SELECT id, title, done FROM todo WHERE id = :id
+  respond
+    html
+      {> todo_row(todo=todo)}
+
+action /todos/:id/delete method POST
+  query: DELETE FROM todo WHERE id = :id
+  redirect /todos
+```
+
+## Where to go next
+
+- Add login so each user only sees their own todos: [Tutorial 2](02-auth-and-sessions.md).
+- Send a reminder email when a todo is overdue: [Tutorial 3](03-background-jobs.md).

--- a/docs/devs/tutorials/02-auth-and-sessions.md
+++ b/docs/devs/tutorials/02-auth-and-sessions.md
@@ -1,0 +1,320 @@
+# Tutorial 2: Auth and sessions
+
+This tutorial extends the [Todo app from Tutorial 1](01-todo-app.md) with login, registration, logout, and role-based access control. By the end every todo will belong to a user and an `admin` role will see an extra moderation page that regular users cannot reach.
+
+References used here: [`auth`](../reference/keywords/auth.md), [`permissions`](../reference/keywords/permissions.md), [`requires`](../reference/attributes/requires.md), and the auth attributes [`table`](../reference/attributes/table.md), [`identity`](../reference/attributes/identity.md), [`password`](../reference/attributes/password.md), [`login`](../reference/attributes/login.md), [`logout`](../reference/attributes/logout.md), [`register`](../reference/attributes/register.md), [`after_login`](../reference/attributes/after_login.md), [`superuser`](../reference/attributes/superuser.md).
+
+## 1. Add a `user` model
+
+Open `app.kilnx` from Tutorial 1 and add a user model above the `todo` model. Notice the `password` field type, which Kilnx automatically bcrypt-hashes on write and verifies on login:
+
+```kilnx
+model user
+  id: uuid auto
+  email: email required unique
+  password: password required
+  role: option [admin, member] default "member"
+  created_at: timestamp auto
+```
+
+The `option [admin, member]` field is what we will gate routes on later. See the [`model`](../reference/keywords/model.md) reference for the full list of field types.
+
+## 2. Wire up `auth`
+
+Below the models, add an `auth` block. Each attribute is written `name: value` (note `after login:` is two words):
+
+```kilnx
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  logout: /logout
+  register: /register
+  after login: /todos
+  superuser: env SUPERUSER_EMAIL
+```
+
+What this gives you for free:
+
+- `GET /login` and `GET /register` render forms.
+- `POST /login` issues a session cookie (HTTP-only, signed with `SECRET_KEY`).
+- `POST /logout` ends the session.
+- `POST /register` creates a `user` row with the password already bcrypt-hashed.
+- After a successful login the user lands on `/todos`.
+- The address in `SUPERUSER_EMAIL` (read at runtime) bypasses every `requires` check, so you can always recover access.
+
+Run the server:
+
+```bash
+SUPERUSER_EMAIL=you@example.com kilnx run app.kilnx
+```
+
+Open `http://localhost:8080/register`, create an account, and you should be redirected to `/todos` after logging in. The session cookie is now set.
+
+## 3. Scope todos to the current user
+
+Right now any user sees every todo. Add a `user_id` reference to the `Todo` model so each row is owned by someone:
+
+```kilnx
+model todo
+  id: uuid auto
+  user_id: reference user required
+  title: text required min 1 max 200
+  done: bool default false
+  due_at: timestamp
+  created_at: timestamp auto
+```
+
+The `due_at` field is unused for now. Tutorial 3 will use it to send overdue reminders. Restart the server and the migration adds the new columns.
+
+## 4. Gate every todo route
+
+Add `requires auth` to every endpoint that touches todos so anonymous users get redirected to `/login`. We also filter every query by `:current_user_id`, the session-bound parameter Kilnx exposes inside route bodies:
+
+```kilnx
+page /todos title "Todos" requires auth
+  query todos: SELECT id, title, done FROM todo WHERE user_id = :current_user_id ORDER BY created_at DESC
+  html
+    <h1>Todos</h1>
+    <p>
+      <a href="/todos/new">New todo</a>
+      <form method="post" action="/logout" style="display:inline">
+        <button type="submit">Log out</button>
+      </form>
+    </p>
+    <ul id="todo-list">
+      {#each todos}
+        {> todo_row(todo=this)}
+      {/each}
+    </ul>
+
+action /todos/create method POST requires auth
+  validate todo
+  query: INSERT INTO todo (title, user_id) VALUES (:title, :current_user_id)
+  redirect /todos
+```
+
+Apply the same pattern to `update`, `toggle`, and `delete`. The `WHERE` clause should always include `user_id = :current_user_id` so users cannot mutate other people's rows by guessing IDs:
+
+```kilnx
+action /todos/:id/update method POST requires auth
+  validate todo
+  query: UPDATE todo SET title = :title, done = :done
+         WHERE id = :id AND user_id = :current_user_id
+  redirect /todos
+
+action /todos/:id/toggle method POST requires auth
+  query: UPDATE todo SET done = NOT done
+         WHERE id = :id AND user_id = :current_user_id
+  query todo: SELECT id, title, done FROM todo
+              WHERE id = :id AND user_id = :current_user_id
+  respond
+    html
+      {> todo_row(todo=todo)}
+
+action /todos/:id/delete method POST requires auth
+  query: DELETE FROM todo WHERE id = :id AND user_id = :current_user_id
+  redirect /todos
+```
+
+The same `requires auth` line goes on `/todos/new` and `/todos/:id/edit`. See [`requires`](../reference/attributes/requires.md) for the full grammar.
+
+Try it: log out, hit `http://localhost:8080/todos`, and you should be bounced to the login form. Log in as a different user and confirm you only see your own todos.
+
+## 5. Roles with `permissions`
+
+Now we add role-based gating. Add a `permissions` block:
+
+```kilnx
+permissions
+  admin: all
+  member: read todo where user_id = current_user, write todo where user_id = current_user
+```
+
+What each rule means:
+
+- `admin: all`. The `admin` role can read and write every model.
+- `member: read todo where user_id = current_user, write todo where user_id = current_user`. Members can only see and modify their own todos. The `where` clause is enforced even when a route does not include the filter manually.
+
+See [`permissions`](../reference/keywords/permissions.md) for the rule grammar.
+
+## 6. Gate a page by role
+
+Add an admin-only page that lists every todo across users. The route opts in via `requires admin`:
+
+```kilnx
+page /admin/todos title "All todos" requires admin
+  query rows: SELECT t.id, t.title, t.done, u.email
+              FROM todo t JOIN user u ON u.id = t.user_id
+              ORDER BY t.created_at DESC
+  html
+    <h1>All todos</h1>
+    <table>
+      <thead><tr><th>User</th><th>Title</th><th>Done</th></tr></thead>
+      <tbody>
+        {#each rows}
+          <tr>
+            <td>{this.email}</td>
+            <td>{this.title}</td>
+            <td>{#if this.done}yes{#else}no{/if}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+```
+
+Since `requires admin` is checked before the body runs, a logged-in `member` who tries `http://localhost:8080/admin/todos` gets a 403. The user identified by `SUPERUSER_EMAIL` bypasses the check thanks to [`superuser`](../reference/attributes/superuser.md).
+
+To create your first admin, either:
+
+1. Log in as `SUPERUSER_EMAIL`, or
+2. Promote an existing user with one SQL statement:
+
+```bash
+sqlite3 adequa.db "UPDATE user SET role = 'admin' WHERE email = 'you@example.com';"
+```
+
+## 7. Try the gates end to end
+
+1. Register two accounts: `alice@example.com` and `bob@example.com`.
+2. Log in as Alice, create two todos.
+3. Log out, log in as Bob, hit `/todos`. You should see an empty list.
+4. Try `http://localhost:8080/admin/todos` as Bob. 403.
+5. Promote Bob to `admin` with the SQL above and revisit the page. Both users' todos appear.
+
+## 8. Final source
+
+The full `app.kilnx` after Tutorials 1 and 2:
+
+```kilnx
+model user
+  id: uuid auto
+  email: email required unique
+  password: password required
+  role: option [admin, member] default "member"
+  created_at: timestamp auto
+
+model todo
+  id: uuid auto
+  user_id: reference user required
+  title: text required min 1 max 200
+  done: bool default false
+  due_at: timestamp
+  created_at: timestamp auto
+
+auth
+  table: user
+  identity: email
+  password: password
+  login: /login
+  logout: /logout
+  register: /register
+  after login: /todos
+  superuser: env SUPERUSER_EMAIL
+
+permissions
+  admin: all
+  member: read todo where user_id = current_user, write todo where user_id = current_user
+
+page /todos title "Todos" requires auth
+  query todos: SELECT id, title, done FROM todo
+               WHERE user_id = :current_user_id
+               ORDER BY created_at DESC
+  html
+    <h1>Todos</h1>
+    <p>
+      <a href="/todos/new">New todo</a>
+      <form method="post" action="/logout" style="display:inline">
+        <button type="submit">Log out</button>
+      </form>
+    </p>
+    <ul id="todo-list">
+      {#each todos}
+        {> todo_row(todo=this)}
+      {/each}
+    </ul>
+
+fragment todo_row(todo)
+  html
+    <li id="todo-{todo.id}" class="todo">
+      <input type="checkbox"
+             hx-post="/todos/{todo.id}/toggle"
+             hx-target="#todo-{todo.id}"
+             hx-swap="outerHTML"
+             {#if todo.done}checked{/if}>
+      <span class="{#if todo.done}done{/if}">{todo.title}</span>
+      <a href="/todos/{todo.id}/edit">edit</a>
+      <form method="post" action="/todos/{todo.id}/delete" style="display:inline">
+        <button type="submit">delete</button>
+      </form>
+    </li>
+
+page /todos/new title "New todo" requires auth
+  html
+    <h1>New todo</h1>
+    <form method="post" action="/todos/create">
+      <label>Title <input name="title" required></label>
+      <button type="submit">Create</button>
+      <a href="/todos">Cancel</a>
+    </form>
+
+action /todos/create method POST requires auth
+  validate todo
+  query: INSERT INTO todo (title, user_id) VALUES (:title, :current_user_id)
+  redirect /todos
+
+page /todos/:id/edit title "Edit todo" requires auth
+  query todo: SELECT id, title, done FROM todo
+              WHERE id = :id AND user_id = :current_user_id
+  html
+    <h1>Edit todo</h1>
+    <form method="post" action="/todos/{todo.id}/update">
+      <label>Title <input name="title" value="{todo.title}" required></label>
+      <label><input type="checkbox" name="done" {#if todo.done}checked{/if}> Done</label>
+      <button type="submit">Save</button>
+      <a href="/todos">Cancel</a>
+    </form>
+
+action /todos/:id/update method POST requires auth
+  validate todo
+  query: UPDATE todo SET title = :title, done = :done
+         WHERE id = :id AND user_id = :current_user_id
+  redirect /todos
+
+action /todos/:id/toggle method POST requires auth
+  query: UPDATE todo SET done = NOT done
+         WHERE id = :id AND user_id = :current_user_id
+  query todo: SELECT id, title, done FROM todo
+              WHERE id = :id AND user_id = :current_user_id
+  respond
+    html
+      {> todo_row(todo=todo)}
+
+action /todos/:id/delete method POST requires auth
+  query: DELETE FROM todo WHERE id = :id AND user_id = :current_user_id
+  redirect /todos
+
+page /admin/todos title "All todos" requires admin
+  query rows: SELECT t.id, t.title, t.done, u.email
+              FROM todo t JOIN user u ON u.id = t.user_id
+              ORDER BY t.created_at DESC
+  html
+    <h1>All todos</h1>
+    <table>
+      <thead><tr><th>User</th><th>Title</th><th>Done</th></tr></thead>
+      <tbody>
+        {#each rows}
+          <tr>
+            <td>{this.email}</td>
+            <td>{this.title}</td>
+            <td>{#if this.done}yes{#else}no{/if}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+```
+
+## Where to go next
+
+Add a background process that emails users when one of their todos is overdue: [Tutorial 3](03-background-jobs.md).

--- a/docs/devs/tutorials/03-background-jobs.md
+++ b/docs/devs/tutorials/03-background-jobs.md
@@ -1,0 +1,200 @@
+# Tutorial 3: Background jobs and schedules
+
+This tutorial picks up the [authenticated Todo app](02-auth-and-sessions.md) and adds an overdue-reminder feature. A background `schedule` runs every minute, finds todos that just went overdue, and `enqueue`s a `job` that sends one email per user. We also mark each todo so we never email twice for the same row.
+
+References used: [`job`](../reference/keywords/job.md), [`schedule`](../reference/keywords/schedule.md), [`enqueue`](../reference/attributes/enqueue.md), [`every`](../reference/attributes/every.md), [`send`](../reference/attributes/send.md), [`retry`](../reference/attributes/retry.md).
+
+## 1. Add a `due_at` and `notified_at` to the model
+
+We already added `due_at` in Tutorial 2. Now add a `notified_at` flag so the schedule can tell which overdue todos have already triggered an email:
+
+```kilnx
+model todo
+  id: uuid auto
+  user_id: reference user required
+  title: text required min 1 max 200
+  done: bool default false
+  due_at: timestamp
+  notified_at: timestamp
+  created_at: timestamp auto
+```
+
+Restart the server. Kilnx adds the `notified_at` column. Existing rows keep `NULL` so they will be evaluated by the schedule on the next tick.
+
+## 2. Let users set a due date
+
+Update the new and edit forms so users can pick a deadline. Only the form changes here, the action SQL already handles the parameter as `:due_at`:
+
+```kilnx
+page /todos/new title "New todo" requires auth
+  html
+    <h1>New todo</h1>
+    <form method="post" action="/todos/create">
+      <label>Title <input name="title" required></label>
+      <label>Due at <input type="datetime-local" name="due_at"></label>
+      <button type="submit">Create</button>
+      <a href="/todos">Cancel</a>
+    </form>
+
+action /todos/create method POST requires auth
+  validate todo
+  query: INSERT INTO todo (title, user_id, due_at)
+         VALUES (:title, :current_user_id, :due_at)
+  redirect /todos
+```
+
+Mirror the same `due_at` field and SQL update in the edit page and update action.
+
+## 3. The job: send one overdue email
+
+A [`job`](../reference/keywords/job.md) runs out of band, so it can be slow without blocking HTTP responses. Add this near the bottom of `app.kilnx`:
+
+```kilnx
+job send-overdue-email
+  retry 3
+  query todo: SELECT t.id, t.title, t.due_at, u.email
+              FROM todo t JOIN user u ON u.id = t.user_id
+              WHERE t.id = :todo_id
+  send email to :todo.email
+    subject: "Your todo is overdue: {todo.title}"
+    body: "Your todo \"{todo.title}\" was due at {todo.due_at}."
+  query: UPDATE todo SET notified_at = now() WHERE id = :todo_id
+```
+
+Things to notice:
+
+- `retry 3` retries up to three times if the email transport fails. See [`retry`](../reference/attributes/retry.md).
+- The job receives `:todo_id` as a parameter, fetches the todo with its owner email, sends the message, then stamps `notified_at` so we never re-send.
+- `send email to <expression>` followed by indented `subject:` and `body:` is the canonical form. See [`send`](../reference/attributes/send.md) for `template:`, `attach:`, and other sub-fields.
+
+The transport (SMTP host, port, credentials) is configured at runtime via env vars, not in the DSL. Check the runtime config docs for the exact variable names.
+
+## 4. The schedule: tick every minute
+
+A [`schedule`](../reference/keywords/schedule.md) runs at a fixed cadence. Use [`every 1m`](../reference/attributes/every.md) for one minute. The body finds every todo that is due, not done, and not yet notified, then enqueues one job per row:
+
+```kilnx
+schedule notify-overdue-todos every 1m
+  query overdue: SELECT id FROM todo
+                 WHERE done = false
+                   AND due_at IS NOT NULL
+                   AND due_at <= now()
+                   AND notified_at IS NULL
+  {#each overdue}
+    enqueue send-overdue-email
+      todo_id: this.id
+  {/each}
+```
+
+`enqueue` parameters are written as `name: value` on indented lines. See [`enqueue`](../reference/attributes/enqueue.md).
+
+A few design notes worth understanding before moving on:
+
+- The schedule does not send the email itself. It only enqueues, which keeps the per-tick work bounded and lets the job retry independently.
+- Filtering by `notified_at IS NULL` makes the schedule idempotent. If the runtime restarts between two ticks, the next tick will still see un-notified rows and pick them up.
+- One job per row, not one job for the whole batch, gives each email its own retry budget.
+
+## 5. Try it locally
+
+1. Start the server with email transport set:
+
+   ```bash
+   SUPERUSER_EMAIL=you@example.com \
+   SMTP_HOST=localhost SMTP_PORT=1025 \
+   kilnx run app.kilnx
+   ```
+
+   For local testing, run a fake SMTP catcher like [MailHog](https://github.com/mailhog/MailHog) or [smtp4dev](https://github.com/rnwood/smtp4dev) on port 1025 so emails are captured but never actually delivered.
+
+2. Log in, create a todo with a due date one minute in the past.
+
+3. Wait up to 60 seconds. The next schedule tick fires, the row is selected, the job runs, and an email lands in the SMTP catcher inbox.
+
+4. Refresh `http://localhost:8080/todos`. The row's `notified_at` is now set, so the next tick ignores it. You can confirm in the database:
+
+   ```bash
+   sqlite3 adequa.db "SELECT id, title, due_at, notified_at FROM todo;"
+   ```
+
+If nothing arrives, run `kilnx run app.kilnx` with the log level turned up so failed jobs surface their error. See [`log`](../reference/keywords/log.md).
+
+## 6. Manual trigger for ad-hoc sends
+
+Sometimes you want to enqueue the job from a button rather than waiting for the schedule. Add an action that any owner can hit on a single todo:
+
+```kilnx
+action /todos/:id/remind method POST requires auth
+  query owns: SELECT id FROM todo
+              WHERE id = :id AND user_id = :current_user_id
+  enqueue send-overdue-email
+    todo_id: :id
+  redirect /todos
+```
+
+Wire it into the row fragment if you want a "remind me" button:
+
+```kilnx
+<form method="post" action="/todos/{todo.id}/remind" style="display:inline">
+  <button type="submit">remind</button>
+</form>
+```
+
+## 7. Full source for the new pieces
+
+Drop these blocks into `app.kilnx` (next to the existing models and routes from Tutorial 2):
+
+```kilnx
+model todo
+  id: uuid auto
+  user_id: reference user required
+  title: text required min 1 max 200
+  done: bool default false
+  due_at: timestamp
+  notified_at: timestamp
+  created_at: timestamp auto
+
+job send-overdue-email
+  retry 3
+  query todo: SELECT t.id, t.title, t.due_at, u.email
+              FROM todo t JOIN user u ON u.id = t.user_id
+              WHERE t.id = :todo_id
+  send email to :todo.email
+    subject: "Your todo is overdue: {todo.title}"
+    body: "Your todo \"{todo.title}\" was due at {todo.due_at}."
+  query: UPDATE todo SET notified_at = now() WHERE id = :todo_id
+
+schedule notify-overdue-todos every 1m
+  query overdue: SELECT id FROM todo
+                 WHERE done = false
+                   AND due_at IS NOT NULL
+                   AND due_at <= now()
+                   AND notified_at IS NULL
+  {#each overdue}
+    enqueue send-overdue-email
+      todo_id: this.id
+  {/each}
+
+action /todos/:id/remind method POST requires auth
+  query owns: SELECT id FROM todo
+              WHERE id = :id AND user_id = :current_user_id
+  enqueue send-overdue-email
+    todo_id: :id
+  redirect /todos
+```
+
+## 8. Things to consider for production
+
+- Replace the per-minute tick with a less aggressive cadence once you have many rows. `every 5m` or a cron expression like `every "*/15 * * * *"` keeps load low.
+- For multi-instance deploys, only one Kilnx process should run the schedule. Use a leader lock or run a dedicated worker instance.
+- Wrap the SQL update in the same transaction as the email send if your transport supports a sync confirmation. The current shape sends first and updates second, which is the right trade-off when retries are cheap and double-sends are not catastrophic.
+- Add an unsubscribe path before you ship reminder emails to real users.
+
+## Wrapping up
+
+You now have:
+
+- a single-file Todo app with htmx ([Tutorial 1](01-todo-app.md)),
+- per-user data and role gating ([Tutorial 2](02-auth-and-sessions.md)),
+- background reminders that run on a clock and survive restarts (this tutorial).
+
+For everything else, head to the [reference](../reference/index.md).

--- a/docs/devs/tutorials/index.md
+++ b/docs/devs/tutorials/index.md
@@ -1,0 +1,17 @@
+# Tutorials
+
+End-to-end walkthroughs for building real apps with Kilnx. Each tutorial assumes a working `kilnx` binary and starts from an empty `.kilnx` file. Code blocks copy and paste cleanly.
+
+For the full keyword and attribute index, see the [reference](../reference/index.md).
+
+## Tutorials
+
+1. [Build a Todo app](01-todo-app.md). One model, three pages, three actions, one inline htmx fragment. Covers `model`, `page`, `action`, `fragment`, and `query`.
+
+2. [Auth and sessions](02-auth-and-sessions.md). Add login, register, logout, and role-based access to an existing app. Covers `auth`, `permissions`, and `requires`.
+
+3. [Background jobs and schedules](03-background-jobs.md). Send overdue-todo emails from a periodic schedule that enqueues a job. Covers `job`, `schedule`, `enqueue`, `every`, and `send email`.
+
+## Conventions
+
+All tutorials use `app.kilnx` as the source filename and run with `kilnx run app.kilnx`. SQLite is the default database, so no extra setup is needed.

--- a/internal/optimizer/doc.go
+++ b/internal/optimizer/doc.go
@@ -1,14 +1,23 @@
-// Package optimizer rewrites the parser AST so that the runtime can
-// execute it efficiently.
+// Package optimizer rewrites the parser AST so the runtime can execute
+// it efficiently. Optimize mutates *parser.App in place.
+//
+// Named-query reference resolution ({queryName.field}, {^field},
+// {^^field}, bare {field}) is performed earlier, by parser.Parse, before
+// the optimizer runs. This package consumes those interpolations to
+// drive its own rewrites.
 //
 // Current responsibilities:
 //
-//   - Resolve named-query references ({queryName.field}, {^field},
-//     {^^field}) into their target queries so each page/action carries
-//     the SQL it actually needs.
-//   - Inline simple template interpolations where safe.
+//   - SELECT * rewriting: when consumer interpolations reveal exactly
+//     which columns a page/fragment/api uses, rewrite "SELECT *" to an
+//     explicit projection (optimizePage in optimizer.go).
+//   - JOIN pruning: drop joins whose tables are not referenced by any
+//     interpolation or by remaining SQL.
+//   - Query deduplication: merge identical queries within a single
+//     page/fragment/api body (deduplicateQueries).
+//   - Stream candidacy: tag scheduled tasks that can be served as SSE
+//     streams without extra work (markStreamCandidates).
 //
-// The optimizer is purely AST-to-AST: it takes a parser.App and returns
-// a parser.App, leaving the runtime free to assume references have
-// already been bound.
+// The optimizer is purely AST-to-AST and never returns errors: callers
+// invoke Optimize(app) after parsing/analysis and use the same *App.
 package optimizer

--- a/internal/parser/doc.go
+++ b/internal/parser/doc.go
@@ -10,4 +10,4 @@
 //	go generate ./...
 package parser
 
-//go:generate go run ../../cmd/kilnx-gendocs -o ../../docs/devs/reference
+//go:generate go run ../../cmd/kilnx-gendocs -o ../../docs


### PR DESCRIPTION
## Summary

- Extends `kilnx-gendocs` to render `docs/contributors/packages/*.md` from the Go AST and doc comments, mirroring the existing reference generator
- Splits `cmd/kilnx-gendocs` into `main.go` (dispatcher) + `reference.go` + `packages.go`, gated by a new `-only=all|reference|packages` flag; default `-o` is now `docs/` (subdirs derived from target)
- Manual content is preserved between `<!-- MANUAL-NOTES START -->` / `<!-- MANUAL-NOTES END -->` markers, read from the canonical committed location so CI's regen-to-tmp + diff pattern stays clean
- CI `validate-docs` job now diffs both `docs/devs/reference` and `docs/contributors/packages` against fresh output
- `internal/parser/doc.go` go:generate directive points at the new `-o ../../docs` root
- `internal/optimizer/doc.go` corrected: named-query reference resolution happens in `parser.Parse`, not the optimizer
- New hand-written content under `docs/devs/{quickstart,concepts,tutorials}` and `docs/contributors/{architecture,go-primer,testing,adding-a-keyword,adding-an-attribute}`

## Test plan

- [x] `go run ./cmd/kilnx-gendocs -o /tmp/x` produces both `devs/reference` and `contributors/packages` trees
- [x] `diff -r docs/devs/reference /tmp/x/devs/reference` exits 0
- [x] `diff -r docs/contributors/packages /tmp/x/contributors/packages` exits 0
- [x] `go run ./cmd/kilnx-gendocs -check-stale` exits 0
- [x] `cd internal/parser && go generate` writes both targets without diff
- [ ] CI `validate-docs` passes
- [ ] CI `lint` and `build` pass