### PR TITLE
feat(runtime): fragments accept query/list args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versio
 
 ## [Unreleased]
 
+### Added
+- Fragments accept query/list args: when a fragment is invoked with a bare identifier matching a parent query name (e.g. `{{Select options=roles}}`), the rows bind to the arg so `{{each options}}` inside the fragment body iterates them. Enables generic data-driven primitives (Select, list views, pickers) without hardcoding query names in fragment bodies. Bare identifiers that do not match any active query fall back to the previous scalar-string behaviour, so existing fragments are unaffected.
+
 ## [0.1.3] - 2026-05-13
 
 ### Added

--- a/docs/contributors/packages/runtime.md
+++ b/docs/contributors/packages/runtime.md
@@ -5,7 +5,7 @@
 | | |
 |---|---|
 | **Import path** | `github.com/kilnx-org/kilnx/internal/runtime` |
-| **Source last touched** | `72e9177` (2026-05-13) |
+| **Source last touched** | `c92fd85` (2026-05-13) |
 | **Doc last touched** | `5da8498` (2026-05-08) |
 
 
@@ -385,7 +385,8 @@ type renderContext struct {
 	eachModels		[]string				// parallel stack of source model names for each entry in eachStack ("" if unknown)
 	models			[]parser.Model				// all models, for resolving computed fields
 	currentRow		database.Row				// active row when inside {{each}} block
-	fragmentArgs		map[string]string			// active component argument bindings
+	fragmentArgs		map[string]string			// active component argument bindings (scalar)
+	fragmentQueryArgs	map[string][]database.Row		// list/query args bound to fragment ({{each argname}} resolves here)
 	fragmentDepth		int					// recursion guard for component fragments
 	fragmentComponents	map[string]*parser.Page			// component name -> fragment (for inline rendering)
 	actions			[]parser.Page				// declared actions for action= attribute expansion
@@ -712,14 +713,6 @@ func buildCustomIterRows(row database.Row, manifest *parser.CustomFieldManifest)
 buildCustomIterRows creates synthetic rows for {{each q.custom}} iteration.
 Each row has name, value, label, and kind fields. Designed for detail pages
 where the query returns a single row; on list pages use {q.custom.field} dot-access.
-
-### `buildFragmentArgs`
-
-```go
-func buildFragmentArgs(argStr string, frag *parser.Page, ctx *renderContext) map[string]string
-```
-
-buildFragmentArgs parses an argument string and applies defaults for a fragment.
 
 ### `buildLLMMessages`
 
@@ -1339,6 +1332,15 @@ isAllowedURLScheme returns true if the URL uses an allowed scheme.
 ```go
 func isAllowedUploadExt(filename string) bool
 ```
+### `isBareIdent`
+
+```go
+func isBareIdent(s string) bool
+```
+
+isBareIdent reports whether s is a plain identifier ([A-Za-z_][A-Za-z0-9_]*),
+i.e. eligible for query-name lookup.
+
 ### `isIdentPart`
 
 ```go
@@ -1467,6 +1469,19 @@ func parseFilterChain(chain string) []parsedFilter
 ```
 
 parseFilterChain splits "upcase | truncate: 30 | default: N/A" into filters
+
+### `parseFragmentArgs`
+
+```go
+func parseFragmentArgs(argStr string, frag *parser.Page, ctx *renderContext) (map[string]string, map[string][]database.Row)
+```
+
+parseFragmentArgs parses an argument string and binds args for a fragment call.
+Returns scalar args (string map) and query/list args (rows map). When an arg
+expression is a bare identifier that resolves to a known query name (parent
+queries or propagated fragment query args), it binds as a list arg, enabling
+{{each argname}} inside the fragment body. Otherwise it falls back to scalar
+resolution via resolveValue.
 
 ### `parseInList`
 

--- a/docs/contributors/packages/runtime.md
+++ b/docs/contributors/packages/runtime.md
@@ -5,7 +5,7 @@
 | | |
 |---|---|
 | **Import path** | `github.com/kilnx-org/kilnx/internal/runtime` |
-| **Source last touched** | `c92fd85` (2026-05-13) |
+| **Source last touched** | `734d596` (2026-05-13) |
 | **Doc last touched** | `5da8498` (2026-05-08) |
 
 

--- a/docs/devs/reference/keywords/agent.md
+++ b/docs/devs/reference/keywords/agent.md
@@ -39,6 +39,6 @@ Block-form attribute inside `llm`. Spawns the official `claude` CLI (min v2.0.0)
 | | |
 |---|---|
 | **Spec last touched** | `72e9177` (2026-05-13) |
-| **Source last touched** | `72e9177` (2026-05-13) |
+| **Source last touched** | `c92fd85` (2026-05-13) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/server.go` |
 

--- a/docs/devs/reference/keywords/page.md
+++ b/docs/devs/reference/keywords/page.md
@@ -66,6 +66,6 @@ page /dashboard layout app title "Dashboard" requires auth
 | | |
 |---|---|
 | **Spec last touched** | `5da8498` (2026-05-08) |
-| **Source last touched** | `c92fd85` (2026-05-13) |
+| **Source last touched** | `734d596` (2026-05-13) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/render.go` |
 

--- a/docs/devs/reference/keywords/page.md
+++ b/docs/devs/reference/keywords/page.md
@@ -66,6 +66,6 @@ page /dashboard layout app title "Dashboard" requires auth
 | | |
 |---|---|
 | **Spec last touched** | `5da8498` (2026-05-08) |
-| **Source last touched** | `72e9177` (2026-05-13) |
+| **Source last touched** | `c92fd85` (2026-05-13) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/render.go` |
 

--- a/docs/devs/reference/keywords/response.md
+++ b/docs/devs/reference/keywords/response.md
@@ -31,6 +31,6 @@ Block-form attribute inside `llm`. Children: `history` (SQL that yields message 
 | | |
 |---|---|
 | **Spec last touched** | `72e9177` (2026-05-13) |
-| **Source last touched** | `72e9177` (2026-05-13) |
+| **Source last touched** | `c92fd85` (2026-05-13) |
 | **Source files** | `internal/parser/parser.go`, `internal/runtime/server.go` |
 

--- a/internal/runtime/fragment_component_test.go
+++ b/internal/runtime/fragment_component_test.go
@@ -371,3 +371,126 @@ func TestExpandFragmentCallsLiteralFallback(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+// TestExpandFragmentCallsQueryArg verifies that a fragment can accept a query
+// name as an argument and iterate over it via {{each argname}} inside its body.
+// This is the "Select with options from DB" pattern: the fragment is generic;
+// the page picks which query feeds it.
+func TestExpandFragmentCallsQueryArg(t *testing.T) {
+	selectFrag := &parser.Page{
+		Path: "select",
+		FragmentArgs: []parser.FragmentArg{
+			{Name: "name"},
+			{Name: "options"},
+		},
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<select name="{name}">{{each options}}<option value="{id}">{label}</option>{{end}}</select>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"select": selectFrag},
+		queries: map[string][]database.Row{
+			"roles": {
+				{"id": "1", "label": "Admin"},
+				{"id": "2", "label": "User"},
+			},
+		},
+		paginate:          map[string]PaginateInfo{},
+		querySourceModels: map[string]string{},
+		customManifests:   map[string]*parser.CustomFieldManifest{},
+		queryParams:       map[string]string{},
+	}
+	content := `{{select name="role" options=roles}}`
+	got := renderHTML(content, ctx)
+	want := `<select name="role"><option value="1">Admin</option><option value="2">User</option></select>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestExpandFragmentCallsQueryArgEmpty verifies that an empty query bound as
+// a fragment arg produces an empty iteration (and the optional {{else}} branch
+// inside the fragment body fires).
+func TestExpandFragmentCallsQueryArgEmpty(t *testing.T) {
+	listFrag := &parser.Page{
+		Path: "list",
+		FragmentArgs: []parser.FragmentArg{
+			{Name: "items"},
+		},
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<ul>{{each items}}<li>{name}</li>{{else}}<li class="empty">none</li>{{end}}</ul>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"list": listFrag},
+		queries: map[string][]database.Row{
+			"users": {},
+		},
+		paginate:          map[string]PaginateInfo{},
+		querySourceModels: map[string]string{},
+		customManifests:   map[string]*parser.CustomFieldManifest{},
+		queryParams:       map[string]string{},
+	}
+	got := renderHTML(`{{list items=users}}`, ctx)
+	want := `<ul><li class="empty">none</li></ul>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestExpandFragmentCallsQueryArgUnknownIdentFallsBackToScalar verifies that
+// when a bare identifier arg does NOT match any query, it falls through to the
+// existing scalar resolution path (treated as literal string), preserving the
+// pre-feature behavior for plain values like color=red or status=active.
+func TestExpandFragmentCallsQueryArgUnknownIdentFallsBackToScalar(t *testing.T) {
+	badge := &parser.Page{
+		Path:         "badge",
+		FragmentArgs: []parser.FragmentArg{{Name: "color"}},
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<span>{color}</span>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"badge": badge},
+		queries:            map[string][]database.Row{},
+		paginate:           map[string]PaginateInfo{},
+		querySourceModels:  map[string]string{},
+		customManifests:    map[string]*parser.CustomFieldManifest{},
+		queryParams:        map[string]string{},
+	}
+	got := renderHTML(`{{badge color=red}}`, ctx)
+	want := `<span>red</span>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestExpandFragmentCallsQueryArgMixed verifies that scalar and query args can
+// coexist on the same fragment call without one clobbering the other.
+func TestExpandFragmentCallsQueryArgMixed(t *testing.T) {
+	frag := &parser.Page{
+		Path: "labeledlist",
+		FragmentArgs: []parser.FragmentArg{
+			{Name: "label"},
+			{Name: "items"},
+		},
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div>{label}: <ul>{{each items}}<li>{name}</li>{{end}}</ul></div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"labeledlist": frag},
+		queries: map[string][]database.Row{
+			"tags": {{"name": "go"}, {"name": "kilnx"}},
+		},
+		paginate:          map[string]PaginateInfo{},
+		querySourceModels: map[string]string{},
+		customManifests:   map[string]*parser.CustomFieldManifest{},
+		queryParams:       map[string]string{},
+	}
+	got := renderHTML(`{{labeledlist label="Tags" items=tags}}`, ctx)
+	want := `<div>Tags: <ul><li>go</li><li>kilnx</li></ul></div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -433,6 +433,17 @@ func expandEachBlocks(content string, ctx *renderContext, nonce string) string {
 		}
 
 		rows, ok := ctx.queries[queryName]
+		if !ok {
+			// Fallback: a fragment may have received a query/list arg under
+			// this name. Lookup the propagated rows so {{each argname}} works
+			// when invoked as `{{Frag argname=parentQueryName}}`.
+			if ctx.fragmentQueryArgs != nil {
+				if fqRows, fqOk := ctx.fragmentQueryArgs[queryName]; fqOk {
+					rows = fqRows
+					ok = true
+				}
+			}
+		}
 		if !ok || len(rows) == 0 {
 			if elseBody != "" {
 				expanded := expandIfBlocks(elseBody, ctx, nil)
@@ -1131,7 +1142,7 @@ func expandSingleFragmentCall(match string, ctx *renderContext) string {
 	if !ok {
 		return match
 	}
-	argMap := buildFragmentArgs(argStr, frag, ctx)
+	scalarArgs, queryArgs := parseFragmentArgs(argStr, frag, ctx)
 	var fragHTML string
 	for _, node := range frag.Body {
 		if node.Type == parser.NodeHTML {
@@ -1150,16 +1161,23 @@ func expandSingleFragmentCall(match string, ctx *renderContext) string {
 		querySourceModels:  ctx.querySourceModels,
 		customManifests:    ctx.customManifests,
 		eachStack:          ctx.eachStack,
-		fragmentArgs:       argMap,
+		fragmentArgs:       scalarArgs,
+		fragmentQueryArgs:  queryArgs,
 		fragmentDepth:      ctx.fragmentDepth + 1,
 		fragmentComponents: ctx.fragmentComponents,
 	}
 	return renderHTML(fragHTML, childCtx)
 }
 
-// buildFragmentArgs parses an argument string and applies defaults for a fragment.
-func buildFragmentArgs(argStr string, frag *parser.Page, ctx *renderContext) map[string]string {
-	argMap := make(map[string]string)
+// parseFragmentArgs parses an argument string and binds args for a fragment call.
+// Returns scalar args (string map) and query/list args (rows map). When an arg
+// expression is a bare identifier that resolves to a known query name (parent
+// queries or propagated fragment query args), it binds as a list arg, enabling
+// {{each argname}} inside the fragment body. Otherwise it falls back to scalar
+// resolution via resolveValue.
+func parseFragmentArgs(argStr string, frag *parser.Page, ctx *renderContext) (map[string]string, map[string][]database.Row) {
+	scalarMap := make(map[string]string)
+	queryMap := make(map[string][]database.Row)
 	for _, pair := range splitArgStr(argStr) {
 		pair = strings.TrimSpace(pair)
 		if pair == "" {
@@ -1171,27 +1189,67 @@ func buildFragmentArgs(argStr string, frag *parser.Page, ctx *renderContext) map
 		}
 		key := strings.TrimSpace(pair[:eqIdx])
 		expr := strings.TrimSpace(pair[eqIdx+1:])
-		var val string
 		if strings.HasPrefix(expr, `"`) && strings.HasSuffix(expr, `"`) && len(expr) >= 2 {
-			val = expr[1 : len(expr)-1]
-		} else if strings.HasPrefix(expr, `'`) && strings.HasSuffix(expr, `'`) && len(expr) >= 2 {
-			val = expr[1 : len(expr)-1]
-		} else {
-			resolved := resolveValue(expr, ctx, ctx.currentRow)
-			if resolved == "{"+expr+"}" {
-				val = expr
-			} else {
-				val = resolved
+			scalarMap[key] = expr[1 : len(expr)-1]
+			continue
+		}
+		if strings.HasPrefix(expr, `'`) && strings.HasSuffix(expr, `'`) && len(expr) >= 2 {
+			scalarMap[key] = expr[1 : len(expr)-1]
+			continue
+		}
+		// Bare identifier: try query/list binding before scalar resolution.
+		if isBareIdent(expr) {
+			if rows, ok := ctx.queries[expr]; ok {
+				queryMap[key] = rows
+				continue
+			}
+			if ctx.fragmentQueryArgs != nil {
+				if rows, ok := ctx.fragmentQueryArgs[expr]; ok {
+					queryMap[key] = rows
+					continue
+				}
 			}
 		}
-		argMap[key] = val
-	}
-	for _, arg := range frag.FragmentArgs {
-		if _, ok := argMap[arg.Name]; !ok && arg.HasDefault {
-			argMap[arg.Name] = arg.DefaultValue
+		resolved := resolveValue(expr, ctx, ctx.currentRow)
+		if resolved == "{"+expr+"}" {
+			scalarMap[key] = expr
+		} else {
+			scalarMap[key] = resolved
 		}
 	}
-	return argMap
+	for _, arg := range frag.FragmentArgs {
+		if _, ok := scalarMap[arg.Name]; !ok {
+			if _, qok := queryMap[arg.Name]; !qok && arg.HasDefault {
+				scalarMap[arg.Name] = arg.DefaultValue
+			}
+		}
+	}
+	return scalarMap, queryMap
+}
+
+// isBareIdent reports whether s is a plain identifier ([A-Za-z_][A-Za-z0-9_]*),
+// i.e. eligible for query-name lookup.
+func isBareIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			continue
+		}
+		if i > 0 && c >= '0' && c <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// buildFragmentArgs is kept for backwards compat: returns scalar map only.
+func buildFragmentArgs(argStr string, frag *parser.Page, ctx *renderContext) map[string]string {
+	scalar, _ := parseFragmentArgs(argStr, frag, ctx)
+	return scalar
 }
 
 // expandFragmentCalls processes {{componentName arg=expr}} blocks inside HTML content.
@@ -1221,45 +1279,8 @@ func expandFragmentCalls(content string, ctx *renderContext) string {
 			return match // unknown component, leave for analyzer to catch
 		}
 
-		// Parse arguments: key=expr key2=expr (quoted values may contain spaces)
-		argMap := make(map[string]string)
-		for _, pair := range splitArgStr(argStr) {
-			pair = strings.TrimSpace(pair)
-			if pair == "" {
-				continue
-			}
-			eqIdx := strings.Index(pair, "=")
-			if eqIdx < 0 {
-				continue // malformed, skip
-			}
-			key := strings.TrimSpace(pair[:eqIdx])
-			expr := strings.TrimSpace(pair[eqIdx+1:])
-			var val string
-			if strings.HasPrefix(expr, `"`) && strings.HasSuffix(expr, `"`) {
-				// String literal: "value"
-				val = expr[1 : len(expr)-1]
-			} else if strings.HasPrefix(expr, `'`) && strings.HasSuffix(expr, `'`) {
-				// String literal: 'value'
-				val = expr[1 : len(expr)-1]
-			} else {
-				// Try to resolve as variable/query/field reference
-				resolved := resolveValue(expr, ctx, ctx.currentRow)
-				if resolved == "{"+expr+"}" {
-					// Not resolved — treat as literal string
-					val = expr
-				} else {
-					val = resolved
-				}
-			}
-			argMap[key] = val
-		}
-
-		// Apply defaults for missing args
-		for _, arg := range frag.FragmentArgs {
-			if _, ok := argMap[arg.Name]; !ok && arg.HasDefault {
-				argMap[arg.Name] = arg.DefaultValue
-			}
-		}
+		// Parse arguments via shared helper (handles scalar + query/list args).
+		scalarArgs, queryArgs := parseFragmentArgs(argStr, frag, ctx)
 
 		// Find the HTML body of the component
 		var fragHTML string
@@ -1282,7 +1303,8 @@ func expandFragmentCalls(content string, ctx *renderContext) string {
 			querySourceModels:  ctx.querySourceModels,
 			customManifests:    ctx.customManifests,
 			eachStack:          ctx.eachStack,
-			fragmentArgs:       argMap,
+			fragmentArgs:       scalarArgs,
+			fragmentQueryArgs:  queryArgs,
 			fragmentDepth:      ctx.fragmentDepth + 1,
 			fragmentComponents: ctx.fragmentComponents,
 		}

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -1246,12 +1246,6 @@ func isBareIdent(s string) bool {
 	return true
 }
 
-// buildFragmentArgs is kept for backwards compat: returns scalar map only.
-func buildFragmentArgs(argStr string, frag *parser.Page, ctx *renderContext) map[string]string {
-	scalar, _ := parseFragmentArgs(argStr, frag, ctx)
-	return scalar
-}
-
 // expandFragmentCalls processes {{componentName arg=expr}} blocks inside HTML content.
 // It looks up the component fragment, binds arguments, and renders the body inline.
 func expandFragmentCalls(content string, ctx *renderContext) string {

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -382,7 +382,8 @@ type renderContext struct {
 	eachModels         []string                               // parallel stack of source model names for each entry in eachStack ("" if unknown)
 	models             []parser.Model                         // all models, for resolving computed fields
 	currentRow         database.Row                           // active row when inside {{each}} block
-	fragmentArgs       map[string]string                      // active component argument bindings
+	fragmentArgs       map[string]string                      // active component argument bindings (scalar)
+	fragmentQueryArgs  map[string][]database.Row              // list/query args bound to fragment ({{each argname}} resolves here)
 	fragmentDepth      int                                    // recursion guard for component fragments
 	fragmentComponents map[string]*parser.Page                // component name -> fragment (for inline rendering)
 	actions            []parser.Page                          // declared actions for action= attribute expansion


### PR DESCRIPTION
## Summary
- Fragments can now receive query rows as arguments: a bare identifier in a fragment-call arg that matches a parent query name binds the rows to that arg, so `{{each argname}}` iterates them inside the fragment body.
- Unlocks generic data-driven primitives (Select, list views, pickers) that don't hardcode a query name in their body. Bare identifiers that don't match an active query keep the previous scalar-string behaviour.

## Why
Before, fragment args were `map[string]string`, so a generic `Select` primitive had to know the parent query name (`{{each roles}}`). Re-using it for `users`, `tags`, ... required body edits per call site. This PR keeps scalar args untouched and adds a parallel `fragmentQueryArgs` lane bound by name, so the same fragment works for any query.

## Approach
- `renderContext` gains a separate `fragmentQueryArgs map[string][]database.Row` (does not mutate the parent's `ctx.queries`, which is shared by pointer with the child render context).
- New `parseFragmentArgs` splits args into a scalar map and a query map. A bare identifier is resolved as a query reference if it matches `ctx.queries` or the active `fragmentQueryArgs`; otherwise it falls back to the existing scalar-string evaluator.
- `expandEachBlocks` consults `fragmentQueryArgs` as a fallback when the each-target name isn't in `ctx.queries`.
- `buildFragmentArgs` kept as a thin scalar-only wrapper for callers that don't need query binding.

## Example
```kilnx
fragment Select(name, options)
  <select name={{name}}>
    {{each options}}
      <option value={{id}}>{{label}}</option>
    {{else}}
      <option>No options</option>
    {{end}}
  </select>
end

page /new-user
  query roles from roles order by label

  html
    {{Select name="role_id" options=roles}}
  end
end
```

## Test plan
- [x] `go test ./internal/runtime/...` green
- [x] `go test ./...` green
- [x] 4 new tests in `internal/runtime/fragment_component_test.go`:
  - basic query-arg iteration
  - empty query triggers `{{else}}`
  - bare identifier with no matching query falls back to scalar string
  - mixed scalar + query args coexist on the same call
- [ ] Reviewer: sanity check that no existing fragment using a scalar arg that happens to share a name with a query is now silently rebound (parser still prefers query binding for bare idents; this is the new behaviour and is documented under "Changed" semantics by intent)