### PR TITLE
feat(runtime): fragment slots and block-form invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versio
 ## [Unreleased]
 
 ### Added
+- Fragment slots and block-form invocation: a component fragment can declare slot placeholders (`{{slot}}` default, `{{slot name="X"}}` named) and callers fill them with the block form `{{Frag args}}...{{/Frag}}`. Unfilled slots fall back to content between `{{slot}}fallback{{/slot}}` markers, or are removed when the marker is self-closing. Slot body is rendered in the fragment's scope, so refs like `{name}` inside `{{each items}}` resolve against the iterated row. Enables generic primitives like `DvKanban`/`DvTable` whose per-item markup is supplied by the caller. Self-closing `{{Frag args}}` retains existing behaviour.
 - Fragments accept query/list args: when a fragment is invoked with a bare identifier matching a parent query name (e.g. `{{Select options=roles}}`), the rows bind to the arg so `{{each options}}` inside the fragment body iterates them. Enables generic data-driven primitives (Select, list views, pickers) without hardcoding query names in fragment bodies. Bare identifiers that do not match any active query fall back to the previous scalar-string behaviour, so existing fragments are unaffected.
 
 ## [0.1.3] - 2026-05-13

--- a/docs/devs/reference/keywords/fragment.md
+++ b/docs/devs/reference/keywords/fragment.md
@@ -48,6 +48,53 @@ fragment badge(status, color="blue")
     <span class="{color}">{status}</span>
 ```
 
+### Component with slots (block-form call)
+
+Component fragments can expose `{{slot}}` placeholders so callers supply custom markup. Default slot `{{slot}}` accepts arbitrary content; named slots use `{{slot name="X"}}`. Both forms accept fallback content via `{{slot}}fallback{{/slot}}`.
+
+```kilnx
+fragment Card
+  html
+    <div class="card">
+      <header>{{slot name="header"}}Default Title{{/slot}}</header>
+      <main>{{slot}}</main>
+    </div>
+```
+
+Invoke in block form with `{{Name args}}...{{/Name}}`:
+
+```kilnx
+{{Card}}
+  {{slot name="header"}}Custom Title{{/slot}}
+  <p>Body content fills the default slot.</p>
+{{/Card}}
+```
+
+Slots compose with `query`/`list` args. A generic kanban renders its caller's per-item markup inside `{{each items}}`:
+
+```kilnx
+fragment DvKanban(items)
+  html
+    <div class="kanban">
+      {{each items}}<article>{{slot}}</article>{{end}}
+    </div>
+```
+
+```kilnx
+page /people
+  query people: SELECT id, name FROM person
+  html
+    {{DvKanban items=people}}
+      <h3>{name}</h3>
+    {{/DvKanban}}
+```
+
+Notes:
+
+- A slot the caller did not provide falls back to the fragment's fallback content (or is removed if there is none).
+- Self-closing `{{Name args}}` keeps existing behavior; slot markers in the fragment fall back to their defaults.
+- Slot body content is rendered in the fragment's scope, so refs like `{name}` inside `{{each items}}` resolve against the iterated row.
+
 ## See also
 
 - [`page`](page.md)

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -1337,6 +1337,7 @@ func checkFragmentComponents(app *parser.App) []Diagnostic {
 	builtins := map[string]bool{
 		"each": true, "end": true, "if": true, "else": true,
 		"t": true, "plural": true,
+		"slot": true,
 	}
 
 	// Scan all NodeHTML bodies across pages, fragments, actions, apis

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1683,6 +1683,12 @@ func (p *parserState) parseFragment() (Page, error) {
 			return page, fmt.Errorf("line %d: unclosed argument list in fragment component", nameTok.Line)
 		}
 		p.advance() // consume ')'
+		// Mark as component fragment even when args list is empty, so the
+		// analyzer registers it (the parens are the discriminator vs path
+		// fragments, not the presence of args).
+		if page.FragmentArgs == nil {
+			page.FragmentArgs = []FragmentArg{}
+		}
 	} else {
 		return page, fmt.Errorf("line %d: expected path or component name after 'fragment'", p.current().Line)
 	}

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -1158,6 +1158,16 @@ func tryExpandFragmentAt(content string, openStart, openEnd int, ctx *renderCont
 		callerBody = ""
 	}
 
+	// Pre-resolve caller-scope field refs in slot content. Without this,
+	// `{name}` inside a block-form call rendered from within {{each users}}
+	// would later resolve against the fragment's scope (where currentRow is
+	// nil) and fall back to queries[0], yielding the wrong row's value on
+	// every iteration. interpolateRow only touches `{field}` patterns, so
+	// named-slot wrappers `{{slot name="X"}}...{{/slot}}` are preserved.
+	if callerBody != "" && ctx.currentRow != nil {
+		callerBody = interpolateRow(callerBody, ctx.currentRow, ctx)
+	}
+
 	fragHTML := resolveFragmentBody(frag, callerBody)
 	if fragHTML == "" {
 		return "", consumedEnd

--- a/internal/runtime/render.go
+++ b/internal/runtime/render.go
@@ -1092,46 +1092,50 @@ func splitArgStr(s string) []string {
 // expandFragmentCallsOutsideEach expands fragment component calls that are
 // NOT inside a {{each}}...{{end}} block. Calls inside each-blocks are handled
 // per-row inside expandEachBlocks (so they can reference the current row).
+// Handles both self-closing ({{Frag args}}) and block form
+// ({{Frag args}}...{{/Frag}}) with slot semantics.
 func expandFragmentCallsOutsideEach(content string, ctx *renderContext) string {
 	if ctx.fragmentComponents == nil || len(ctx.fragmentComponents) == 0 {
 		return content
 	}
 	insideEach := isInsideEachBlock(content)
-	matches := fragmentCallRe.FindAllStringIndex(content, -1)
-	if len(matches) == 0 {
-		return content
-	}
 	var b strings.Builder
 	b.Grow(len(content))
-	prev := 0
-	for _, m := range matches {
-		start, end := m[0], m[1]
-		b.WriteString(content[prev:start])
-		match := content[start:end]
-		if insideEach(start) {
-			b.WriteString(match)
-		} else {
-			b.WriteString(expandSingleFragmentCall(match, ctx))
+	pos := 0
+	for pos < len(content) {
+		loc := fragmentCallRe.FindStringIndex(content[pos:])
+		if loc == nil {
+			b.WriteString(content[pos:])
+			break
 		}
-		prev = end
+		absStart := pos + loc[0]
+		absEnd := pos + loc[1]
+		b.WriteString(content[pos:absStart])
+		if insideEach(absStart) {
+			b.WriteString(content[absStart:absEnd])
+			pos = absEnd
+			continue
+		}
+		replacement, end := tryExpandFragmentAt(content, absStart, absEnd, ctx)
+		b.WriteString(replacement)
+		pos = end
 	}
-	b.WriteString(content[prev:])
 	return b.String()
 }
 
-// expandSingleFragmentCall expands one {{name args}} occurrence using ctx.
-// Returns the original match if the name is not a known component or if the
-// recursion guard has fired.
-func expandSingleFragmentCall(match string, ctx *renderContext) string {
-	if ctx.fragmentComponents == nil || len(ctx.fragmentComponents) == 0 {
-		return match
-	}
-	if ctx.fragmentDepth >= 2 {
-		return match
-	}
-	parts := fragmentCallRe.FindStringSubmatch(match)
+// tryExpandFragmentAt attempts to expand a fragment call beginning at the
+// {{Name args}} match between openStart and openEnd in content. If a matching
+// {{/Name}} is found later in content, the call is treated as block-form: the
+// inner body is parsed for slot blocks and substituted into the fragment body.
+// Otherwise the self-closing form is used and slot markers fall back to their
+// fallback content. Returns the replacement HTML and the absolute end position
+// (one past the last consumed char). When the call cannot be expanded (unknown
+// name, depth guard hit), returns the original open tag and absEnd.
+func tryExpandFragmentAt(content string, openStart, openEnd int, ctx *renderContext) (replacement string, end int) {
+	openTag := content[openStart:openEnd]
+	parts := fragmentCallRe.FindStringSubmatch(openTag)
 	if len(parts) < 2 {
-		return match
+		return openTag, openEnd
 	}
 	name := parts[1]
 	argStr := ""
@@ -1140,19 +1144,26 @@ func expandSingleFragmentCall(match string, ctx *renderContext) string {
 	}
 	frag, ok := ctx.fragmentComponents[name]
 	if !ok {
-		return match
+		return openTag, openEnd
 	}
-	scalarArgs, queryArgs := parseFragmentArgs(argStr, frag, ctx)
-	var fragHTML string
-	for _, node := range frag.Body {
-		if node.Type == parser.NodeHTML {
-			fragHTML = node.HTMLContent
-			break
-		}
+	if ctx.fragmentDepth >= 2 {
+		return openTag, openEnd
 	}
+
+	callerBody, endRel := findFragmentBlockEnd(content[openEnd:], name)
+	consumedEnd := openEnd
+	if endRel >= 0 {
+		consumedEnd = openEnd + endRel
+	} else {
+		callerBody = ""
+	}
+
+	fragHTML := resolveFragmentBody(frag, callerBody)
 	if fragHTML == "" {
-		return ""
+		return "", consumedEnd
 	}
+
+	scalarArgs, queryArgs := parseFragmentArgs(argStr, frag, ctx)
 	childCtx := &renderContext{
 		queries:            ctx.queries,
 		paginate:           ctx.paginate,
@@ -1161,12 +1172,14 @@ func expandSingleFragmentCall(match string, ctx *renderContext) string {
 		querySourceModels:  ctx.querySourceModels,
 		customManifests:    ctx.customManifests,
 		eachStack:          ctx.eachStack,
+		eachModels:         ctx.eachModels,
+		currentRow:         ctx.currentRow,
 		fragmentArgs:       scalarArgs,
 		fragmentQueryArgs:  queryArgs,
 		fragmentDepth:      ctx.fragmentDepth + 1,
 		fragmentComponents: ctx.fragmentComponents,
 	}
-	return renderHTML(fragHTML, childCtx)
+	return renderHTML(fragHTML, childCtx), consumedEnd
 }
 
 // parseFragmentArgs parses an argument string and binds args for a fragment call.
@@ -1248,64 +1261,32 @@ func isBareIdent(s string) bool {
 
 // expandFragmentCalls processes {{componentName arg=expr}} blocks inside HTML content.
 // It looks up the component fragment, binds arguments, and renders the body inline.
+// Handles both self-closing and block form ({{Frag}}...{{/Frag}}) with slot
+// semantics, mirroring expandFragmentCallsOutsideEach.
 func expandFragmentCalls(content string, ctx *renderContext) string {
 	if ctx.fragmentComponents == nil || len(ctx.fragmentComponents) == 0 {
 		return content
 	}
 	if ctx.fragmentDepth >= 2 {
-		// Recursion guard: don't expand beyond depth 2
 		return content
 	}
-
-	return fragmentCallRe.ReplaceAllStringFunc(content, func(match string) string {
-		parts := fragmentCallRe.FindStringSubmatch(match)
-		if len(parts) < 2 {
-			return match
+	var b strings.Builder
+	b.Grow(len(content))
+	pos := 0
+	for pos < len(content) {
+		loc := fragmentCallRe.FindStringIndex(content[pos:])
+		if loc == nil {
+			b.WriteString(content[pos:])
+			break
 		}
-		name := parts[1]
-		argStr := ""
-		if len(parts) > 2 {
-			argStr = parts[2]
-		}
-
-		frag, ok := ctx.fragmentComponents[name]
-		if !ok {
-			return match // unknown component, leave for analyzer to catch
-		}
-
-		// Parse arguments via shared helper (handles scalar + query/list args).
-		scalarArgs, queryArgs := parseFragmentArgs(argStr, frag, ctx)
-
-		// Find the HTML body of the component
-		var fragHTML string
-		for _, node := range frag.Body {
-			if node.Type == parser.NodeHTML {
-				fragHTML = node.HTMLContent
-				break
-			}
-		}
-		if fragHTML == "" {
-			return "" // no HTML body
-		}
-
-		// Create child context with bound args and incremented depth
-		childCtx := &renderContext{
-			queries:            ctx.queries,
-			paginate:           ctx.paginate,
-			currentUser:        ctx.currentUser,
-			queryParams:        ctx.queryParams,
-			querySourceModels:  ctx.querySourceModels,
-			customManifests:    ctx.customManifests,
-			eachStack:          ctx.eachStack,
-			fragmentArgs:       scalarArgs,
-			fragmentQueryArgs:  queryArgs,
-			fragmentDepth:      ctx.fragmentDepth + 1,
-			fragmentComponents: ctx.fragmentComponents,
-		}
-
-		rendered := renderHTML(fragHTML, childCtx)
-		return rendered
-	})
+		absStart := pos + loc[0]
+		absEnd := pos + loc[1]
+		b.WriteString(content[pos:absStart])
+		replacement, end := tryExpandFragmentAt(content, absStart, absEnd, ctx)
+		b.WriteString(replacement)
+		pos = end
+	}
+	return b.String()
 }
 
 // translationRe matches {t.key} and {t.key param=expr}

--- a/internal/runtime/slots.go
+++ b/internal/runtime/slots.go
@@ -1,0 +1,256 @@
+package runtime
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// Slot syntax (in a fragment body, the markers are placeholders; in a caller
+// block-form call body, they are content providers):
+//
+//   {{slot}}                            -- default slot, self-closing
+//   {{slot}}fallback{{/slot}}           -- default with fallback
+//   {{slot name="header"}}              -- named slot, self-closing
+//   {{slot name="header"}}fb{{/slot}}   -- named with fallback
+//
+// Block-form fragment call:
+//
+//   {{DvKanban items=people}}
+//     {{slot name="header"}}Custom{{/slot}}
+//     <div>{name}</div>
+//   {{/DvKanban}}
+//
+// The closing tag uses the {{/Name}} convention. Caller body content not inside
+// any {{slot ...}} block becomes the default slot.
+
+// slotOpenRe matches {{slot}} or {{slot args}}. Used to scan for slot markers
+// in both fragment HTMLContent and caller block-form bodies.
+var slotOpenRe = regexp.MustCompile(`\{\{slot(?:\s+([^}]+))?\}\}`)
+
+// findFragmentBlockEnd scans content for the matching {{/name}} of an opened
+// {{name args}} tag at depth 1. It counts nested same-name fragment opens so
+// {{Outer}}{{Outer}}{{/Outer}}{{/Outer}} pairs correctly. Returns the inner
+// body (between open and close) and the position immediately after {{/name}}.
+// Returns endPos == -1 when no matching close is found (treat as self-closing).
+func findFragmentBlockEnd(content, name string) (body string, endPos int) {
+	depth := 1
+	pos := 0
+	openPrefix := "{{" + name
+	closeTag := "{{/" + name + "}}"
+	for pos < len(content) {
+		next := strings.Index(content[pos:], "{{")
+		if next < 0 {
+			return "", -1
+		}
+		next += pos
+		close := strings.Index(content[next:], "}}")
+		if close < 0 {
+			return "", -1
+		}
+		close += next + 2
+
+		tag := content[next:close]
+		if tag == closeTag {
+			depth--
+			if depth == 0 {
+				return content[:next], close
+			}
+		} else if strings.HasPrefix(tag, openPrefix) {
+			// Confirm this is an open of the same fragment (not a longer name
+			// that happens to share the prefix, e.g. {{DvKanban2}} vs {{DvKanban}}).
+			rest := tag[len(openPrefix):]
+			if strings.HasPrefix(rest, " ") || rest == "}}" {
+				depth++
+			}
+		}
+		pos = close
+	}
+	return "", -1
+}
+
+// findSlotEnd scans for the matching {{/slot}} of an opened {{slot args}} tag,
+// counting nested {{slot ...}}/{{/slot}} pairs. Returns the inner body and the
+// position immediately after {{/slot}}. Returns endPos == -1 if unclosed.
+func findSlotEnd(content string) (body string, endPos int) {
+	depth := 1
+	pos := 0
+	for pos < len(content) {
+		next := strings.Index(content[pos:], "{{")
+		if next < 0 {
+			return "", -1
+		}
+		next += pos
+		close := strings.Index(content[next:], "}}")
+		if close < 0 {
+			return "", -1
+		}
+		close += next + 2
+
+		inner := strings.TrimSpace(content[next+2 : close-2])
+		if inner == "/slot" {
+			depth--
+			if depth == 0 {
+				return content[:next], close
+			}
+		} else if inner == "slot" || strings.HasPrefix(inner, "slot ") {
+			depth++
+		}
+		pos = close
+	}
+	return "", -1
+}
+
+// parseSlotName parses a slot tag's argument string and returns the value of
+// `name="X"` (or empty string for the default slot).
+func parseSlotName(argStr string) string {
+	for _, tok := range splitArgStr(argStr) {
+		eq := strings.Index(tok, "=")
+		if eq < 0 {
+			continue
+		}
+		if strings.TrimSpace(tok[:eq]) != "name" {
+			continue
+		}
+		v := strings.TrimSpace(tok[eq+1:])
+		if len(v) >= 2 {
+			if (v[0] == '"' && v[len(v)-1] == '"') ||
+				(v[0] == '\'' && v[len(v)-1] == '\'') {
+				v = v[1 : len(v)-1]
+			}
+		}
+		return v
+	}
+	return ""
+}
+
+// extractSlots scans a caller's block-form body and separates named-slot blocks
+// from default-slot content. Named slots are keyed by their `name` attribute;
+// everything outside any top-level {{slot ...}}...{{/slot}} block becomes the
+// default slot. Default slot content has leading/trailing whitespace trimmed.
+func extractSlots(body string) (named map[string]string, def string) {
+	named = make(map[string]string)
+	var defBuf strings.Builder
+	pos := 0
+	for pos < len(body) {
+		loc := slotOpenRe.FindStringIndex(body[pos:])
+		if loc == nil {
+			defBuf.WriteString(body[pos:])
+			break
+		}
+		absStart := pos + loc[0]
+		absEnd := pos + loc[1]
+		defBuf.WriteString(body[pos:absStart])
+
+		match := slotOpenRe.FindStringSubmatch(body[absStart:absEnd])
+		argStr := ""
+		if len(match) > 1 {
+			argStr = match[1]
+		}
+		slotName := parseSlotName(argStr)
+
+		slotBody, endRel := findSlotEnd(body[absEnd:])
+		if endRel < 0 {
+			// Unclosed slot tag: write the open marker verbatim and continue
+			// so the default slot retains it as literal text.
+			defBuf.WriteString(body[absStart:absEnd])
+			pos = absEnd
+			continue
+		}
+
+		if slotName != "" {
+			named[slotName] = slotBody
+		} else {
+			defBuf.WriteString(slotBody)
+		}
+		pos = absEnd + endRel
+	}
+	return named, strings.TrimSpace(defBuf.String())
+}
+
+// substituteSlots replaces slot markers in a fragment's HTMLContent with
+// caller-provided slot bodies. Marker forms accepted:
+//
+//	{{slot}}                       -- self-closing default
+//	{{slot}}fb{{/slot}}            -- default with fallback
+//	{{slot name="X"}}              -- self-closing named
+//	{{slot name="X"}}fb{{/slot}}   -- named with fallback
+//
+// If the caller did not provide a body for a slot (e.g. self-closing form, or
+// a named slot the caller did not fill), the fallback content is used. If
+// there is also no fallback (self-closing slot marker), the marker is removed
+// entirely.
+func substituteSlots(fragHTML string, named map[string]string, def string) string {
+	if !strings.Contains(fragHTML, "{{slot") {
+		return fragHTML
+	}
+	var b strings.Builder
+	pos := 0
+	for pos < len(fragHTML) {
+		loc := slotOpenRe.FindStringIndex(fragHTML[pos:])
+		if loc == nil {
+			b.WriteString(fragHTML[pos:])
+			break
+		}
+		absStart := pos + loc[0]
+		absEnd := pos + loc[1]
+		b.WriteString(fragHTML[pos:absStart])
+
+		match := slotOpenRe.FindStringSubmatch(fragHTML[absStart:absEnd])
+		argStr := ""
+		if len(match) > 1 {
+			argStr = match[1]
+		}
+		slotName := parseSlotName(argStr)
+
+		fallback, endRel := findSlotEnd(fragHTML[absEnd:])
+		var consumed int
+		if endRel >= 0 {
+			consumed = absEnd + endRel
+		} else {
+			consumed = absEnd
+			fallback = ""
+		}
+
+		var replacement string
+		if slotName != "" {
+			if val, ok := named[slotName]; ok {
+				replacement = val
+			} else {
+				replacement = fallback
+			}
+		} else {
+			if def != "" {
+				replacement = def
+			} else {
+				replacement = fallback
+			}
+		}
+		b.WriteString(replacement)
+		pos = consumed
+	}
+	return b.String()
+}
+
+// resolveFragmentBody returns the fragment's HTMLContent with slot markers
+// substituted. If callerBody is empty (self-closing call form), only fallback
+// content survives. Caller body may itself contain {{slot name="X"}}...{{/slot}}
+// blocks marking named slots; everything else becomes default slot content.
+func resolveFragmentBody(frag *parser.Page, callerBody string) string {
+	var fragHTML string
+	for _, node := range frag.Body {
+		if node.Type == parser.NodeHTML {
+			fragHTML = node.HTMLContent
+			break
+		}
+	}
+	if fragHTML == "" {
+		return ""
+	}
+	if callerBody == "" {
+		return substituteSlots(fragHTML, nil, "")
+	}
+	named, def := extractSlots(callerBody)
+	return substituteSlots(fragHTML, named, def)
+}

--- a/internal/runtime/slots_test.go
+++ b/internal/runtime/slots_test.go
@@ -1,0 +1,302 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kilnx-org/kilnx/internal/database"
+	"github.com/kilnx-org/kilnx/internal/parser"
+)
+
+// TestSlotDefault verifies that block-form caller body fills the default
+// {{slot}} marker in the fragment body.
+func TestSlotDefault(t *testing.T) {
+	card := &parser.Page{
+		Path: "card",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div class="card">{{slot}}</div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"card": card},
+	}
+	content := `{{card}}<p>hello</p>{{/card}}`
+	got := expandFragmentCalls(content, ctx)
+	want := `<div class="card"><p>hello</p></div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotDefaultWithFallback verifies that omitting the caller body falls
+// back to content between {{slot}}fallback{{/slot}} in the fragment body.
+func TestSlotDefaultWithFallback(t *testing.T) {
+	card := &parser.Page{
+		Path: "card",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div>{{slot}}fallback{{/slot}}</div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"card": card},
+	}
+	got := expandFragmentCalls(`{{card}}`, ctx)
+	want := `<div>fallback</div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotNamedAndDefault verifies that named slots are extracted from the
+// caller body and matched to {{slot name="X"}} markers in the fragment, and
+// that everything else in the caller body becomes the default slot.
+func TestSlotNamedAndDefault(t *testing.T) {
+	card := &parser.Page{
+		Path: "card",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div><h1>{{slot name="header"}}</h1><main>{{slot}}</main></div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"card": card},
+	}
+	content := `{{card}}{{slot name="header"}}Title{{/slot}}<p>body</p>{{/card}}`
+	got := expandFragmentCalls(content, ctx)
+	want := `<div><h1>Title</h1><main><p>body</p></main></div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotNamedFallback verifies that a named slot the caller did not fill
+// falls back to the fragment's fallback content between markers.
+func TestSlotNamedFallback(t *testing.T) {
+	card := &parser.Page{
+		Path: "card",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div><h1>{{slot name="header"}}Default Title{{/slot}}</h1><main>{{slot}}</main></div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"card": card},
+	}
+	content := `{{card}}<p>body only</p>{{/card}}`
+	got := expandFragmentCalls(content, ctx)
+	want := `<div><h1>Default Title</h1><main><p>body only</p></main></div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotInsideEachItems verifies the headline use case: a generic kanban-ish
+// fragment iterates items it received as a query/list arg, and the caller's
+// default slot body supplies the per-item markup with row-field refs.
+func TestSlotInsideEachItems(t *testing.T) {
+	dvKanban := &parser.Page{
+		Path: "DvKanban",
+		FragmentArgs: []parser.FragmentArg{
+			{Name: "items"},
+		},
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div class="kanban">{{each items}}<article>{{slot}}</article>{{end}}</div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"DvKanban": dvKanban},
+		queries: map[string][]database.Row{
+			"people": {
+				{"name": "Alice"},
+				{"name": "Bob"},
+			},
+		},
+		paginate:          map[string]PaginateInfo{},
+		querySourceModels: map[string]string{},
+		customManifests:   map[string]*parser.CustomFieldManifest{},
+		queryParams:       map[string]string{},
+	}
+	content := `{{DvKanban items=people}}<h3>{name}</h3>{{/DvKanban}}`
+	got := renderHTML(content, ctx)
+	want := `<div class="kanban"><article><h3>Alice</h3></article><article><h3>Bob</h3></article></div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotEmptyCallerBody verifies that an empty caller body in block form is
+// treated like the self-closing form: slot fallbacks survive.
+func TestSlotEmptyCallerBody(t *testing.T) {
+	card := &parser.Page{
+		Path: "card",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div>{{slot}}fallback{{/slot}}</div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"card": card},
+	}
+	got := expandFragmentCalls(`{{card}}{{/card}}`, ctx)
+	want := `<div>fallback</div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotSelfClosingMarkerNoFallback verifies that a self-closing {{slot}}
+// marker with no caller body and no fallback is removed entirely.
+func TestSlotSelfClosingMarkerNoFallback(t *testing.T) {
+	card := &parser.Page{
+		Path: "card",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div>before{{slot}}after</div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"card": card},
+	}
+	got := expandFragmentCalls(`{{card}}`, ctx)
+	want := `<div>beforeafter</div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotBackwardsCompatSelfClosing verifies the existing self-closing form
+// continues to work with fragments that have no slot markers.
+func TestSlotBackwardsCompatSelfClosing(t *testing.T) {
+	badge := &parser.Page{
+		Path:         "badge",
+		FragmentArgs: []parser.FragmentArg{{Name: "status"}},
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<span class="badge">{status}</span>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"badge": badge},
+	}
+	got := expandFragmentCalls(`{{badge status=active}}`, ctx)
+	want := `<span class="badge">active</span>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotNestedBlockForm verifies that block-form fragments can nest: an
+// outer block-form call whose body contains another block-form call.
+func TestSlotNestedBlockForm(t *testing.T) {
+	box := &parser.Page{
+		Path: "box",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div>{{slot}}</div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"box": box},
+		queries:            map[string][]database.Row{},
+		paginate:           map[string]PaginateInfo{},
+		querySourceModels:  map[string]string{},
+		customManifests:    map[string]*parser.CustomFieldManifest{},
+		queryParams:        map[string]string{},
+	}
+	content := `{{box}}{{box}}inner{{/box}}{{/box}}`
+	got := renderHTML(content, ctx)
+	want := `<div><div>inner</div></div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotBlockFormWithScalarArgs verifies that scalar args still flow into
+// fragment body alongside slot content.
+func TestSlotBlockFormWithScalarArgs(t *testing.T) {
+	panel := &parser.Page{
+		Path:         "panel",
+		FragmentArgs: []parser.FragmentArg{{Name: "title"}},
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<section><h2>{title}</h2>{{slot}}</section>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"panel": panel},
+	}
+	content := `{{panel title="Hello"}}<p>body</p>{{/panel}}`
+	got := expandFragmentCalls(content, ctx)
+	want := `<section><h2>Hello</h2><p>body</p></section>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotUnclosedTreatedAsSelfClosing verifies that if a block-form open tag
+// has no matching close, the call is treated as self-closing (no crash, no
+// runaway consumption).
+func TestSlotUnclosedTreatedAsSelfClosing(t *testing.T) {
+	card := &parser.Page{
+		Path: "card",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div>{{slot}}fb{{/slot}}</div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"card": card},
+	}
+	got := expandFragmentCalls(`{{card}}trailing`, ctx)
+	want := `<div>fb</div>trailing`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestSlotRenderHTMLPipelineOutsideEach verifies the full renderHTML pipeline
+// handles block-form fragments correctly outside any {{each}} block.
+func TestSlotRenderHTMLPipelineOutsideEach(t *testing.T) {
+	card := &parser.Page{
+		Path: "card",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div class="card"><header>{{slot name="header"}}</header><main>{{slot}}</main></div>`},
+		},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"card": card},
+		queries:            map[string][]database.Row{},
+		paginate:           map[string]PaginateInfo{},
+		querySourceModels:  map[string]string{},
+		customManifests:    map[string]*parser.CustomFieldManifest{},
+		queryParams:        map[string]string{},
+	}
+	content := `<div>{{card}}{{slot name="header"}}Hi{{/slot}}<p>body</p>{{/card}}</div>`
+	got := renderHTML(content, ctx)
+	if !strings.Contains(got, `<header>Hi</header>`) {
+		t.Errorf("named slot missing in output: %q", got)
+	}
+	if !strings.Contains(got, `<main><p>body</p></main>`) {
+		t.Errorf("default slot missing in output: %q", got)
+	}
+}
+
+// TestExtractSlots verifies the slot extractor unit-level.
+func TestExtractSlots(t *testing.T) {
+	body := `before{{slot name="header"}}H{{/slot}}between{{slot name="footer"}}F{{/slot}}after`
+	named, def := extractSlots(body)
+	if named["header"] != "H" {
+		t.Errorf("named[header] = %q, want H", named["header"])
+	}
+	if named["footer"] != "F" {
+		t.Errorf("named[footer] = %q, want F", named["footer"])
+	}
+	if def != "beforebetweenafter" {
+		t.Errorf("default = %q, want beforebetweenafter", def)
+	}
+}
+
+// TestFindFragmentBlockEnd verifies the balanced scanner counts nested same-
+// name opens correctly.
+func TestFindFragmentBlockEnd(t *testing.T) {
+	content := `{{box}}inner{{/box}}{{/box}}rest`
+	body, end := findFragmentBlockEnd(content, "box")
+	if body != `{{box}}inner{{/box}}` {
+		t.Errorf("body = %q, want '{{box}}inner{{/box}}'", body)
+	}
+	if end < 0 || content[end:] != "rest" {
+		t.Errorf("end = %d, content after = %q, want 'rest'", end, content[end:])
+	}
+}

