### PR TITLE
fix(migrate): detect type, NOT NULL, UNIQUE e DEFAULT drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versio
 ### Changed
 - Transport-level `fetch` failures (DNS, timeout, connection refused) now abort the surrounding action with `502 Bad Gateway` and roll back the implicit transaction. Jobs and schedules surface the error to the queue. HTTP 4xx / 5xx are still parsed and exposed (not treated as transport errors). Page renders continue to degrade gracefully.
 
+### Fixed
+- `kilnx migrate` now detects schema drift across five dimensions: orphan columns (DB has them but model no longer declares them), column type mismatch, NOT NULL mismatch, single-column UNIQUE mismatch, and DEFAULT presence mismatch (value not compared, since dialect normalization is unreliable across SQLite/Postgres). Previously the diff was unidirectional (model -> DB only), so any DB-side change beyond a missing column went unreported and `kilnx migrate` reported "up to date" against a divergent schema. Warnings are grouped by kind with `table.column (detail)` lines plus a manual-fix hint per kind. Migration itself remains additive: no destructive ALTERs are generated.
+
 ### Security
 - `fetch` log lines redact the URL query string so secrets passed via `:param` substitution do not leak to stdout.
 

--- a/cmd/kilnx/main.go
+++ b/cmd/kilnx/main.go
@@ -270,6 +270,18 @@ func cmdMigrate(filename string, flags []string) error {
 		fmt.Println()
 	}
 
