### PR TITLE
chore(release): prepare v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versio
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-05-13
+
 ### Added
 - `llm ... agent` runtime (P3): the `agent` discriminator now spawns the `claude` CLI (Claude Code v2.x) as a subprocess and consumes its `stream-json` output. Exposes `:<name>.text`, `:<name>.session_id`, `:<name>.cost_usd`, `:<name>.duration_ms`, `:<name>.stop_reason` to downstream nodes for manual persistence. Honours `permission-mode` (default `plan`), `tools`, `max-budget-usd` (required), `max-turns` (enforced in runtime since CLI lacks the flag), `cwd` (contained inside `config workspace-root` via `EvalSymlinks` prefix check; tmpdir created and removed when omitted), `resume: :session_id` for conversation continuation, and `mcp:` to mount top-level `mcp <name>` server declarations via a per-request `--mcp-config` file. `show-tools: true` opt-in surfaces tool_use/tool_result frames on a separate hyperstream channel when streaming.
 - Top-level `mcp <name>` keyword: declares MCP servers (stdio or http/sse transport) reachable by `llm ... agent` blocks. Children: `command`, `args`, `env`, `url`, `transport`.

--- a/docs/contributors/packages/lexer.md
+++ b/docs/contributors/packages/lexer.md
@@ -5,7 +5,7 @@
 | | |
 |---|---|
 | **Import path** | `github.com/kilnx-org/kilnx/internal/lexer` |
-| **Source last touched** | `1ced616` (2026-05-13) |
+| **Source last touched** | `4a785a0` (2026-05-13) |
 | **Doc last touched** | `5da8498` (2026-05-08) |
 
 


### PR DESCRIPTION
## Summary
- Promove `[Unreleased]` para `[0.1.3] - 2026-05-13` em `CHANGELOG.md`.
- Conteúdo do release: LLM keyword redesign (response+agent), MCP servers, drift detection multidimensional, AGENTS.md autogen, fetch result naming + builtins.

## Test plan
- [x] CI verde no PR
- [ ] Após merge, tag `v0.1.3` no commit de merge e push para `upstream` dispara goreleaser