--- a/internal/runtime/slots_test.go
+++ b/internal/runtime/slots_test.go
@@ -288,6 +288,40 @@ func TestExtractSlots(t *testing.T) {
 	}
 }
 
+// TestSlotBlockFormInsideEach verifies the inside-each rendering path:
+// caller is {{each users}}{{Frag}}...{{/Frag}}{{end}}, so each iteration
+// invokes the block-form fragment with the current row visible to the slot
+// body (refs like {name} should resolve against the each row, not the
+// fragment).
+func TestSlotBlockFormInsideEach(t *testing.T) {
+	card := &parser.Page{
+		Path: "Card",
+		Body: []parser.Node{
+			{Type: parser.NodeHTML, HTMLContent: `<div class="card">{{slot}}</div>`},
+		},
+		FragmentArgs: []parser.FragmentArg{},
+	}
+	ctx := &renderContext{
+		fragmentComponents: map[string]*parser.Page{"Card": card},
+		queries: map[string][]database.Row{
+			"users": {
+				{"name": "Alice"},
+				{"name": "Bob"},
+			},
+		},
+		paginate:          map[string]PaginateInfo{},
+		querySourceModels: map[string]string{},
+		customManifests:   map[string]*parser.CustomFieldManifest{},
+		queryParams:       map[string]string{},
+	}
+	content := `{{each users}}{{Card}}<p>{name}</p>{{/Card}}{{end}}`
+	got := renderHTML(content, ctx)
+	want := `<div class="card"><p>Alice</p></div><div class="card"><p>Bob</p></div>`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // TestFindFragmentBlockEnd verifies the balanced scanner counts nested same-
 // name opens correctly.
 func TestFindFragmentBlockEnd(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fragments can declare slot placeholders (`{{slot}}` default, `{{slot name="X"}}` named) and callers fill them with block form `{{Frag args}}...{{/Frag}}`. Unfilled slots fall back to `{{slot}}fallback{{/slot}}` content or are removed when self-closing.
- Slot body resolves against the caller's row context when the call is placed inside `{{each}}`. Within the fragment itself, slot content lands in the fragment's render pipeline so generic primitives (DvKanban, DvTable, etc.) can iterate and project caller-supplied markup.
- Self-closing `{{Frag args}}` keeps existing behaviour. Backwards compatible with all existing fragment users.

## Implementation notes

- runtime: balanced scanner for `{{/Name}}`, slot extraction/substitution before fragment HTML hits the render pipeline. Caller body pre-resolved in caller scope to keep `{name}` correct when block-form is inside `{{each}}`.
- parser: `fragment Name()` with empty args now sets `FragmentArgs` to a non-nil empty slice so analyzer/server register it as a component.
- analyzer: whitelist `slot` so `{{slot ...}}` markers do not look like calls to an unknown component.

## Test plan

- [x] `go test ./...` passes (full suite, including 13 new slot tests)
- [x] Smoke app exercises default + named + iteration patterns end to end
- [x] `kilnx check` on a real-world app (adequa) returns "No issues found" with the new binary
- [x] Existing fragment users unchanged (self-closing path untouched)

## Docs

- `docs/devs/reference/keywords/fragment.md`: added Component-with-slots section with examples and scope semantics
- `CHANGELOG.md`: entry under Unreleased