+	// Detect schema drift between declared models and the live database.
+	// Reported as warnings only: `kilnx migrate` is purely additive (no
+	// DROP/ALTER COLUMN), so divergence persists until the operator fixes
+	// it manually.
+	drifts, err := db.DetectColumnDrift(app.Models, app.CustomManifests)
+	if err != nil {
+		return fmt.Errorf("checking column drift: %w", err)
+	}
+	if len(drifts) > 0 {
+		printDrifts(drifts)
+	}
+
 	if status {
 		// Show migration history
 		history, err := db.MigrationHistory()
@@ -334,6 +346,61 @@ func cmdMigrate(filename string, flags []string) error {
 	}
 
 	return nil
+}
+
+// printDrifts emits a grouped warning summary for the slice of ColumnDrift
+// returned by database.DetectColumnDrift. Each kind gets its own section so
+// the operator can scan by category. The migration itself is not blocked.
+func printDrifts(drifts []database.ColumnDrift) {
+	groups := make(map[database.ColumnDriftKind][]database.ColumnDrift, 5)
+	order := []database.ColumnDriftKind{
+		database.DriftOrphan,
+		database.DriftType,
+		database.DriftNotNull,
+		database.DriftUnique,
+		database.DriftDefault,
+	}
+	for _, d := range drifts {
+		groups[d.Kind] = append(groups[d.Kind], d)
+	}
+	headings := map[database.ColumnDriftKind]string{
+		database.DriftOrphan:  "Columns present in the DB but no longer declared on their model:",
+		database.DriftType:    "Column types differ between model and DB:",
+		database.DriftNotNull: "NOT NULL differs between model and DB:",
+		database.DriftUnique:  "UNIQUE differs between model and DB (single-column only):",
+		database.DriftDefault: "DEFAULT presence differs between model and DB (value not compared):",
+	}
+	hints := map[database.ColumnDriftKind]string{
+		database.DriftOrphan:  "Remove with `ALTER TABLE ... DROP COLUMN ...` (Postgres) or rebuild (SQLite).",
+		database.DriftType:    "Reconcile by `ALTER TABLE ... ALTER COLUMN ... TYPE ...` (Postgres) or rebuild (SQLite).",
+		database.DriftNotNull: "Backfill missing values, then `ALTER TABLE ... ALTER COLUMN ... SET/DROP NOT NULL` (Postgres) or rebuild (SQLite).",
+		database.DriftUnique:  "Add or drop the unique index/constraint manually; `kilnx migrate` is additive only.",
+		database.DriftDefault: "Set or drop the DEFAULT manually if you want the schemas to match.",
+	}
+	printed := false
+	for _, kind := range order {
+		items := groups[kind]
+		if len(items) == 0 {
+			continue
+		}
+		if !printed {
+			fmt.Println("WARNING: schema drift detected (migration is additive and will not fix these):")
+			printed = true
+		}
+		fmt.Println()
+		fmt.Printf("  %s\n", headings[kind])
+		for _, d := range items {
+			if d.Detail != "" {
+				fmt.Printf("    - %s.%s  (%s)\n", d.TableName, d.Column, d.Detail)
+			} else {
+				fmt.Printf("    - %s.%s\n", d.TableName, d.Column)
+			}
+		}
+		fmt.Printf("  %s\n", hints[kind])
+	}
+	if printed {
+		fmt.Println()
+	}
 }
 
 func printMigrationStmt(stmt string) {

--- a/docs/contributors/packages/database.md
+++ b/docs/contributors/packages/database.md
@@ -6,10 +6,8 @@
 |---|---|
 | **Import path** | `github.com/kilnx-org/kilnx/internal/database` |
 | **Source last touched** | `965a64b` (2026-05-13) |
-| **Doc last touched** | `5da8498` (2026-05-08) |
+| **Doc last touched** | `b549e17` (2026-05-13) |
 
-
-> **Implementation touched after doc.go.** Source changed on `2026-05-13`, but `doc.go` was last edited on `2026-05-08`. The summary above may be out of date.
 
 ## Overview
 

--- a/docs/contributors/packages/database.md
+++ b/docs/contributors/packages/database.md
@@ -5,9 +5,11 @@
 | | |
 |---|---|
 | **Import path** | `github.com/kilnx-org/kilnx/internal/database` |
-| **Source last touched** | `5da8498` (2026-05-08) |
+| **Source last touched** | `34a4269` (2026-05-13) |
 | **Doc last touched** | `5da8498` (2026-05-08) |
 
+
+> **Implementation touched after doc.go.** Source changed on `2026-05-13`, but `doc.go` was last edited on `2026-05-08`. The summary above may be out of date.
 
 ## Overview
 
@@ -41,6 +43,33 @@ substitute fakes.
 | [`query.go`](../../../internal/database/query.go) | _no file-level doc_ |
 
 ## Types
+
+### `ColumnDrift`
+
+```go
+type ColumnDrift struct {
+	Kind		ColumnDriftKind
+	TableName	string
+	Column		string
+	Detail		string	// human-readable, e.g. "model=TEXT db=INTEGER"
+}
+```
+
+ColumnDrift describes one divergence between a declared model field and
+the live database schema. PlanMigration is intentionally additive (model
+-> DB) and never emits DROP COLUMN or ALTER COLUMN, so these warnings are
+the only signal that the schemas have diverged. `kilnx migrate` reports
+them as warnings; the migration itself is not blocked.
+
+### `ColumnDriftKind`
+
+```go
+type ColumnDriftKind string
+```
+
+ColumnDriftKind classifies how a database column diverges from its model
+declaration. Drift detection is read-only; PlanMigration never emits ALTER
+COLUMN or DROP COLUMN automatically, so this is purely advisory.
 
 ### `DB`
 
@@ -104,6 +133,17 @@ type Dialect interface {
 	// ColumnsSQL returns a query that yields (column_name TEXT) rows for a table.
 	// Receives the table name as a literal (not a parameter) for PRAGMA compat.
 	ColumnsSQL(table string) string
+
+	// ColumnsInfoSQL returns a query that yields (name TEXT, type TEXT,
+	// notnull INT, has_default INT) rows for a table. Used by drift
+	// detection to compare DB columns against model field declarations
+	// across type, NOT NULL, and default-presence dimensions.
+	ColumnsInfoSQL(table string) string
+
+	// UniqueColumnsSQL returns a query that yields (column_name TEXT) rows
+	// for each column that has a single-column UNIQUE index/constraint on
+	// the given table. Composite unique constraints are excluded.
+	UniqueColumnsSQL(table string) string
 
 	// AutoIncrementPK returns the PRIMARY KEY column definition for an
 	// auto-incrementing integer id.
@@ -202,6 +242,18 @@ type TxHandle struct {
 
 TxHandle wraps a *sql.Tx with named-parameter execution and idempotent
 commit/rollback. It is created by [DB.BeginTxHandle].
+
+### `columnInfo`
+
+```go
+type columnInfo struct {
+	Type		string
+	NotNull		bool
+	HasDefault	bool
+}
+```
+
+columnInfo captures the per-column data returned by Dialect.ColumnsInfoSQL.
 
 ### `querier`
 
@@ -314,6 +366,16 @@ skipped; the analyzer surfaces the error.
 ```go
 func isValidIdentifier(name string) bool
 ```
+### `normalizeSQLType`
+
+```go
+func normalizeSQLType(t string) string
+```
+
+normalizeSQLType maps a declared or introspected SQL type to a canonical
+form for cross-comparison. Strips parenthesized length/precision and
+resolves SQLite/PG type aliases (int/integer, bool/boolean, etc.).
+
 ### `queryRowsInternal`
 
 ```go
@@ -329,6 +391,17 @@ func scanRows(rows *sql.Rows) ([]Row, error)
 ```go
 func schemaHash(models []parser.Model) string
 ```
+### `typesEqual`
+
+```go
+func typesEqual(a, b string) bool
+```
+
+typesEqual returns true when two SQL type strings are equivalent after
+normalization (lowercase, whitespace collapsed, common dialect aliases
+resolved, parameterized lengths stripped). Conservative: when in doubt
+it returns true to avoid false-positive drift warnings.
+
 ### `uniqueIndexDDLs`
 
 ```go
@@ -365,6 +438,21 @@ func (db *DB) Conn() *sql.DB
 
 Conn returns the underlying *sql.DB for callers that need direct access
 (e.g. to start raw transactions or run driver-specific queries).
+
+### `(DB) DetectColumnDrift`
+
+```go
+func (db *DB) DetectColumnDrift(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]ColumnDrift, error)
+```
+
+DetectColumnDrift introspects each declared model's table and returns
+every divergence between the live schema and the model declaration:
+orphan columns, type mismatches, NOT NULL mismatches, single-column
+UNIQUE mismatches, and DEFAULT presence/absence mismatches. Tables
+missing from the database are skipped (planExistingTable adds them as
+part of normal migration); orphan tables are covered by
+DetectDataLossRisk. Reserved `id` / `custom` columns and column-mode
+custom-field manifest entries are exempted.
 
 ### `(DB) DetectDataLossRisk`
 
@@ -461,6 +549,16 @@ func (db *DB) generateCreateTable(model parser.Model, cm map[string]*parser.Cust
 ```go
 func (db *DB) getColumns(table string) (map[string]bool, error)
 ```
+### `(DB) getColumnsInfo`
+
+```go
+func (db *DB) getColumnsInfo(table string) (map[string]columnInfo, error)
+```
+### `(DB) getUniqueColumns`
+
+```go
+func (db *DB) getUniqueColumns(table string) (map[string]bool, error)
+```
 ### `(DB) planExistingTable`
 
 ```go
@@ -508,6 +606,17 @@ func (PostgresDialect) BoolTrue() string
 ```
 
 BoolTrue returns the SQL literal "TRUE".
+
+### `(PostgresDialect) ColumnsInfoSQL`
+
+```go
+func (PostgresDialect) ColumnsInfoSQL(table string) string
+```
+
+ColumnsInfoSQL returns name, normalized data_type, notnull flag, and a
+1/0 has_default flag for each column of the given public-schema table.
+data_type follows information_schema conventions (e.g. "integer",
+"double precision", "timestamp without time zone"); callers normalize.
 
 ### `(PostgresDialect) ColumnsSQL`
 
@@ -596,6 +705,16 @@ func (PostgresDialect) TableExistsSQL() string
 TableExistsSQL returns a query that counts matching rows in
 information_schema.tables for the public schema.
 
+### `(PostgresDialect) UniqueColumnsSQL`
+
+```go
+func (PostgresDialect) UniqueColumnsSQL(table string) string
+```
+
+UniqueColumnsSQL returns the names of columns covered by a single-column
+UNIQUE constraint on the given public-schema table. Composite UNIQUE
+constraints are excluded via the HAVING COUNT(*) = 1 group filter.
+
 ### `(SqliteDialect) AutoIncrementPK`
 
 ```go
@@ -629,6 +748,15 @@ func (SqliteDialect) BoolTrue() string
 ```
 
 BoolTrue returns the SQL literal "1".
+
+### `(SqliteDialect) ColumnsInfoSQL`
+
+```go
+func (SqliteDialect) ColumnsInfoSQL(table string) string
+```
+
+ColumnsInfoSQL returns name, type, notnull flag, and a 1/0 has_default
+flag (derived from dflt_value IS NOT NULL) via pragma_table_info.
 
 ### `(SqliteDialect) ColumnsSQL`
 
@@ -718,6 +846,18 @@ func (SqliteDialect) TableExistsSQL() string
 
 TableExistsSQL returns a query that counts entries in sqlite_master
 matching the given table name.
+
+### `(SqliteDialect) UniqueColumnsSQL`
+
+```go
+func (SqliteDialect) UniqueColumnsSQL(table string) string
+```
+
+UniqueColumnsSQL returns the names of columns that have a single-column
+unique index on the given table. Composite unique indexes are skipped.
+Includes both `u` (user CREATE UNIQUE INDEX) and `c` (table-level UNIQUE
+constraint) origins; skips `pk` (PRIMARY KEY) since id is excluded by
+callers.
 
 ### `(TxHandle) Commit`
 

--- a/docs/contributors/packages/database.md
+++ b/docs/contributors/packages/database.md
@@ -5,7 +5,7 @@
 | | |
 |---|---|
 | **Import path** | `github.com/kilnx-org/kilnx/internal/database` |
-| **Source last touched** | `34a4269` (2026-05-13) |
+| **Source last touched** | `965a64b` (2026-05-13) |
 | **Doc last touched** | `5da8498` (2026-05-08) |
 
 

--- a/docs/contributors/packages/database.md
+++ b/docs/contributors/packages/database.md
@@ -24,6 +24,11 @@ The package is organized around three concerns:
     parser AST, diffs it against the live schema, and applies the
     necessary CREATE/ALTER statements transactionally. Migration
     history is recorded in a kilnx-managed metadata table.
+    Read-only drift detection (DetectColumnDrift) reports columns
+    whose live schema diverges from the model along orphan, type,
+    NOT NULL, UNIQUE, and DEFAULT-presence axes. Drift is advisory:
+    PlanMigration is intentionally additive and never emits ALTER
+    or DROP COLUMN to reconcile.
 
 Query execution helpers live in query.go. Public types in
 interfaces.go define what the runtime depends on so tests can

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -432,6 +432,247 @@ func (db *DB) DetectDataLossRisk(models []parser.Model) ([]DataLossRisk, error) 
 	return risks, rows.Err()
 }
 
+// ColumnDriftKind classifies how a database column diverges from its model
+// declaration. Drift detection is read-only; PlanMigration never emits ALTER
+// COLUMN or DROP COLUMN automatically, so this is purely advisory.
+type ColumnDriftKind string
+
+const (
+	// DriftOrphan: column exists in DB but no longer declared in the model.
+	DriftOrphan ColumnDriftKind = "orphan"
+	// DriftType: column type in DB differs from the type the model would emit.
+	DriftType ColumnDriftKind = "type"
+	// DriftNotNull: model and DB disagree on NOT NULL.
+	DriftNotNull ColumnDriftKind = "notnull"
+	// DriftUnique: model and DB disagree on single-column UNIQUE.
+	DriftUnique ColumnDriftKind = "unique"
+	// DriftDefault: model and DB disagree on the presence of a DEFAULT.
+	// (Value comparison is intentionally skipped: dialect normalization is
+	// too noisy to compare default expressions reliably across SQLite/PG.)
+	DriftDefault ColumnDriftKind = "default"
+)
+
+// ColumnDrift describes one divergence between a declared model field and
+// the live database schema. PlanMigration is intentionally additive (model
+// -> DB) and never emits DROP COLUMN or ALTER COLUMN, so these warnings are
+// the only signal that the schemas have diverged. `kilnx migrate` reports
+// them as warnings; the migration itself is not blocked.
+type ColumnDrift struct {
+	Kind      ColumnDriftKind
+	TableName string
+	Column    string
+	Detail    string // human-readable, e.g. "model=TEXT db=INTEGER"
+}
+
+// columnInfo captures the per-column data returned by Dialect.ColumnsInfoSQL.
+type columnInfo struct {
+	Type       string
+	NotNull    bool
+	HasDefault bool
+}
+
+// DetectColumnDrift introspects each declared model's table and returns
+// every divergence between the live schema and the model declaration:
+// orphan columns, type mismatches, NOT NULL mismatches, single-column
+// UNIQUE mismatches, and DEFAULT presence/absence mismatches. Tables
+// missing from the database are skipped (planExistingTable adds them as
+// part of normal migration); orphan tables are covered by
+// DetectDataLossRisk. Reserved `id` / `custom` columns and column-mode
+// custom-field manifest entries are exempted.
+func (db *DB) DetectColumnDrift(models []parser.Model, manifests ...map[string]*parser.CustomFieldManifest) ([]ColumnDrift, error) {
+	var cm map[string]*parser.CustomFieldManifest
+	if len(manifests) > 0 {
+		cm = manifests[0]
+	}
+	var drifts []ColumnDrift
+	for _, model := range models {
+		if !isValidIdentifier(model.Name) {
+			continue
+		}
+		exists, err := db.tableExists(model.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+		dbCols, err := db.getColumnsInfo(model.Name)
+		if err != nil {
+			return nil, err
+		}
+		dbUniques, err := db.getUniqueColumns(model.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		// Build the expected column set: id + non-computed model fields +
+		// reserved custom slot + column-mode manifest fields.
+		expected := map[string]bool{"id": true}
+		fieldByCol := make(map[string]parser.Field, len(model.Fields))
+		for _, field := range model.Fields {
+			if field.Type == parser.FieldComputed {
+				continue
+			}
+			col := fieldToColumnName(field)
+			expected[col] = true
+			fieldByCol[col] = field
+		}
+		if model.CustomFieldsFile != "" || model.DynamicFields {
+			expected["custom"] = true
+		}
+		if manifest, ok := cm[model.Name]; ok {
+			for _, f := range manifest.Fields {
+				if f.Mode != parser.CustomFieldModeColumn {
+					continue
+				}
+				expected[f.Name] = true
+			}
+		}
+
+		// Orphan columns (DB-only).
+		for col := range dbCols {
+			if !expected[col] {
+				drifts = append(drifts, ColumnDrift{
+					Kind:      DriftOrphan,
+					TableName: model.Name,
+					Column:    col,
+				})
+			}
+		}
+
+		// Per-field drift (type / notnull / unique / default presence).
+		// Skip if the DB column is missing: that case is handled by the
+		// additive migrator (planExistingTable will ADD COLUMN it).
+		for col, field := range fieldByCol {
+			info, ok := dbCols[col]
+			if !ok {
+				continue
+			}
+			expectedType := db.dialect.FieldToSQLType(field)
+			if !typesEqual(expectedType, info.Type) {
+				drifts = append(drifts, ColumnDrift{
+					Kind:      DriftType,
+					TableName: model.Name,
+					Column:    col,
+					Detail:    fmt.Sprintf("model=%s db=%s", expectedType, info.Type),
+				})
+			}
+			if field.Required != info.NotNull {
+				drifts = append(drifts, ColumnDrift{
+					Kind:      DriftNotNull,
+					TableName: model.Name,
+					Column:    col,
+					Detail:    fmt.Sprintf("model required=%t db notnull=%t", field.Required, info.NotNull),
+				})
+			}
+			_, hasUniq := dbUniques[col]
+			// Field-level UNIQUE only; primary key on id is excluded by
+			// fieldByCol (id is never a field).
+			if field.Unique != hasUniq {
+				drifts = append(drifts, ColumnDrift{
+					Kind:      DriftUnique,
+					TableName: model.Name,
+					Column:    col,
+					Detail:    fmt.Sprintf("model unique=%t db unique=%t", field.Unique, hasUniq),
+				})
+			}
+			modelHasDefault := field.Default != "" || field.Auto
+			if modelHasDefault != info.HasDefault {
+				drifts = append(drifts, ColumnDrift{
+					Kind:      DriftDefault,
+					TableName: model.Name,
+					Column:    col,
+					Detail:    fmt.Sprintf("model has_default=%t db has_default=%t", modelHasDefault, info.HasDefault),
+				})
+			}
+		}
+	}
+	return drifts, nil
+}
+
+// typesEqual returns true when two SQL type strings are equivalent after
+// normalization (lowercase, whitespace collapsed, common dialect aliases
+// resolved, parameterized lengths stripped). Conservative: when in doubt
+// it returns true to avoid false-positive drift warnings.
+func typesEqual(a, b string) bool {
+	return normalizeSQLType(a) == normalizeSQLType(b)
+}
+
+// normalizeSQLType maps a declared or introspected SQL type to a canonical
+// form for cross-comparison. Strips parenthesized length/precision and
+// resolves SQLite/PG type aliases (int/integer, bool/boolean, etc.).
+func normalizeSQLType(t string) string {
+	t = strings.ToLower(strings.TrimSpace(t))
+	if i := strings.IndexByte(t, '('); i >= 0 {
+		t = strings.TrimSpace(t[:i])
+	}
+	t = strings.Join(strings.Fields(t), " ")
+	switch t {
+	case "int", "int4", "integer":
+		return "integer"
+	case "int8", "bigint", "bigserial":
+		return "bigint"
+	case "real", "float8", "double precision":
+		return "double precision"
+	case "bool", "boolean":
+		return "boolean"
+	case "timestamp", "timestamp without time zone", "datetime":
+		return "timestamp"
+	case "timestamptz", "timestamp with time zone":
+		return "timestamptz"
+	case "varchar", "character varying", "text":
+		return "text"
+	case "numeric", "decimal":
+		return "numeric"
+	}
+	return t
+}
+
+func (db *DB) getColumnsInfo(table string) (map[string]columnInfo, error) {
+	if !isValidIdentifier(table) {
+		return nil, fmt.Errorf("invalid table name: %q", table)
+	}
+	rows, err := db.conn.Query(db.dialect.ColumnsInfoSQL(table))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]columnInfo)
+	for rows.Next() {
+		var (
+			name       string
+			ctype      string
+			notnull    int
+			hasDefault int
+		)
+		if err := rows.Scan(&name, &ctype, &notnull, &hasDefault); err != nil {
+			return nil, err
+		}
+		out[name] = columnInfo{Type: ctype, NotNull: notnull != 0, HasDefault: hasDefault != 0}
+	}
+	return out, rows.Err()
+}
+
+func (db *DB) getUniqueColumns(table string) (map[string]bool, error) {
+	if !isValidIdentifier(table) {
+		return nil, fmt.Errorf("invalid table name: %q", table)
+	}
+	rows, err := db.conn.Query(db.dialect.UniqueColumnsSQL(table))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out[name] = true
+	}
+	return out, rows.Err()
+}
+
 func (db *DB) planExistingTable(model parser.Model, cm map[string]*parser.CustomFieldManifest) ([]string, error) {
 	var stmts []string
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -636,7 +636,7 @@ func (db *DB) getColumnsInfo(table string) (map[string]columnInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	out := make(map[string]columnInfo)
 	for rows.Next() {
 		var (
@@ -661,7 +661,7 @@ func (db *DB) getUniqueColumns(table string) (map[string]bool, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	out := make(map[string]bool)
 	for rows.Next() {
 		var name string

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1422,6 +1422,294 @@ func TestDetectDataLossRisk_SqliteInternalsFiltered(t *testing.T) {
 	}
 }
 
+func TestDetectColumnDrift_NoneWhenSchemaMatches(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{{
+		Name: "post",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+			{Name: "views", Type: parser.FieldInt},
+		},
+	}}
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if len(drifts) != 0 {
+		t.Fatalf("expected no drift, got %d: %#v", len(drifts), drifts)
+	}
+}
+
+func TestDetectColumnDrift_OrphanColumnReported(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Bootstrap with a model that declared `code`.
+	v1 := []parser.Model{{
+		Name: "product",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+			{Name: "code", Type: parser.FieldText},
+		},
+	}}
+	if _, err := db.Migrate(v1); err != nil {
+		t.Fatalf("migrate v1: %v", err)
+	}
+
+	// Author removes `code` from the .kilnx — drift detector must flag it.
+	v2 := []parser.Model{{
+		Name: "product",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+		},
+	}}
+	drifts, err := db.DetectColumnDrift(v2)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if len(drifts) != 1 {
+		t.Fatalf("expected 1 drift, got %d: %#v", len(drifts), drifts)
+	}
+	if drifts[0].TableName != "product" || drifts[0].Column != "code" {
+		t.Errorf("drift = %#v, want product.code", drifts[0])
+	}
+}
+
+func TestDetectColumnDrift_IgnoresReservedIdAndCustom(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{{
+		Name:             "note",
+		CustomFieldsFile: "notes.json",
+		Fields: []parser.Field{
+			{Name: "body", Type: parser.FieldText},
+		},
+	}}
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if len(drifts) != 0 {
+		t.Fatalf("id and custom should not count as drift, got %#v", drifts)
+	}
+}
+
+func TestDetectColumnDrift_ReferenceFieldUsesUnderscoreId(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	models := []parser.Model{
+		{Name: "author", Fields: []parser.Field{{Name: "name", Type: parser.FieldText}}},
+		{Name: "book", Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText},
+			{Name: "author", Type: parser.FieldReference, Reference: "author"},
+		}},
+	}
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if len(drifts) != 0 {
+		t.Fatalf("reference field expanded to author_id should match, got %#v", drifts)
+	}
+}
+
+func TestDetectColumnDrift_SkipsTableMissingFromDB(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Model declared but never migrated -> no table on disk. Drift detector
+	// should silently skip it; orphan-table coverage is the other direction.
+	models := []parser.Model{{
+		Name:   "ghost",
+		Fields: []parser.Field{{Name: "x", Type: parser.FieldText}},
+	}}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if len(drifts) != 0 {
+		t.Fatalf("expected no drift for missing table, got %#v", drifts)
+	}
+}
+
+// driftKindCount counts entries in drifts matching kind for the given column.
+func driftKindCount(drifts []ColumnDrift, kind ColumnDriftKind, table, column string) int {
+	n := 0
+	for _, d := range drifts {
+		if d.Kind == kind && d.TableName == table && d.Column == column {
+			n++
+		}
+	}
+	return n
+}
+
+func TestDetectColumnDrift_TypeMismatchReported(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Raw schema: amount is INTEGER. Model declares FieldFloat (REAL).
+	_, err := db.Conn().Exec(`CREATE TABLE "invoice" ("id" INTEGER PRIMARY KEY, "amount" INTEGER)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	models := []parser.Model{{
+		Name: "invoice",
+		Fields: []parser.Field{
+			{Name: "amount", Type: parser.FieldFloat},
+		},
+	}}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if got := driftKindCount(drifts, DriftType, "invoice", "amount"); got != 1 {
+		t.Fatalf("expected 1 type drift on invoice.amount, got %d (all=%#v)", got, drifts)
+	}
+}
+
+func TestDetectColumnDrift_NotNullMismatchReported(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Raw schema: NOT NULL on title. Model declares title as not Required.
+	_, err := db.Conn().Exec(`CREATE TABLE "post" ("id" INTEGER PRIMARY KEY, "title" TEXT NOT NULL)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	models := []parser.Model{{
+		Name: "post",
+		Fields: []parser.Field{
+			{Name: "title", Type: parser.FieldText, Required: false},
+		},
+	}}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if got := driftKindCount(drifts, DriftNotNull, "post", "title"); got != 1 {
+		t.Fatalf("expected 1 notnull drift on post.title, got %d (all=%#v)", got, drifts)
+	}
+}
+
+func TestDetectColumnDrift_UniqueMismatchReported(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Raw schema: unique index on email. Model declares email without unique.
+	_, err := db.Conn().Exec(`CREATE TABLE "person" ("id" INTEGER PRIMARY KEY, "email" TEXT)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Conn().Exec(`CREATE UNIQUE INDEX "ux_person_email" ON "person"("email")`); err != nil {
+		t.Fatalf("create unique index: %v", err)
+	}
+	models := []parser.Model{{
+		Name: "person",
+		Fields: []parser.Field{
+			{Name: "email", Type: parser.FieldEmail, Unique: false},
+		},
+	}}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if got := driftKindCount(drifts, DriftUnique, "person", "email"); got != 1 {
+		t.Fatalf("expected 1 unique drift on person.email, got %d (all=%#v)", got, drifts)
+	}
+}
+
+func TestDetectColumnDrift_UniqueMatch_CompositeIgnored(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Composite UNIQUE (a,b) on DB: must NOT be reported as single-column
+	// drift against field-level unique declarations.
+	_, err := db.Conn().Exec(`CREATE TABLE "pair" ("id" INTEGER PRIMARY KEY, "a" TEXT, "b" TEXT)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Conn().Exec(`CREATE UNIQUE INDEX "uq_pair_ab" ON "pair"("a","b")`); err != nil {
+		t.Fatalf("create composite unique index: %v", err)
+	}
+	models := []parser.Model{{
+		Name: "pair",
+		Fields: []parser.Field{
+			{Name: "a", Type: parser.FieldText, Unique: false},
+			{Name: "b", Type: parser.FieldText, Unique: false},
+		},
+	}}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if got := driftKindCount(drifts, DriftUnique, "pair", "a"); got != 0 {
+		t.Fatalf("composite unique must not flag column a, got %d", got)
+	}
+	if got := driftKindCount(drifts, DriftUnique, "pair", "b"); got != 0 {
+		t.Fatalf("composite unique must not flag column b, got %d", got)
+	}
+}
+
+func TestDetectColumnDrift_DefaultPresenceReported(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Raw schema: status has a DEFAULT. Model declares no default.
+	_, err := db.Conn().Exec(`CREATE TABLE "task" ("id" INTEGER PRIMARY KEY, "status" TEXT DEFAULT 'open')`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	models := []parser.Model{{
+		Name: "task",
+		Fields: []parser.Field{
+			{Name: "status", Type: parser.FieldText, Default: ""},
+		},
+	}}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if got := driftKindCount(drifts, DriftDefault, "task", "status"); got != 1 {
+		t.Fatalf("expected 1 default drift on task.status, got %d (all=%#v)", got, drifts)
+	}
+}
+
+func TestDetectColumnDrift_AllMatchEmitsNothing(t *testing.T) {
+	db, cleanup := openTemp(t)
+	defer cleanup()
+
+	// Model: required + unique + default. DB built by Migrate matches.
+	models := []parser.Model{{
+		Name: "account",
+		Fields: []parser.Field{
+			{Name: "handle", Type: parser.FieldText, Required: true, Unique: true, Default: "anon"},
+		},
+	}}
+	if _, err := db.Migrate(models); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	drifts, err := db.DetectColumnDrift(models)
+	if err != nil {
+		t.Fatalf("DetectColumnDrift: %v", err)
+	}
+	if len(drifts) != 0 {
+		t.Fatalf("expected zero drift after fresh migrate, got %#v", drifts)
+	}
+}
+
 func TestDetectDataLossRisk_EmptyTableIgnored(t *testing.T) {
 	db, cleanup := openTemp(t)
 	defer cleanup()

--- a/internal/database/dialect.go
+++ b/internal/database/dialect.go
@@ -36,6 +36,17 @@ type Dialect interface {
 	// Receives the table name as a literal (not a parameter) for PRAGMA compat.
 	ColumnsSQL(table string) string
 
+	// ColumnsInfoSQL returns a query that yields (name TEXT, type TEXT,
+	// notnull INT, has_default INT) rows for a table. Used by drift
+	// detection to compare DB columns against model field declarations
+	// across type, NOT NULL, and default-presence dimensions.
+	ColumnsInfoSQL(table string) string
+
+	// UniqueColumnsSQL returns a query that yields (column_name TEXT) rows
+	// for each column that has a single-column UNIQUE index/constraint on
+	// the given table. Composite unique constraints are excluded.
+	UniqueColumnsSQL(table string) string
+
 	// AutoIncrementPK returns the PRIMARY KEY column definition for an
 	// auto-incrementing integer id.
 	// SQLite: "id INTEGER PRIMARY KEY AUTOINCREMENT"

--- a/internal/database/dialect_postgres.go
+++ b/internal/database/dialect_postgres.go
@@ -58,6 +58,39 @@ func (PostgresDialect) ColumnsSQL(table string) string {
 		 ORDER BY ordinal_position`, table)
 }
 
+// ColumnsInfoSQL returns name, normalized data_type, notnull flag, and a
+// 1/0 has_default flag for each column of the given public-schema table.
+// data_type follows information_schema conventions (e.g. "integer",
+// "double precision", "timestamp without time zone"); callers normalize.
+func (PostgresDialect) ColumnsInfoSQL(table string) string {
+	return fmt.Sprintf(
+		`SELECT column_name,
+		        data_type,
+		        CASE WHEN is_nullable = 'NO' THEN 1 ELSE 0 END,
+		        CASE WHEN column_default IS NULL THEN 0 ELSE 1 END
+		 FROM information_schema.columns
+		 WHERE table_schema = 'public' AND table_name = '%s'
+		 ORDER BY ordinal_position`, table)
+}
+
+// UniqueColumnsSQL returns the names of columns covered by a single-column
+// UNIQUE constraint on the given public-schema table. Composite UNIQUE
+// constraints are excluded via the HAVING COUNT(*) = 1 group filter.
+func (PostgresDialect) UniqueColumnsSQL(table string) string {
+	return fmt.Sprintf(`
+		SELECT MIN(kcu.column_name)
+		FROM information_schema.table_constraints AS tc
+		JOIN information_schema.key_column_usage AS kcu
+		  ON tc.constraint_name = kcu.constraint_name
+		 AND tc.table_schema = kcu.table_schema
+		WHERE tc.constraint_type = 'UNIQUE'
+		  AND tc.table_schema = 'public'
+		  AND tc.table_name = '%s'
+		GROUP BY tc.constraint_name
+		HAVING COUNT(*) = 1
+	`, table)
+}
+
 // AutoIncrementPK returns the PostgreSQL BIGSERIAL primary key definition.
 func (PostgresDialect) AutoIncrementPK() string {
 	return "id BIGSERIAL PRIMARY KEY"

--- a/internal/database/dialect_sqlite.go
+++ b/internal/database/dialect_sqlite.go
@@ -56,6 +56,31 @@ func (SqliteDialect) ColumnsSQL(table string) string {
 	return fmt.Sprintf(`SELECT name FROM pragma_table_info("%s")`, table)
 }
 
+// ColumnsInfoSQL returns name, type, notnull flag, and a 1/0 has_default
+// flag (derived from dflt_value IS NOT NULL) via pragma_table_info.
+func (SqliteDialect) ColumnsInfoSQL(table string) string {
+	return fmt.Sprintf(
+		`SELECT name, type, "notnull", CASE WHEN dflt_value IS NULL THEN 0 ELSE 1 END FROM pragma_table_info("%s")`,
+		table,
+	)
+}
+
+// UniqueColumnsSQL returns the names of columns that have a single-column
+// unique index on the given table. Composite unique indexes are skipped.
+// Includes both `u` (user CREATE UNIQUE INDEX) and `c` (table-level UNIQUE
+// constraint) origins; skips `pk` (PRIMARY KEY) since id is excluded by
+// callers.
+func (SqliteDialect) UniqueColumnsSQL(table string) string {
+	return fmt.Sprintf(`
+		SELECT ii.name
+		FROM pragma_index_list("%s") AS il
+		JOIN pragma_index_info(il.name) AS ii
+		WHERE il."unique" = 1
+		  AND il.origin IN ('u', 'c')
+		  AND (SELECT COUNT(*) FROM pragma_index_info(il.name)) = 1
+	`, table)
+}
+
 // AutoIncrementPK returns the SQLite INTEGER PRIMARY KEY AUTOINCREMENT
 // definition.
 func (SqliteDialect) AutoIncrementPK() string {

--- a/internal/database/doc.go
+++ b/internal/database/doc.go
@@ -13,6 +13,11 @@
 //     parser AST, diffs it against the live schema, and applies the
 //     necessary CREATE/ALTER statements transactionally. Migration
 //     history is recorded in a kilnx-managed metadata table.
+//     Read-only drift detection (DetectColumnDrift) reports columns
+//     whose live schema diverges from the model along orphan, type,
+//     NOT NULL, UNIQUE, and DEFAULT-presence axes. Drift is advisory:
+//     PlanMigration is intentionally additive and never emits ALTER
+//     or DROP COLUMN to reconcile.
 //
 // Query execution helpers live in query.go. Public types in
 // interfaces.go define what the runtime depends on so tests can


### PR DESCRIPTION
## Summary

Previously, `kilnx migrate` diffed only model -> DB. Removing a field from a `.kilnx` file left the column on disk silently and the next `kilnx migrate` reported "up to date" against a divergent schema.

This PR widens drift detection to five dimensions:

- **orphan**: column on disk, no longer declared on the model
- **type**: column SQL type differs from what the model would emit
- **notnull**: model and DB disagree on NOT NULL
- **unique**: single-column UNIQUE index missing or extra (composite uniques are excluded; they have their own path via `unique (...)` directive)
- **default**: model and DB disagree on whether a DEFAULT exists (value not compared, since `'foo'::text` vs `'foo'`, `now()` vs `CURRENT_TIMESTAMP`, etc. would false-positive on virtually every PG row)

Output is grouped by kind with a per-kind manual-fix hint. Migration itself stays additive: no ALTER COLUMN or DROP COLUMN is generated automatically.

## Implementation

- `Dialect` gains `ColumnsInfoSQL` (name, type, notnull, has_default) and `UniqueColumnsSQL` (single-column unique names).
- SQLite: `pragma_table_info` + correlated `pragma_index_list` / `pragma_index_info` for unique filtering. `"notnull"` quoted because SQLite parser treats it as a keyword.
- Postgres: `information_schema.columns` + `table_constraints` JOIN `key_column_usage` with `HAVING COUNT(*) = 1` to exclude composite uniques.
- `typesEqual` normalizes common aliases across dialects (`int/integer`, `bool/boolean`, `timestamp/datetime`, `real/double precision`, etc.) and strips parameterized lengths.
- `printDrifts` in `cmd/kilnx/main.go` groups warnings by kind.

## Test plan

- [x] `TestDetectColumnDrift_TypeMismatchReported`
- [x] `TestDetectColumnDrift_NotNullMismatchReported`
- [x] `TestDetectColumnDrift_UniqueMismatchReported`
- [x] `TestDetectColumnDrift_UniqueMatch_CompositeIgnored`
- [x] `TestDetectColumnDrift_DefaultPresenceReported`
- [x] `TestDetectColumnDrift_AllMatchEmitsNothing`
- [x] Existing orphan / reserved-column / reference-field tests still pass
- [x] `go test ./...` green